### PR TITLE
feat: Implement mcctl.sh management CLI (#8)

### DIFF
--- a/platform/scripts/lib/common.sh
+++ b/platform/scripts/lib/common.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# =============================================================================
+# common.sh - Shared functions for mcctl scripts
+# =============================================================================
+# Source this file in other scripts:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+# =============================================================================
+
+# Get script/platform directories
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+PLATFORM_DIR="${PLATFORM_DIR:-$(dirname "$SCRIPT_DIR")}"
+
+# Colors (disabled if not terminal or JSON output)
+setup_colors() {
+    if [[ -t 1 ]] && [[ "${JSON_OUTPUT:-}" != "true" ]]; then
+        RED='\033[0;31m'
+        GREEN='\033[0;32m'
+        YELLOW='\033[1;33m'
+        BLUE='\033[0;34m'
+        CYAN='\033[0;36m'
+        BOLD='\033[1m'
+        NC='\033[0m'
+    else
+        RED=''
+        GREEN=''
+        YELLOW=''
+        BLUE=''
+        CYAN=''
+        BOLD=''
+        NC=''
+    fi
+}
+setup_colors
+
+# =============================================================================
+# Output Functions
+# =============================================================================
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1" >&2
+}
+
+info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+debug() {
+    if [[ "${DEBUG:-}" == "true" ]]; then
+        echo -e "${BLUE}[DEBUG]${NC} $1" >&2
+    fi
+}
+
+# =============================================================================
+# Docker Functions
+# =============================================================================
+
+# Check if Docker is available
+check_docker() {
+    if ! command -v docker &> /dev/null; then
+        error "Docker is not installed or not in PATH"
+        return 1
+    fi
+    if ! docker info &> /dev/null; then
+        error "Docker daemon is not running or permission denied"
+        return 1
+    fi
+    return 0
+}
+
+# Get container status (running, exited, paused, etc.)
+get_container_status() {
+    local container="$1"
+    local status
+    status=$(docker inspect --format '{{.State.Status}}' "$container" 2>/dev/null) || status="not_found"
+    echo -n "$status"
+}
+
+# Check if container exists
+container_exists() {
+    local container="$1"
+    docker inspect "$container" &>/dev/null
+}
+
+# Get container health status
+get_container_health() {
+    local container="$1"
+    local health
+    health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" 2>/dev/null) || health="unknown"
+    echo -n "$health"
+}
+
+# Get minecraft server containers (those starting with mc-)
+get_mc_containers() {
+    docker ps -a --filter "name=mc-" --format '{{.Names}}' | grep -v "mc-router" | sort
+}
+
+# Get running minecraft server containers
+get_running_mc_containers() {
+    docker ps --filter "name=mc-" --filter "status=running" --format '{{.Names}}' | grep -v "mc-router" | sort
+}
+
+# Get container's assigned world (from environment or volume mount)
+get_container_world() {
+    local container="$1"
+    # Check WORLD environment variable first
+    local world=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$container" 2>/dev/null | grep "^WORLD=" | cut -d= -f2)
+    if [[ -n "$world" ]]; then
+        echo "$world"
+        return
+    fi
+    # Otherwise try to get from volume mount
+    echo "-"
+}
+
+# Get container's hostname label (mc-router.host)
+get_container_hostname() {
+    local container="$1"
+    local hostname
+    hostname=$(docker inspect --format '{{index .Config.Labels "mc-router.host"}}' "$container" 2>/dev/null) || hostname="-"
+    [[ -z "$hostname" ]] && hostname="-"
+    echo -n "$hostname"
+}
+
+# =============================================================================
+# JSON Output Functions
+# =============================================================================
+
+# Escape string for JSON
+json_escape() {
+    local str="$1"
+    str="${str//\\/\\\\}"
+    str="${str//\"/\\\"}"
+    str="${str//$'\n'/\\n}"
+    str="${str//$'\r'/\\r}"
+    str="${str//$'\t'/\\t}"
+    echo "$str"
+}
+
+# =============================================================================
+# Path Functions
+# =============================================================================
+
+get_servers_dir() {
+    echo "$PLATFORM_DIR/servers"
+}
+
+get_worlds_dir() {
+    echo "$PLATFORM_DIR/worlds"
+}
+
+get_locks_dir() {
+    echo "$PLATFORM_DIR/worlds/.locks"
+}
+
+# List all server directories
+get_server_names() {
+    local servers_dir
+    servers_dir=$(get_servers_dir)
+    if [[ -d "$servers_dir" ]]; then
+        find "$servers_dir" -maxdepth 1 -mindepth 1 -type d ! -name '_template' -exec basename {} \; 2>/dev/null | sort
+    fi
+}

--- a/platform/scripts/mcctl.sh
+++ b/platform/scripts/mcctl.sh
@@ -1,0 +1,459 @@
+#!/bin/bash
+# =============================================================================
+# mcctl.sh - Minecraft Server Management CLI
+# =============================================================================
+# Main management tool for Minecraft servers with mc-router integration.
+#
+# Usage:
+#   mcctl.sh status [--json]              Show all server status
+#   mcctl.sh logs <server> [lines]        View server logs
+#   mcctl.sh console <server>             Connect to RCON console
+#   mcctl.sh world list [--json]          List worlds and locks
+#   mcctl.sh world assign <world> <srv>   Assign world to server
+#   mcctl.sh world release <world>        Force release world lock
+#   mcctl.sh start <server>               Start server (bypass auto-scale)
+#   mcctl.sh stop <server>                Stop server
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#   2 - Warning
+# =============================================================================
+
+set -e
+
+# Get script directory and source common functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLATFORM_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/lib/common.sh"
+
+# =============================================================================
+# Usage
+# =============================================================================
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <command> [options]
+
+Server Management:
+  status [--json]              Show status of all servers and router
+  logs <server> [lines]        View server logs (default: 50 lines)
+  console <server>             Connect to RCON console (interactive)
+  start <server>               Start a specific server
+  stop <server>                Stop a specific server
+
+World Management:
+  world list [--json]          List worlds and their lock status
+  world assign <world> <srv>   Lock world and assign to server
+  world release <world>        Force release world lock
+
+Options:
+  --json                       Output in JSON format
+  -h, --help                   Show this help message
+
+Examples:
+  $(basename "$0") status
+  $(basename "$0") status --json
+  $(basename "$0") logs ironwood 100
+  $(basename "$0") console ironwood
+  $(basename "$0") world list
+  $(basename "$0") world assign survival mc-ironwood
+  $(basename "$0") start ironwood
+  $(basename "$0") stop ironwood
+EOF
+}
+
+# =============================================================================
+# Status Command
+# =============================================================================
+
+cmd_status() {
+    local json_output=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json)
+                json_output=true
+                JSON_OUTPUT=true
+                setup_colors
+                shift
+                ;;
+            *)
+                error "Unknown option: $1"
+                return 1
+                ;;
+        esac
+    done
+
+    check_docker || return 1
+
+    local router_status
+    local router_health
+    local router_port
+
+    # Get router status
+    router_status=$(get_container_status "mc-router")
+    router_health=$(get_container_health "mc-router")
+    router_port="25565"
+
+    # Get mdns-publisher status
+    local mdns_status
+    mdns_status=$(get_container_status "mdns-publisher")
+
+    if $json_output; then
+        # JSON output
+        echo "{"
+        echo '  "router": {'
+        echo "    \"name\": \"mc-router\","
+        echo "    \"status\": \"$router_status\","
+        echo "    \"health\": \"$router_health\","
+        echo "    \"port\": $router_port"
+        echo '  },'
+        echo '  "mdns_publisher": {'
+        echo "    \"name\": \"mdns-publisher\","
+        echo "    \"status\": \"$mdns_status\""
+        echo '  },'
+        echo '  "servers": ['
+
+        local first=true
+        local containers
+        containers=$(get_mc_containers)
+
+        for container in $containers; do
+            local status
+            local health
+            local hostname
+            local server_name
+
+            status=$(get_container_status "$container")
+            health=$(get_container_health "$container")
+            hostname=$(get_container_hostname "$container")
+            server_name="${container#mc-}"  # Remove mc- prefix
+
+            if [[ "$first" != "true" ]]; then
+                echo ","
+            fi
+            first=false
+
+            printf '    {"name": "%s", "container": "%s", "status": "%s", "health": "%s", "hostname": "%s"}' \
+                "$server_name" "$container" "$status" "$health" "$hostname"
+        done
+
+        echo ""
+        echo "  ]"
+        echo "}"
+    else
+        # Human-readable output
+        echo -e "${BOLD}=== Server Status (mc-router Managed) ===${NC}"
+        echo ""
+
+        # Router status
+        echo -e "${CYAN}INFRASTRUCTURE${NC}"
+        printf "%-20s %-12s %-10s %s\n" "SERVICE" "STATUS" "HEALTH" "PORT/INFO"
+        printf "%-20s %-12s %-10s %s\n" "-------" "------" "------" "---------"
+
+        local router_color="${RED}"
+        [[ "$router_status" == "running" ]] && router_color="${GREEN}"
+        printf "%-20s ${router_color}%-12s${NC} %-10s %s\n" "mc-router" "$router_status" "$router_health" ":$router_port (hostname routing)"
+
+        local mdns_color="${RED}"
+        [[ "$mdns_status" == "running" ]] && mdns_color="${GREEN}"
+        printf "%-20s ${mdns_color}%-12s${NC} %-10s %s\n" "mdns-publisher" "$mdns_status" "-" "mDNS broadcast"
+
+        echo ""
+        echo -e "${CYAN}MINECRAFT SERVERS${NC}"
+        printf "%-20s %-12s %-10s %s\n" "SERVER" "STATUS" "HEALTH" "HOSTNAME"
+        printf "%-20s %-12s %-10s %s\n" "------" "------" "------" "--------"
+
+        local containers
+        containers=$(get_mc_containers)
+
+        if [[ -z "$containers" ]]; then
+            echo "  No Minecraft servers configured"
+        else
+            for container in $containers; do
+                local status
+                local health
+                local hostname
+                local server_name
+                local status_color="${RED}"
+
+                status=$(get_container_status "$container")
+                health=$(get_container_health "$container")
+                hostname=$(get_container_hostname "$container")
+                server_name="${container#mc-}"
+
+                [[ "$status" == "running" ]] && status_color="${GREEN}"
+                [[ "$status" == "exited" ]] && status_color="${YELLOW}"
+
+                printf "%-20s ${status_color}%-12s${NC} %-10s %s\n" "$server_name" "$status" "$health" "$hostname"
+            done
+        fi
+
+        echo ""
+    fi
+}
+
+# =============================================================================
+# Logs Command
+# =============================================================================
+
+cmd_logs() {
+    local server="$1"
+    local lines="${2:-50}"
+
+    if [[ -z "$server" ]]; then
+        error "Usage: logs <server> [lines]"
+        return 1
+    fi
+
+    check_docker || return 1
+
+    local container="mc-$server"
+
+    if ! container_exists "$container"; then
+        error "Server '$server' (container: $container) not found"
+        return 1
+    fi
+
+    # Use the logs.sh script if available
+    if [[ -x "$SCRIPT_DIR/logs.sh" ]]; then
+        "$SCRIPT_DIR/logs.sh" "$server" "$lines"
+    else
+        docker logs --tail "$lines" "$container"
+    fi
+}
+
+# =============================================================================
+# Console Command
+# =============================================================================
+
+cmd_console() {
+    local server="$1"
+
+    if [[ -z "$server" ]]; then
+        error "Usage: console <server>"
+        return 1
+    fi
+
+    check_docker || return 1
+
+    local container="mc-$server"
+
+    if ! container_exists "$container"; then
+        error "Server '$server' (container: $container) not found"
+        return 1
+    fi
+
+    local status
+    status=$(get_container_status "$container")
+
+    if [[ "$status" != "running" ]]; then
+        error "Server '$server' is not running (status: $status)"
+        return 1
+    fi
+
+    info "Connecting to RCON console for '$server'..."
+    info "Type 'quit' or press Ctrl+C to exit"
+    echo ""
+
+    docker exec -i "$container" rcon-cli
+}
+
+# =============================================================================
+# World Commands
+# =============================================================================
+
+cmd_world() {
+    local subcmd="${1:-}"
+    shift || true
+
+    case "$subcmd" in
+        list)
+            cmd_world_list "$@"
+            ;;
+        assign)
+            cmd_world_assign "$@"
+            ;;
+        release)
+            cmd_world_release "$@"
+            ;;
+        "")
+            error "Usage: world <list|assign|release> [options]"
+            return 1
+            ;;
+        *)
+            error "Unknown world subcommand: $subcmd"
+            return 1
+            ;;
+    esac
+}
+
+cmd_world_list() {
+    # Delegate to lock.sh
+    if [[ -x "$SCRIPT_DIR/lock.sh" ]]; then
+        "$SCRIPT_DIR/lock.sh" list "$@"
+    else
+        error "lock.sh not found"
+        return 1
+    fi
+}
+
+cmd_world_assign() {
+    local world="$1"
+    local server="$2"
+
+    if [[ -z "$world" || -z "$server" ]]; then
+        error "Usage: world assign <world> <server>"
+        return 1
+    fi
+
+    # Delegate to lock.sh
+    if [[ -x "$SCRIPT_DIR/lock.sh" ]]; then
+        "$SCRIPT_DIR/lock.sh" lock "$world" "$server"
+    else
+        error "lock.sh not found"
+        return 1
+    fi
+}
+
+cmd_world_release() {
+    local world="$1"
+
+    if [[ -z "$world" ]]; then
+        error "Usage: world release <world>"
+        return 1
+    fi
+
+    # Get current holder from lock.sh check
+    if [[ -x "$SCRIPT_DIR/lock.sh" ]]; then
+        local lock_status
+        lock_status=$("$SCRIPT_DIR/lock.sh" check "$world")
+
+        if [[ "$lock_status" == "unlocked" ]]; then
+            warn "World '$world' is not locked"
+            return 2
+        fi
+
+        local holder
+        holder=$(echo "$lock_status" | cut -d: -f2)
+
+        "$SCRIPT_DIR/lock.sh" unlock "$world" "$holder" --force
+    else
+        error "lock.sh not found"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Start/Stop Commands
+# =============================================================================
+
+cmd_start() {
+    local server="$1"
+
+    if [[ -z "$server" ]]; then
+        error "Usage: start <server>"
+        return 1
+    fi
+
+    check_docker || return 1
+
+    local container="mc-$server"
+
+    if ! container_exists "$container"; then
+        error "Server '$server' (container: $container) not found"
+        return 1
+    fi
+
+    local status
+    status=$(get_container_status "$container")
+
+    if [[ "$status" == "running" ]]; then
+        warn "Server '$server' is already running"
+        return 2
+    fi
+
+    info "Starting server '$server'..."
+    docker start "$container"
+    info "Server '$server' started"
+}
+
+cmd_stop() {
+    local server="$1"
+
+    if [[ -z "$server" ]]; then
+        error "Usage: stop <server>"
+        return 1
+    fi
+
+    check_docker || return 1
+
+    local container="mc-$server"
+
+    if ! container_exists "$container"; then
+        error "Server '$server' (container: $container) not found"
+        return 1
+    fi
+
+    local status
+    status=$(get_container_status "$container")
+
+    if [[ "$status" != "running" ]]; then
+        warn "Server '$server' is not running (status: $status)"
+        return 2
+    fi
+
+    info "Stopping server '$server'..."
+    docker stop "$container"
+    info "Server '$server' stopped"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+    local command="${1:-}"
+    shift || true
+
+    case "$command" in
+        status)
+            cmd_status "$@"
+            ;;
+        logs)
+            cmd_logs "$@"
+            ;;
+        console)
+            cmd_console "$@"
+            ;;
+        world)
+            cmd_world "$@"
+            ;;
+        start)
+            cmd_start "$@"
+            ;;
+        stop)
+            cmd_stop "$@"
+            ;;
+        -h|--help|help)
+            usage
+            exit 0
+            ;;
+        "")
+            error "No command specified"
+            usage
+            exit 1
+            ;;
+        *)
+            error "Unknown command: $command"
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+# Run main if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary
- Implement main Minecraft server management CLI with mc-router integration
- Add status/logs/console/world/start/stop commands
- Create shared functions library in lib/common.sh

## Changes
- `platform/scripts/mcctl.sh`: Main CLI tool
- `platform/scripts/lib/common.sh`: Shared functions

## Test Plan
- [x] `mcctl.sh --help` displays usage
- [x] `mcctl.sh status` shows infrastructure and servers
- [x] `mcctl.sh status --json` outputs valid JSON
- [x] `mcctl.sh world list` shows world lock status

Closes #8

---
Generated with [Claude Code](https://claude.ai/code)