### PR TITLE
feat: add @clack/prompts and CLI dependencies (#30)

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,0 +1,9 @@
+---
+active: true
+iteration: 1
+max_iterations: 0
+completion_promise: null
+started_at: "2026-01-18T03:06:30Z"
+---
+
+Implement Milestone v0.4.0 CLI Interactive Mode: Issues

--- a/platform/services/cli/package.json
+++ b/platform/services/cli/package.json
@@ -38,7 +38,9 @@
     "darwin"
   ],
   "dependencies": {
-    "@minecraft-docker/shared": "workspace:*"
+    "@minecraft-docker/shared": "workspace:*",
+    "@clack/prompts": "^0.8.0",
+    "picocolors": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/platform/services/cli/tests/clack-prompts.test.ts
+++ b/platform/services/cli/tests/clack-prompts.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+
+// Test that @clack/prompts can be imported
+describe('@clack/prompts dependency', () => {
+  it('should be importable', async () => {
+    const clack = await import('@clack/prompts');
+    assert.ok(clack, '@clack/prompts should be importable');
+    assert.ok(typeof clack.text === 'function', 'text function should exist');
+    assert.ok(typeof clack.select === 'function', 'select function should exist');
+    assert.ok(typeof clack.confirm === 'function', 'confirm function should exist');
+    assert.ok(typeof clack.spinner === 'function', 'spinner function should exist');
+    assert.ok(typeof clack.intro === 'function', 'intro function should exist');
+    assert.ok(typeof clack.outro === 'function', 'outro function should exist');
+  });
+
+  it('should have isCancel helper', async () => {
+    const clack = await import('@clack/prompts');
+    assert.ok(typeof clack.isCancel === 'function', 'isCancel function should exist');
+  });
+});
+
+// Test that picocolors can be imported
+describe('picocolors dependency', () => {
+  it('should be importable', async () => {
+    const pc = await import('picocolors');
+    assert.ok(pc, 'picocolors should be importable');
+    assert.ok(typeof pc.default.green === 'function', 'green function should exist');
+    assert.ok(typeof pc.default.red === 'function', 'red function should exist');
+    assert.ok(typeof pc.default.cyan === 'function', 'cyan function should exist');
+    assert.ok(typeof pc.default.bold === 'function', 'bold function should exist');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,15 @@ importers:
 
   platform/services/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^0.8.0
+        version: 0.8.2
       '@minecraft-docker/shared':
         specifier: workspace:*
         version: link:../shared
+      picocolors:
+        specifier: ^1.1.0
+        version: 1.1.1
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -32,8 +38,20 @@ importers:
 
 packages:
 
+  '@clack/core@0.3.5':
+    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+
+  '@clack/prompts@0.8.2':
+    resolution: {integrity: sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==}
+
   '@types/node@20.19.30':
     resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -45,9 +63,24 @@ packages:
 
 snapshots:
 
+  '@clack/core@0.3.5':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.8.2':
+    dependencies:
+      '@clack/core': 0.3.5
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@types/node@20.19.30':
     dependencies:
       undici-types: 6.21.0
+
+  picocolors@1.1.1: {}
+
+  sisteransi@1.0.5: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary
- Add `@clack/prompts` ^0.8.0 for interactive CLI prompts
- Add `picocolors` ^1.1.0 for terminal color support
- Add basic import tests to verify dependencies work correctly

## Test plan
- [x] Dependencies installed successfully
- [x] Basic import test passes
- [x] Build succeeds with new dependencies
- [x] No conflicts with existing dependencies

## Related
- Closes #30
- Part of Milestone: v0.4.0 - CLI Interactive Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)