### PR TITLE
feat: DocsAdapter - Dynamic prompts from docs/ (#35)

### DIFF
--- a/platform/services/cli/src/infrastructure/adapters/DocsAdapter.ts
+++ b/platform/services/cli/src/infrastructure/adapters/DocsAdapter.ts
@@ -1,0 +1,546 @@
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { Paths } from '@minecraft-docker/shared';
+import { ServerTypeEnum } from '../../domain/index.js';
+import type {
+  IDocProvider,
+  DocServerTypeInfo,
+  DocEnvVarInfo,
+  DocVersionInfo,
+  DocMemoryInfo,
+} from '../../application/ports/outbound/IDocProvider.js';
+
+/**
+ * DocsAdapter
+ * Parses docs/ directory for dynamic server configuration information
+ */
+export class DocsAdapter implements IDocProvider {
+  private readonly docsDir: string;
+  private serverTypesCache: DocServerTypeInfo[] | null = null;
+  private envVarsCache: DocEnvVarInfo[] | null = null;
+
+  constructor(rootDir?: string) {
+    const paths = new Paths(rootDir);
+    // docs/ is at project root, not platform root
+    this.docsDir = join(paths.root, '..', 'docs');
+  }
+
+  /**
+   * Check if docs directory is available
+   */
+  async isAvailable(): Promise<boolean> {
+    const typesFile = join(this.docsDir, '06-types-and-platforms.md');
+    return existsSync(typesFile);
+  }
+
+  /**
+   * Get server types from docs/06-types-and-platforms.md
+   */
+  async getServerTypes(): Promise<DocServerTypeInfo[]> {
+    if (this.serverTypesCache) {
+      return this.serverTypesCache;
+    }
+
+    const filePath = join(this.docsDir, '06-types-and-platforms.md');
+
+    if (!existsSync(filePath)) {
+      return this.getDefaultServerTypes();
+    }
+
+    try {
+      const content = await readFile(filePath, 'utf-8');
+      this.serverTypesCache = this.parseServerTypes(content);
+      return this.serverTypesCache;
+    } catch {
+      return this.getDefaultServerTypes();
+    }
+  }
+
+  /**
+   * Get environment variables from docs/03-variables.md
+   */
+  async getEnvVars(category?: string): Promise<DocEnvVarInfo[]> {
+    if (!this.envVarsCache) {
+      const filePath = join(this.docsDir, '03-variables.md');
+
+      if (!existsSync(filePath)) {
+        this.envVarsCache = this.getDefaultEnvVars();
+      } else {
+        try {
+          const content = await readFile(filePath, 'utf-8');
+          this.envVarsCache = this.parseEnvVars(content);
+        } catch {
+          this.envVarsCache = this.getDefaultEnvVars();
+        }
+      }
+    }
+
+    if (category) {
+      return this.envVarsCache.filter(
+        (v) => v.category.toLowerCase() === category.toLowerCase()
+      );
+    }
+
+    return this.envVarsCache;
+  }
+
+  /**
+   * Get version compatibility information
+   */
+  async getVersionCompatibility(serverType: string): Promise<DocVersionInfo[]> {
+    // Version compatibility based on known data
+    const commonVersions = await this.getCommonVersions();
+
+    return commonVersions.map((version) => {
+      const javaVersion = this.getJavaVersionForMc(version);
+      const supportedTypes = this.getSupportedTypesForVersion(version);
+
+      return {
+        mcVersion: version,
+        javaVersion,
+        supportedTypes,
+        isLatest: version === 'LATEST',
+      };
+    });
+  }
+
+  /**
+   * Get common Minecraft versions
+   */
+  async getCommonVersions(): Promise<string[]> {
+    return [
+      'LATEST',
+      '1.21.4',
+      '1.21.3',
+      '1.21.1',
+      '1.21',
+      '1.20.4',
+      '1.20.1',
+      '1.19.4',
+      '1.18.2',
+      '1.16.5',
+      '1.12.2',
+    ];
+  }
+
+  /**
+   * Get recommended memory settings
+   */
+  async getMemoryRecommendations(): Promise<DocMemoryInfo[]> {
+    return [
+      {
+        label: '2 GB',
+        value: '2G',
+        description: 'Minimum for vanilla servers',
+        recommended: false,
+        forMods: false,
+      },
+      {
+        label: '4 GB',
+        value: '4G',
+        description: 'Recommended for most servers',
+        recommended: true,
+        forMods: false,
+      },
+      {
+        label: '6 GB',
+        value: '6G',
+        description: 'For modded servers with 20-50 mods',
+        recommended: false,
+        forMods: true,
+      },
+      {
+        label: '8 GB',
+        value: '8G',
+        description: 'For large modpacks (50+ mods)',
+        recommended: false,
+        forMods: true,
+      },
+      {
+        label: '10 GB',
+        value: '10G',
+        description: 'For heavy modpacks and many players',
+        recommended: false,
+        forMods: true,
+      },
+    ];
+  }
+
+  // ========================================
+  // Private: Parsing Methods
+  // ========================================
+
+  private parseServerTypes(content: string): DocServerTypeInfo[] {
+    const types: DocServerTypeInfo[] = [];
+    const lines = content.split('\n');
+
+    // Parse the summary table at the end
+    const summaryStart = content.indexOf('## Server Type Summary');
+    if (summaryStart !== -1) {
+      const tableMatch = content
+        .slice(summaryStart)
+        .match(/\| Type \| Purpose \| Plugins \| Mods \|[\s\S]*?(?=\n\n|$)/);
+
+      if (tableMatch) {
+        const tableLines = tableMatch[0].split('\n').slice(2); // Skip header and separator
+
+        for (const line of tableLines) {
+          const match = line.match(
+            /\|\s*`(\w+)`\s*\|\s*([^|]+)\s*\|\s*([OX-])\s*\|\s*([OX-])\s*\|/
+          );
+          if (match) {
+            const typeValue = match[1];
+            const purpose = match[2];
+            const plugins = match[3];
+            const mods = match[4];
+
+            if (!typeValue || !purpose || !plugins || !mods) continue;
+
+            const enumValue = typeValue as ServerTypeEnum;
+
+            if (Object.values(ServerTypeEnum).includes(enumValue)) {
+              types.push({
+                value: enumValue,
+                label: this.formatLabel(typeValue),
+                description: purpose.trim(),
+                supportsPlugins: plugins === 'O',
+                supportsMods: mods === 'O',
+                recommended: typeValue === 'PAPER',
+                javaVersions: this.getDefaultJavaVersions(typeValue),
+              });
+            }
+          }
+        }
+      }
+    }
+
+    // If parsing failed, return defaults
+    if (types.length === 0) {
+      return this.getDefaultServerTypes();
+    }
+
+    return types;
+  }
+
+  private parseEnvVars(content: string): DocEnvVarInfo[] {
+    const vars: DocEnvVarInfo[] = [];
+    const sections = content.split(/^## /m).slice(1);
+
+    for (const section of sections) {
+      const lines = section.split('\n');
+      const categoryLine = lines[0];
+      const rest = lines.slice(1);
+
+      if (!categoryLine) continue;
+
+      const category = categoryLine.trim();
+      const sectionContent = rest.join('\n');
+
+      // Parse tables in this section
+      const tableMatches = sectionContent.matchAll(
+        /\| Variable \|[^|]*\|[^|]*\|?\n\|[-|]+\|\n([\s\S]*?)(?=\n\n|\n##|$)/g
+      );
+
+      for (const tableMatch of tableMatches) {
+        const tableContent = tableMatch[1];
+        if (!tableContent) continue;
+
+        const rows = tableContent.split('\n').filter((r) => r.includes('|'));
+
+        for (const row of rows) {
+          const cells = row
+            .split('|')
+            .map((c) => c.trim())
+            .filter(Boolean);
+          if (cells.length >= 2) {
+            const name = (cells[0] ?? '').replace(/`/g, '');
+            const defaultOrDesc = cells[1] ?? '';
+            const description = cells[2] ?? defaultOrDesc;
+
+            vars.push({
+              name,
+              type: this.inferType(name, description),
+              default: cells.length >= 3 ? (defaultOrDesc !== '-' ? defaultOrDesc : undefined) : undefined,
+              description: description.replace(/\*\*/g, ''),
+              required: description.toLowerCase().includes('required'),
+              category,
+            });
+          }
+        }
+      }
+    }
+
+    if (vars.length === 0) {
+      return this.getDefaultEnvVars();
+    }
+
+    return vars;
+  }
+
+  // ========================================
+  // Private: Helper Methods
+  // ========================================
+
+  private formatLabel(type: string): string {
+    const labels: Record<string, string> = {
+      VANILLA: 'Vanilla',
+      PAPER: 'Paper',
+      FORGE: 'Forge',
+      FABRIC: 'Fabric',
+      QUILT: 'Quilt',
+      SPIGOT: 'Spigot',
+      BUKKIT: 'Bukkit',
+      PURPUR: 'Purpur',
+      MOHIST: 'Mohist',
+      AUTO_CURSEFORGE: 'CurseForge Modpack',
+      MODRINTH: 'Modrinth Modpack',
+    };
+    return labels[type] || type;
+  }
+
+  private getDefaultJavaVersions(type: string): string[] {
+    // Based on server type, return recommended Java versions
+    switch (type.toUpperCase()) {
+      case 'FORGE':
+        return ['java8', 'java17', 'java21'];
+      case 'FABRIC':
+      case 'QUILT':
+        return ['java17', 'java21'];
+      default:
+        return ['java21', 'java17'];
+    }
+  }
+
+  private getJavaVersionForMc(version: string): string {
+    if (version === 'LATEST') return 'java21';
+
+    const parts = version.split('.').map(Number);
+    const major = parts[0] ?? 0;
+    const minor = parts[1] ?? 0;
+
+    if (major === 1) {
+      if (minor >= 21) return 'java21';
+      if (minor >= 18) return 'java17';
+      if (minor >= 17) return 'java16';
+      return 'java8';
+    }
+
+    return 'java21';
+  }
+
+  private getSupportedTypesForVersion(version: string): string[] {
+    if (version === 'LATEST') {
+      return ['VANILLA', 'PAPER', 'FABRIC', 'FORGE', 'QUILT'];
+    }
+
+    const parts = version.split('.').map(Number);
+    const major = parts[0] ?? 0;
+    const minor = parts[1] ?? 0;
+
+    if (major === 1) {
+      if (minor >= 20) {
+        return ['VANILLA', 'PAPER', 'FABRIC', 'FORGE', 'QUILT', 'PURPUR'];
+      }
+      if (minor >= 17) {
+        return ['VANILLA', 'PAPER', 'FABRIC', 'FORGE', 'SPIGOT'];
+      }
+      if (minor >= 12) {
+        return ['VANILLA', 'PAPER', 'FORGE', 'SPIGOT', 'BUKKIT'];
+      }
+    }
+
+    return ['VANILLA', 'FORGE'];
+  }
+
+  private inferType(name: string, description: string): string {
+    const lowerName = name.toLowerCase();
+    const lowerDesc = description.toLowerCase();
+
+    if (lowerName.includes('enable') || lowerDesc.includes('true/false')) {
+      return 'boolean';
+    }
+    if (lowerName.includes('port') || lowerName.includes('count') || lowerName.includes('max')) {
+      return 'number';
+    }
+    if (lowerName.includes('memory') || name === 'MEMORY') {
+      return 'memory';
+    }
+
+    return 'string';
+  }
+
+  // ========================================
+  // Private: Default Data
+  // ========================================
+
+  private getDefaultServerTypes(): DocServerTypeInfo[] {
+    return [
+      {
+        value: ServerTypeEnum.PAPER,
+        label: 'Paper',
+        description: 'High performance server with plugin support',
+        supportsPlugins: true,
+        supportsMods: false,
+        recommended: true,
+        javaVersions: ['java21', 'java17'],
+      },
+      {
+        value: ServerTypeEnum.VANILLA,
+        label: 'Vanilla',
+        description: 'Official Minecraft server',
+        supportsPlugins: false,
+        supportsMods: false,
+        recommended: false,
+        javaVersions: ['java21', 'java17'],
+      },
+      {
+        value: ServerTypeEnum.FORGE,
+        label: 'Forge',
+        description: 'Mod server for Forge mods',
+        supportsPlugins: false,
+        supportsMods: true,
+        recommended: false,
+        javaVersions: ['java8', 'java17', 'java21'],
+      },
+      {
+        value: ServerTypeEnum.FABRIC,
+        label: 'Fabric',
+        description: 'Lightweight modded server',
+        supportsPlugins: false,
+        supportsMods: true,
+        recommended: false,
+        javaVersions: ['java17', 'java21'],
+      },
+      {
+        value: ServerTypeEnum.QUILT,
+        label: 'Quilt',
+        description: 'Fabric-compatible mod loader',
+        supportsPlugins: false,
+        supportsMods: true,
+        recommended: false,
+        javaVersions: ['java17', 'java21'],
+      },
+      {
+        value: ServerTypeEnum.SPIGOT,
+        label: 'Spigot',
+        description: 'Modified Bukkit server with plugin support',
+        supportsPlugins: true,
+        supportsMods: false,
+        recommended: false,
+        javaVersions: ['java17', 'java21'],
+      },
+      {
+        value: ServerTypeEnum.BUKKIT,
+        label: 'Bukkit',
+        description: 'Classic plugin server',
+        supportsPlugins: true,
+        supportsMods: false,
+        recommended: false,
+        javaVersions: ['java17', 'java21'],
+      },
+      {
+        value: ServerTypeEnum.PURPUR,
+        label: 'Purpur',
+        description: 'Paper fork with additional features',
+        supportsPlugins: true,
+        supportsMods: false,
+        recommended: false,
+        javaVersions: ['java17', 'java21'],
+      },
+    ];
+  }
+
+  private getDefaultEnvVars(): DocEnvVarInfo[] {
+    return [
+      {
+        name: 'EULA',
+        type: 'boolean',
+        default: undefined,
+        description: 'Minecraft EULA agreement (Required: TRUE)',
+        required: true,
+        category: 'General Settings',
+      },
+      {
+        name: 'TYPE',
+        type: 'string',
+        default: 'VANILLA',
+        description: 'Server type',
+        required: false,
+        category: 'General Settings',
+      },
+      {
+        name: 'VERSION',
+        type: 'string',
+        default: 'LATEST',
+        description: 'Minecraft version',
+        required: false,
+        category: 'General Settings',
+      },
+      {
+        name: 'MEMORY',
+        type: 'memory',
+        default: '1G',
+        description: 'Initial/max heap memory',
+        required: false,
+        category: 'Memory Settings',
+      },
+      {
+        name: 'SEED',
+        type: 'string',
+        default: undefined,
+        description: 'World seed',
+        required: false,
+        category: 'Server Settings',
+      },
+      {
+        name: 'MOTD',
+        type: 'string',
+        default: undefined,
+        description: 'Server message',
+        required: false,
+        category: 'Server Settings',
+      },
+      {
+        name: 'DIFFICULTY',
+        type: 'string',
+        default: 'easy',
+        description: 'Difficulty (peaceful, easy, normal, hard)',
+        required: false,
+        category: 'Server Settings',
+      },
+      {
+        name: 'MODE',
+        type: 'string',
+        default: 'survival',
+        description: 'Game mode (survival, creative, adventure, spectator)',
+        required: false,
+        category: 'Server Settings',
+      },
+      {
+        name: 'MAX_PLAYERS',
+        type: 'number',
+        default: '20',
+        description: 'Maximum player count',
+        required: false,
+        category: 'Server Settings',
+      },
+      {
+        name: 'ENABLE_RCON',
+        type: 'boolean',
+        default: 'true',
+        description: 'Enable RCON',
+        required: false,
+        category: 'RCON',
+      },
+      {
+        name: 'RCON_PASSWORD',
+        type: 'string',
+        default: undefined,
+        description: 'RCON password',
+        required: false,
+        category: 'RCON',
+      },
+    ];
+  }
+}

--- a/platform/services/cli/src/infrastructure/adapters/index.ts
+++ b/platform/services/cli/src/infrastructure/adapters/index.ts
@@ -2,3 +2,4 @@ export { ClackPromptAdapter } from './ClackPromptAdapter.js';
 export { ShellAdapter } from './ShellAdapter.js';
 export { ServerRepository } from './ServerRepository.js';
 export { WorldRepository } from './WorldRepository.js';
+export { DocsAdapter } from './DocsAdapter.js';

--- a/platform/services/cli/src/infrastructure/di/container.ts
+++ b/platform/services/cli/src/infrastructure/di/container.ts
@@ -4,6 +4,7 @@ import {
   ShellAdapter,
   ServerRepository,
   WorldRepository,
+  DocsAdapter,
 } from '../adapters/index.js';
 import {
   CreateServerUseCase,
@@ -18,6 +19,7 @@ import type {
   IShellPort,
   IServerRepository,
   IWorldRepository,
+  IDocProvider,
   ICreateServerUseCase,
   IDeleteServerUseCase,
   IServerStatusUseCase,
@@ -38,6 +40,7 @@ export class Container {
   private _shellPort?: IShellPort;
   private _serverRepo?: IServerRepository;
   private _worldRepo?: IWorldRepository;
+  private _docProvider?: IDocProvider;
 
   constructor(rootDir?: string) {
     this.paths = new Paths(rootDir);
@@ -73,6 +76,13 @@ export class Container {
       this._worldRepo = new WorldRepository(this.paths);
     }
     return this._worldRepo;
+  }
+
+  get docProvider(): IDocProvider {
+    if (!this._docProvider) {
+      this._docProvider = new DocsAdapter(this.paths.root);
+    }
+    return this._docProvider;
   }
 
   // ========================================

--- a/platform/services/cli/src/infrastructure/index.ts
+++ b/platform/services/cli/src/infrastructure/index.ts
@@ -4,6 +4,7 @@ export {
   ShellAdapter,
   ServerRepository,
   WorldRepository,
+  DocsAdapter,
 } from './adapters/index.js';
 
 // DI Container

--- a/platform/services/cli/tests/unit/infrastructure/adapters/DocsAdapter.test.ts
+++ b/platform/services/cli/tests/unit/infrastructure/adapters/DocsAdapter.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { DocsAdapter } from '../../../../src/infrastructure/adapters/DocsAdapter.js';
+
+describe('DocsAdapter', () => {
+  let adapter: DocsAdapter;
+
+  beforeEach(() => {
+    // Use project root (../../.. from cli/tests/unit/infrastructure/adapters)
+    adapter = new DocsAdapter();
+  });
+
+  describe('isAvailable', () => {
+    it('should return true when docs directory exists', async () => {
+      const available = await adapter.isAvailable();
+      // May be true or false depending on test environment
+      assert.strictEqual(typeof available, 'boolean');
+    });
+  });
+
+  describe('getServerTypes', () => {
+    it('should return server types array', async () => {
+      const types = await adapter.getServerTypes();
+
+      assert.ok(Array.isArray(types));
+      assert.ok(types.length > 0);
+    });
+
+    it('should include PAPER server type', async () => {
+      const types = await adapter.getServerTypes();
+      const paper = types.find((t) => t.value === 'PAPER');
+
+      assert.ok(paper);
+      assert.strictEqual(paper.label, 'Paper');
+      assert.strictEqual(paper.supportsPlugins, true);
+      assert.strictEqual(paper.supportsMods, false);
+      assert.strictEqual(paper.recommended, true);
+    });
+
+    it('should include VANILLA server type', async () => {
+      const types = await adapter.getServerTypes();
+      const vanilla = types.find((t) => t.value === 'VANILLA');
+
+      assert.ok(vanilla);
+      assert.strictEqual(vanilla.label, 'Vanilla');
+      assert.strictEqual(vanilla.supportsPlugins, false);
+      assert.strictEqual(vanilla.supportsMods, false);
+    });
+
+    it('should include FORGE server type', async () => {
+      const types = await adapter.getServerTypes();
+      const forge = types.find((t) => t.value === 'FORGE');
+
+      assert.ok(forge);
+      assert.strictEqual(forge.label, 'Forge');
+      assert.strictEqual(forge.supportsPlugins, false);
+      assert.strictEqual(forge.supportsMods, true);
+    });
+
+    it('should include FABRIC server type', async () => {
+      const types = await adapter.getServerTypes();
+      const fabric = types.find((t) => t.value === 'FABRIC');
+
+      assert.ok(fabric);
+      assert.strictEqual(fabric.label, 'Fabric');
+      assert.strictEqual(fabric.supportsPlugins, false);
+      assert.strictEqual(fabric.supportsMods, true);
+    });
+
+    it('should have javaVersions for each type', async () => {
+      const types = await adapter.getServerTypes();
+
+      for (const type of types) {
+        assert.ok(Array.isArray(type.javaVersions));
+        assert.ok(type.javaVersions.length > 0);
+      }
+    });
+  });
+
+  describe('getEnvVars', () => {
+    it('should return environment variables array', async () => {
+      const vars = await adapter.getEnvVars();
+
+      assert.ok(Array.isArray(vars));
+      assert.ok(vars.length > 0);
+    });
+
+    it('should include EULA variable as required', async () => {
+      const vars = await adapter.getEnvVars();
+      const eula = vars.find((v) => v.name === 'EULA');
+
+      assert.ok(eula);
+      assert.strictEqual(eula.required, true);
+    });
+
+    it('should include TYPE variable', async () => {
+      const vars = await adapter.getEnvVars();
+      const type = vars.find((v) => v.name === 'TYPE');
+
+      assert.ok(type);
+      assert.strictEqual(type.default, 'VANILLA');
+    });
+
+    it('should include MEMORY variable', async () => {
+      const vars = await adapter.getEnvVars();
+      const memory = vars.find((v) => v.name === 'MEMORY');
+
+      assert.ok(memory);
+      assert.strictEqual(memory.type, 'memory');
+    });
+
+    it('should filter by category', async () => {
+      const memoryVars = await adapter.getEnvVars('Memory Settings');
+
+      assert.ok(Array.isArray(memoryVars));
+      for (const v of memoryVars) {
+        assert.strictEqual(v.category, 'Memory Settings');
+      }
+    });
+  });
+
+  describe('getCommonVersions', () => {
+    it('should return common versions array', async () => {
+      const versions = await adapter.getCommonVersions();
+
+      assert.ok(Array.isArray(versions));
+      assert.ok(versions.length > 0);
+    });
+
+    it('should include LATEST', async () => {
+      const versions = await adapter.getCommonVersions();
+
+      assert.ok(versions.includes('LATEST'));
+    });
+
+    it('should include recent versions', async () => {
+      const versions = await adapter.getCommonVersions();
+
+      assert.ok(versions.some((v) => v.startsWith('1.21')));
+      assert.ok(versions.some((v) => v.startsWith('1.20')));
+    });
+  });
+
+  describe('getVersionCompatibility', () => {
+    it('should return version compatibility array', async () => {
+      const compatibility = await adapter.getVersionCompatibility('PAPER');
+
+      assert.ok(Array.isArray(compatibility));
+      assert.ok(compatibility.length > 0);
+    });
+
+    it('should include java version for each entry', async () => {
+      const compatibility = await adapter.getVersionCompatibility('PAPER');
+
+      for (const entry of compatibility) {
+        assert.ok(entry.javaVersion);
+        assert.ok(entry.javaVersion.startsWith('java'));
+      }
+    });
+
+    it('should recommend java21 for LATEST', async () => {
+      const compatibility = await adapter.getVersionCompatibility('PAPER');
+      const latest = compatibility.find((c) => c.mcVersion === 'LATEST');
+
+      assert.ok(latest);
+      assert.strictEqual(latest.javaVersion, 'java21');
+    });
+
+    it('should recommend java8 for old versions', async () => {
+      const compatibility = await adapter.getVersionCompatibility('FORGE');
+      const old = compatibility.find((c) => c.mcVersion === '1.12.2');
+
+      assert.ok(old);
+      assert.strictEqual(old.javaVersion, 'java8');
+    });
+  });
+
+  describe('getMemoryRecommendations', () => {
+    it('should return memory recommendations array', async () => {
+      const recommendations = await adapter.getMemoryRecommendations();
+
+      assert.ok(Array.isArray(recommendations));
+      assert.ok(recommendations.length > 0);
+    });
+
+    it('should include 4G as recommended', async () => {
+      const recommendations = await adapter.getMemoryRecommendations();
+      const fourG = recommendations.find((r) => r.value === '4G');
+
+      assert.ok(fourG);
+      assert.strictEqual(fourG.recommended, true);
+    });
+
+    it('should include options for mods', async () => {
+      const recommendations = await adapter.getMemoryRecommendations();
+      const forMods = recommendations.filter((r) => r.forMods);
+
+      assert.ok(forMods.length > 0);
+    });
+
+    it('should have valid memory format', async () => {
+      const recommendations = await adapter.getMemoryRecommendations();
+
+      for (const rec of recommendations) {
+        assert.ok(/^\d+[GMK]$/i.test(rec.value));
+      }
+    });
+  });
+
+  describe('caching', () => {
+    it('should cache server types on subsequent calls', async () => {
+      const types1 = await adapter.getServerTypes();
+      const types2 = await adapter.getServerTypes();
+
+      assert.deepStrictEqual(types1, types2);
+    });
+
+    it('should cache env vars on subsequent calls', async () => {
+      const vars1 = await adapter.getEnvVars();
+      const vars2 = await adapter.getEnvVars();
+
+      assert.deepStrictEqual(vars1, vars2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `DocsAdapter` that parses `docs/06-types-and-platforms.md` and `docs/03-variables.md` for dynamic server configuration
- Parse server types with plugin/mod support information and Java version recommendations
- Parse environment variables by category with automatic type inference
- Provide memory recommendations with mod-specific options
- Provide version compatibility with Java version mapping (java8 for 1.12.2, java21 for 1.21+)
- Add caching for parsed content to improve performance
- Register `DocsAdapter` in DI Container as `IDocProvider`

## Test Plan
- [x] Unit tests for `isAvailable()` method
- [x] Unit tests for `getServerTypes()` - PAPER, VANILLA, FORGE, FABRIC
- [x] Unit tests for `getEnvVars()` - EULA, TYPE, MEMORY, category filtering
- [x] Unit tests for `getCommonVersions()` - LATEST, recent versions
- [x] Unit tests for `getVersionCompatibility()` - Java version mapping
- [x] Unit tests for `getMemoryRecommendations()` - 4G recommended, mod options
- [x] Unit tests for caching behavior

**All 25 tests passing**

## Files Changed
- `platform/services/cli/src/infrastructure/adapters/DocsAdapter.ts` - Main implementation
- `platform/services/cli/src/infrastructure/adapters/index.ts` - Export DocsAdapter
- `platform/services/cli/src/infrastructure/index.ts` - Export from infrastructure
- `platform/services/cli/src/infrastructure/di/container.ts` - Register in DI container
- `platform/services/cli/tests/unit/infrastructure/adapters/DocsAdapter.test.ts` - Unit tests

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)