### PR TITLE
feat: Interactive create command implementation (#36)

### DIFF
--- a/platform/services/cli/src/commands/create.ts
+++ b/platform/services/cli/src/commands/create.ts
@@ -1,0 +1,106 @@
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../infrastructure/index.js';
+
+/**
+ * Create command options from CLI arguments
+ */
+export interface CreateCommandOptions {
+  root?: string;
+  name?: string;
+  type?: string;
+  version?: string;
+  seed?: string;
+  worldUrl?: string;
+  worldName?: string;
+  noStart?: boolean;
+}
+
+/**
+ * Execute create server command
+ *
+ * If name is provided, runs in CLI mode with arguments.
+ * If name is not provided, runs in interactive mode.
+ */
+export async function createCommand(options: CreateCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  // Check if initialized
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+
+  // Determine execution mode
+  if (options.name) {
+    // CLI argument mode - use executeWithConfig
+    return createWithArguments(container, options);
+  } else {
+    // Interactive mode - use execute
+    return createInteractive(container);
+  }
+}
+
+/**
+ * Create server with CLI arguments (non-interactive)
+ */
+async function createWithArguments(
+  container: ReturnType<typeof getContainer>,
+  options: CreateCommandOptions
+): Promise<number> {
+  const useCase = container.createServerUseCase;
+  const prompt = container.promptPort;
+
+  try {
+    const server = await useCase.executeWithConfig({
+      name: options.name!,
+      type: options.type,
+      version: options.version,
+      seed: options.seed,
+      worldUrl: options.worldUrl,
+      worldName: options.worldName,
+      autoStart: !options.noStart,
+    });
+
+    console.log('');
+    console.log(colors.green(`✓ Server '${server.name.value}' created successfully!`));
+    console.log(`  Container: ${colors.cyan(server.containerName)}`);
+    console.log(`  Type: ${server.type.label}`);
+    console.log(`  Version: ${server.version.value}`);
+    console.log(`  Memory: ${server.memory.value}`);
+    console.log('');
+    console.log(`  Connect via: ${colors.cyan(server.name.hostname + ':25565')}`);
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}
+
+/**
+ * Create server interactively (with prompts)
+ */
+async function createInteractive(
+  container: ReturnType<typeof getContainer>
+): Promise<number> {
+  const useCase = container.createServerUseCase;
+
+  try {
+    await useCase.execute();
+    return 0;
+  } catch (error) {
+    // Check if user cancelled
+    const prompt = container.promptPort;
+    if (prompt.isCancel(error)) {
+      return 0; // User cancellation is not an error
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -1,0 +1,3 @@
+export { initCommand } from './init.js';
+export { statusCommand } from './status.js';
+export { createCommand, type CreateCommandOptions } from './create.js';

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { Paths, log, colors } from '@minecraft-docker/shared';
-import { initCommand } from './commands/init.js';
-import { statusCommand } from './commands/status.js';
+import { initCommand, statusCommand, createCommand } from './commands/index.js';
 import { ShellExecutor } from './lib/shell.js';
 
 const VERSION = '0.1.0';
@@ -191,31 +190,18 @@ async function main(): Promise<void> {
         break;
 
       case 'create': {
-        const name = positional[0];
-        if (!name) {
-          log.error('Server name is required');
-          console.log('Usage: mcctl create <name> [options]');
-          exitCode = 1;
-          break;
-        }
-
-        // Check if initialized
-        if (!paths.isInitialized()) {
-          log.error('Platform not initialized. Run: mcctl init');
-          exitCode = 1;
-          break;
-        }
-
-        // Build options for create-server.sh
-        const createOpts: string[] = [];
-        if (flags['type']) createOpts.push('-t', flags['type'] as string);
-        if (flags['version']) createOpts.push('-v', flags['version'] as string);
-        if (flags['seed']) createOpts.push('-s', flags['seed'] as string);
-        if (flags['world-url']) createOpts.push('-u', flags['world-url'] as string);
-        if (flags['world']) createOpts.push('-w', flags['world'] as string);
-        if (flags['no-start']) createOpts.push('--no-start');
-
-        exitCode = await shell.createServer(name, createOpts);
+        // Use new interactive create command
+        // If no name provided, will run in interactive mode
+        exitCode = await createCommand({
+          root: rootDir,
+          name: positional[0],
+          type: flags['type'] as string | undefined,
+          version: flags['version'] as string | undefined,
+          seed: flags['seed'] as string | undefined,
+          worldUrl: flags['world-url'] as string | undefined,
+          worldName: flags['world'] as string | undefined,
+          noStart: flags['no-start'] === true,
+        });
         break;
       }
 


### PR DESCRIPTION
## Summary
- Implement `createCommand` that supports both interactive and CLI argument modes
- When no server name provided, runs interactive mode with @clack/prompts
- When server name provided, runs CLI argument mode using `CreateServerUseCase.executeWithConfig()`
- Integrate with existing DI container and use cases
- Add `commands/index.ts` for centralized command exports
- Refactor `index.ts` to use the new modular create command

## Interactive Mode Flow
```
$ mcctl create

┌  Create Minecraft Server
│
◆  Server name?
│  myserver
│
◆  Server type?
│  ● Paper (Recommended)
│  ○ Vanilla
│  ○ Forge
│  ○ Fabric
│
◆  Minecraft version?
│  ● Latest
│  ○ 1.21.1
│  ○ 1.20.4
│
◆  World setup?
│  ● New world
│  ○ Use existing world
│  ○ Download from URL
│
◆  Memory allocation?
│  4G
│
◇  Creating server...
│
└  ✓ Server 'myserver' created!
```

## CLI Argument Mode (Backward Compatible)
```bash
# Still works as before
mcctl create myserver -t PAPER -v 1.21.1
mcctl create myserver --type FORGE --version 1.20.4
```

## Test Plan
- [x] Build passes
- [ ] Interactive mode works end-to-end (manual test)
- [ ] CLI argument mode works (manual test)
- [ ] Error handling for invalid inputs

## Files Changed
- `platform/services/cli/src/commands/create.ts` - New create command implementation
- `platform/services/cli/src/commands/index.ts` - Centralized command exports
- `platform/services/cli/src/index.ts` - Integration with main CLI

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)