### PR TITLE
feat: Interactive delete command implementation (#37)

### DIFF
--- a/platform/services/cli/src/commands/delete.ts
+++ b/platform/services/cli/src/commands/delete.ts
@@ -1,0 +1,89 @@
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../infrastructure/index.js';
+
+/**
+ * Delete command options from CLI arguments
+ */
+export interface DeleteCommandOptions {
+  root?: string;
+  name?: string;
+  force?: boolean;
+}
+
+/**
+ * Execute delete server command
+ *
+ * If name is provided, runs in CLI mode with direct deletion.
+ * If name is not provided, runs in interactive mode with selection.
+ */
+export async function deleteCommand(options: DeleteCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  // Check if initialized
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+
+  // Determine execution mode
+  if (options.name) {
+    // CLI argument mode - use executeWithName
+    return deleteWithArguments(container, options);
+  } else {
+    // Interactive mode - use execute
+    return deleteInteractive(container);
+  }
+}
+
+/**
+ * Delete server with CLI arguments (non-interactive)
+ */
+async function deleteWithArguments(
+  container: ReturnType<typeof getContainer>,
+  options: DeleteCommandOptions
+): Promise<number> {
+  const useCase = container.deleteServerUseCase;
+
+  try {
+    const deleted = await useCase.executeWithName(options.name!, options.force ?? false);
+
+    if (deleted) {
+      console.log('');
+      console.log(colors.green(`✓ Server '${options.name}' deleted successfully!`));
+      console.log(colors.dim('  World data has been preserved in worlds/ directory.'));
+      console.log('');
+    }
+
+    return deleted ? 0 : 1;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}
+
+/**
+ * Delete server interactively (with prompts)
+ */
+async function deleteInteractive(
+  container: ReturnType<typeof getContainer>
+): Promise<number> {
+  const useCase = container.deleteServerUseCase;
+
+  try {
+    const deleted = await useCase.execute();
+    return deleted ? 0 : 1;
+  } catch (error) {
+    // Check if user cancelled
+    const prompt = container.promptPort;
+    if (prompt.isCancel(error)) {
+      return 0; // User cancellation is not an error
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -1,3 +1,4 @@
 export { initCommand } from './init.js';
 export { statusCommand } from './status.js';
 export { createCommand, type CreateCommandOptions } from './create.js';
+export { deleteCommand, type DeleteCommandOptions } from './delete.js';

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Paths, log, colors } from '@minecraft-docker/shared';
-import { initCommand, statusCommand, createCommand } from './commands/index.js';
+import { initCommand, statusCommand, createCommand, deleteCommand } from './commands/index.js';
 import { ShellExecutor } from './lib/shell.js';
 
 const VERSION = '0.1.0';
@@ -206,24 +206,13 @@ async function main(): Promise<void> {
       }
 
       case 'delete': {
-        const name = positional[0];
-        if (!name) {
-          log.error('Server name is required');
-          console.log('Usage: mcctl delete <name> [--force]');
-          exitCode = 1;
-          break;
-        }
-
-        if (!paths.isInitialized()) {
-          log.error('Platform not initialized. Run: mcctl init');
-          exitCode = 1;
-          break;
-        }
-
-        const deleteOpts: string[] = [];
-        if (flags['force'] || flags['yes']) deleteOpts.push('--force');
-
-        exitCode = await shell.deleteServer(name, deleteOpts);
+        // Use new interactive delete command
+        // If no name provided, will run in interactive mode with server selection
+        exitCode = await deleteCommand({
+          root: rootDir,
+          name: positional[0],
+          force: flags['force'] === true || flags['yes'] === true,
+        });
         break;
       }
 


### PR DESCRIPTION
## Summary
- Implement `deleteCommand` that supports both interactive and CLI argument modes
- When no server name provided, runs interactive mode with server selection from @clack/prompts
- When server name provided, runs CLI argument mode using `DeleteServerUseCase.executeWithName()`
- Integrate with existing DI container and use cases
- Support `--force` flag to skip player online check

## Interactive Mode Flow
```
$ mcctl delete

┌  Delete Minecraft Server
│
◆  Select server to delete:
│  ● mc-myserver (Running - 3 players online)
│  ○ mc-testserver (Stopped)
│  ○ mc-creative (Running - 0 players)
│
◇  Server: mc-myserver
│  Type: PAPER 1.21.1
│  Status: Running
│  Players: 3 online
│
⚠  Warning: 3 player(s) are currently online!
│
◆  Are you sure you want to delete this server?
│  ● Yes, delete server
│  ○ No, cancel
│
◇  Stopping server...
◇  Removing server...
│
└  ✓ Server 'mc-myserver' deleted.
   World data preserved in worlds/myworld/
```

## CLI Argument Mode (Backward Compatible)
```bash
# With confirmation via UseCase
mcctl delete myserver

# Force delete (skips player check)
mcctl delete myserver --force
mcctl delete myserver -y
```

## Safety Features
- [x] Server selection with status info
- [x] Warn if players are online
- [x] Require explicit confirmation
- [x] `--force` flag skips player check
- [x] World data preservation notice

## Test Plan
- [x] Build passes
- [ ] Interactive mode works end-to-end (manual test)
- [ ] CLI argument mode works (manual test)
- [ ] Force mode skips player check (manual test)

## Files Changed
- `platform/services/cli/src/commands/delete.ts` - New delete command implementation
- `platform/services/cli/src/commands/index.ts` - Export delete command
- `platform/services/cli/src/index.ts` - Integration with main CLI

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)