### PR TITLE
feat: Interactive world and backup commands (#38)

### DIFF
--- a/platform/services/cli/src/commands/backup.ts
+++ b/platform/services/cli/src/commands/backup.ts
@@ -1,0 +1,234 @@
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../infrastructure/index.js';
+
+/**
+ * Backup command options
+ */
+export interface BackupCommandOptions {
+  root?: string;
+  subCommand?: string;
+  message?: string;
+  commitHash?: string;
+  json?: boolean;
+  auto?: boolean;
+}
+
+/**
+ * Execute backup command
+ */
+export async function backupCommand(options: BackupCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  // Check if initialized
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const subCommand = options.subCommand ?? 'status';
+
+  switch (subCommand) {
+    case 'status':
+      return backupStatus(container, options);
+
+    case 'push':
+      return backupPush(container, options);
+
+    case 'history':
+      return backupHistory(container, options);
+
+    case 'restore':
+      return backupRestore(container, options);
+
+    default:
+      log.error(`Unknown backup subcommand: ${subCommand}`);
+      console.log('Usage: mcctl backup [status|push|history|restore]');
+      return 1;
+  }
+}
+
+/**
+ * Show backup status
+ */
+async function backupStatus(
+  container: ReturnType<typeof getContainer>,
+  options: BackupCommandOptions
+): Promise<number> {
+  const useCase = container.backupUseCase;
+
+  try {
+    const status = await useCase.status();
+
+    if (options.json) {
+      console.log(JSON.stringify(status, null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.bold('Backup Configuration:'));
+    console.log('');
+
+    if (!status.configured) {
+      console.log(colors.yellow('  Status: Not configured'));
+      console.log('');
+      console.log('  To enable backups, set in .env:');
+      console.log(colors.dim('    BACKUP_GITHUB_TOKEN=your-token'));
+      console.log(colors.dim('    BACKUP_GITHUB_REPO=username/repo'));
+      console.log('');
+      return 0;
+    }
+
+    console.log(colors.green('  Status: Configured'));
+    if (status.repository) {
+      console.log(`  Repository: ${colors.cyan(status.repository)}`);
+    }
+    if (status.branch) {
+      console.log(`  Branch: ${status.branch}`);
+    }
+    if (status.lastBackup) {
+      console.log(`  Last backup: ${status.lastBackup.toLocaleString()}`);
+    }
+    if (status.autoBackupEnabled !== undefined) {
+      console.log(
+        `  Auto backup: ${status.autoBackupEnabled ? colors.green('enabled') : colors.dim('disabled')}`
+      );
+    }
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}
+
+/**
+ * Push backup to GitHub
+ */
+async function backupPush(
+  container: ReturnType<typeof getContainer>,
+  options: BackupCommandOptions
+): Promise<number> {
+  const useCase = container.backupUseCase;
+
+  try {
+    // If message provided, use direct push
+    if (options.message) {
+      const result = await useCase.pushWithMessage(options.message);
+
+      if (result.success) {
+        console.log('');
+        console.log(colors.green('✓ Backup complete!'));
+        if (result.commitHash) {
+          console.log(`  Commit: ${colors.cyan(result.commitHash)}`);
+        }
+        console.log('');
+        return 0;
+      } else {
+        log.error(result.error || 'Backup failed');
+        return 1;
+      }
+    }
+
+    // Interactive mode
+    const result = await useCase.push();
+    return result.success ? 0 : 1;
+  } catch (error) {
+    const prompt = container.promptPort;
+    if (prompt.isCancel(error)) {
+      return 0;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}
+
+/**
+ * Show backup history
+ */
+async function backupHistory(
+  container: ReturnType<typeof getContainer>,
+  options: BackupCommandOptions
+): Promise<number> {
+  const useCase = container.backupUseCase;
+
+  try {
+    const history = await useCase.history();
+
+    if (history.length === 0) {
+      console.log('No backup history found');
+      return 0;
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(history, null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.bold('Backup History:'));
+    console.log('');
+
+    for (const entry of history.slice(0, 10)) {
+      const hash = colors.cyan(entry.commitHash.substring(0, 7));
+      const date = colors.dim(entry.date.toLocaleDateString());
+      console.log(`  ${hash}  ${entry.message}  ${date}`);
+    }
+
+    if (history.length > 10) {
+      console.log(colors.dim(`  ... and ${history.length - 10} more`));
+    }
+
+    console.log('');
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}
+
+/**
+ * Restore from backup
+ */
+async function backupRestore(
+  container: ReturnType<typeof getContainer>,
+  options: BackupCommandOptions
+): Promise<number> {
+  const useCase = container.backupUseCase;
+
+  try {
+    // If commit hash provided, use direct restore
+    if (options.commitHash) {
+      const result = await useCase.restoreFromCommit(options.commitHash);
+
+      if (result.success) {
+        console.log('');
+        console.log(colors.green('✓ Restore complete!'));
+        console.log(`  Restored from: ${colors.cyan(result.commitHash.substring(0, 7))}`);
+        console.log('');
+        return 0;
+      } else {
+        log.error(result.error || 'Restore failed');
+        return 1;
+      }
+    }
+
+    // Interactive mode
+    const result = await useCase.restore();
+    return result.success ? 0 : 1;
+  } catch (error) {
+    const prompt = container.promptPort;
+    if (prompt.isCancel(error)) {
+      return 0;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -2,3 +2,5 @@ export { initCommand } from './init.js';
 export { statusCommand } from './status.js';
 export { createCommand, type CreateCommandOptions } from './create.js';
 export { deleteCommand, type DeleteCommandOptions } from './delete.js';
+export { worldCommand, type WorldCommandOptions } from './world.js';
+export { backupCommand, type BackupCommandOptions } from './backup.js';

--- a/platform/services/cli/src/commands/world.ts
+++ b/platform/services/cli/src/commands/world.ts
@@ -1,0 +1,185 @@
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../infrastructure/index.js';
+
+/**
+ * World command options
+ */
+export interface WorldCommandOptions {
+  root?: string;
+  subCommand?: string;
+  worldName?: string;
+  serverName?: string;
+  json?: boolean;
+  force?: boolean;
+}
+
+/**
+ * Execute world management command
+ */
+export async function worldCommand(options: WorldCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  // Check if initialized
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const subCommand = options.subCommand ?? 'list';
+
+  switch (subCommand) {
+    case 'list':
+      return worldList(container, options);
+
+    case 'assign':
+      return worldAssign(container, options);
+
+    case 'release':
+      return worldRelease(container, options);
+
+    default:
+      log.error(`Unknown world subcommand: ${subCommand}`);
+      console.log('Usage: mcctl world [list|assign|release]');
+      return 1;
+  }
+}
+
+/**
+ * List all worlds
+ */
+async function worldList(
+  container: ReturnType<typeof getContainer>,
+  options: WorldCommandOptions
+): Promise<number> {
+  const useCase = container.worldManagementUseCase;
+
+  try {
+    const worlds = await useCase.listWorlds();
+
+    if (worlds.length === 0) {
+      console.log('No worlds found in worlds/ directory');
+      return 0;
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(worlds, null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.bold('Worlds:'));
+    console.log('');
+
+    for (const world of worlds) {
+      const lockStatus = world.isLocked
+        ? colors.yellow(`locked: ${world.lockedBy}`)
+        : colors.green('unlocked');
+
+      console.log(`  ${colors.cyan(world.name)}`);
+      console.log(`    Status: ${lockStatus}`);
+      console.log(`    Size: ${world.size}`);
+      console.log(`    Path: ${world.path}`);
+      console.log('');
+    }
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}
+
+/**
+ * Assign world to server
+ */
+async function worldAssign(
+  container: ReturnType<typeof getContainer>,
+  options: WorldCommandOptions
+): Promise<number> {
+  const useCase = container.worldManagementUseCase;
+
+  try {
+    // If both world and server provided, use direct assignment
+    if (options.worldName && options.serverName) {
+      const result = await useCase.assignWorldByName(
+        options.worldName,
+        options.serverName
+      );
+
+      if (result.success) {
+        console.log('');
+        console.log(
+          colors.green(
+            `✓ World '${result.worldName}' assigned to '${result.serverName}'`
+          )
+        );
+        console.log('');
+        return 0;
+      } else {
+        log.error(result.error || 'Failed to assign world');
+        return 1;
+      }
+    }
+
+    // Interactive mode
+    const result = await useCase.assignWorld();
+    return result.success ? 0 : 1;
+  } catch (error) {
+    const prompt = container.promptPort;
+    if (prompt.isCancel(error)) {
+      return 0;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}
+
+/**
+ * Release world lock
+ */
+async function worldRelease(
+  container: ReturnType<typeof getContainer>,
+  options: WorldCommandOptions
+): Promise<number> {
+  const useCase = container.worldManagementUseCase;
+
+  try {
+    // If world name provided, use direct release
+    if (options.worldName) {
+      const result = await useCase.releaseWorldByName(
+        options.worldName,
+        options.force ?? false
+      );
+
+      if (result.success) {
+        console.log('');
+        console.log(colors.green(`✓ World '${result.worldName}' lock released`));
+        if (result.previousServer) {
+          console.log(colors.dim(`  Previously locked by: ${result.previousServer}`));
+        }
+        console.log('');
+        return 0;
+      } else {
+        log.error(result.error || 'Failed to release world lock');
+        return 1;
+      }
+    }
+
+    // Interactive mode
+    const result = await useCase.releaseWorld();
+    return result.success ? 0 : 1;
+  } catch (error) {
+    const prompt = container.promptPort;
+    if (prompt.isCancel(error)) {
+      return 0;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(message);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 
 import { Paths, log, colors } from '@minecraft-docker/shared';
-import { initCommand, statusCommand, createCommand, deleteCommand } from './commands/index.js';
+import {
+  initCommand,
+  statusCommand,
+  createCommand,
+  deleteCommand,
+  worldCommand,
+  backupCommand,
+} from './commands/index.js';
 import { ShellExecutor } from './lib/shell.js';
 
 const VERSION = '0.1.0';
@@ -237,17 +244,15 @@ async function main(): Promise<void> {
       }
 
       case 'world': {
-        if (!paths.isInitialized()) {
-          log.error('Platform not initialized. Run: mcctl init');
-          exitCode = 1;
-          break;
-        }
-
-        const worldArgs = [subCommand ?? 'list', ...positional];
-        if (flags['json']) worldArgs.push('--json');
-        if (flags['force']) worldArgs.push('--force');
-
-        exitCode = await shell.mcctl(['world', ...worldArgs]);
+        // Use new interactive world command
+        exitCode = await worldCommand({
+          root: rootDir,
+          subCommand: subCommand,
+          worldName: positional[0],
+          serverName: positional[1],
+          json: flags['json'] === true,
+          force: flags['force'] === true,
+        });
         break;
       }
 
@@ -261,18 +266,15 @@ async function main(): Promise<void> {
       }
 
       case 'backup': {
-        if (!paths.isInitialized()) {
-          log.error('Platform not initialized. Run: mcctl init');
-          exitCode = 1;
-          break;
-        }
-
-        const backupArgs = [subCommand ?? 'status', ...positional];
-        if (flags['json']) backupArgs.push('--json');
-        if (flags['message']) backupArgs.push('-m', flags['message'] as string);
-        if (flags['auto']) backupArgs.push('--auto');
-
-        exitCode = await shell.backup(backupArgs);
+        // Use new interactive backup command
+        exitCode = await backupCommand({
+          root: rootDir,
+          subCommand: subCommand,
+          message: flags['message'] as string | undefined,
+          commitHash: positional[0],
+          json: flags['json'] === true,
+          auto: flags['auto'] === true,
+        });
         break;
       }
 


### PR DESCRIPTION
## Summary
Implement interactive world management and backup commands with @clack/prompts integration.

### World Management
- `mcctl world list` - List worlds with lock status
- `mcctl world assign` - Interactive world-to-server assignment
- `mcctl world release` - Interactive lock release with confirmation

### Backup Commands
- `mcctl backup status` - Show backup configuration
- `mcctl backup push` - Interactive backup with message prompt
- `mcctl backup history` - Show backup history
- `mcctl backup restore` - Interactive commit selection

## Interactive Flows

### World Assign
```
$ mcctl world assign

┌  Assign World to Server
│
◆  Select world:
│  ● survival (unlocked)
│  ○ creative (locked: mc-creative)
│
◆  Select server:
│  ● mc-myserver
│  ○ mc-testserver
│
◇  Assigning world...
│
└  ✓ World 'survival' assigned to 'mc-myserver'
```

### Backup Push
```
$ mcctl backup push

┌  Backup Worlds to GitHub
│
◆  Backup message:
│  Before server upgrade
│
◇  Backing up worlds...
│
└  ✓ Backup complete!
   Commit: abc1234
```

## CLI Argument Mode (Backward Compatible)
```bash
# World management
mcctl world list --json
mcctl world assign survival mc-myserver
mcctl world release survival

# Backup
mcctl backup status
mcctl backup push -m "Manual backup"
mcctl backup history --json
mcctl backup restore abc1234
```

## Test Plan
- [x] Build passes
- [ ] World list works (manual test)
- [ ] World assign interactive mode (manual test)
- [ ] World release interactive mode (manual test)
- [ ] Backup status shows configuration (manual test)
- [ ] Backup push interactive mode (manual test)
- [ ] Backup history displays correctly (manual test)
- [ ] Backup restore interactive mode (manual test)

## Files Changed
- `platform/services/cli/src/commands/world.ts` - World command implementation
- `platform/services/cli/src/commands/backup.ts` - Backup command implementation
- `platform/services/cli/src/commands/index.ts` - Export new commands
- `platform/services/cli/src/index.ts` - Integration with main CLI

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)