### PR TITLE
feat(cli): add up/down commands and --all option for start/stop

### DIFF
--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       AUTO_SCALE_UP: "true"
       AUTO_SCALE_DOWN: "false"
       # AUTO_SCALE_DOWN disabled due to bug: disconnects players after timeout
-      # See: https://github.com/itzg/mc-router/issues (report pending)
+      # See: https://github.com/itzg/mc-router/issues/507
       DOCKER_TIMEOUT: "120"
       AUTO_SCALE_ASLEEP_MOTD: "§e§lServer is sleeping§r\n§7Connect to wake up!"
     ports:


### PR DESCRIPTION
## Summary
- Add `mcctl up` command to start all infrastructure (router + servers)
- Add `mcctl down` command to stop all infrastructure
- Add `--all` / `-a` option to `start` and `stop` commands

## New Commands

| Command | Description |
|---------|-------------|
| `mcctl up` | Start all infrastructure (mc-router + all MC servers) |
| `mcctl down` | Stop all infrastructure |
| `mcctl start --all` | Start all Minecraft servers (except router) |
| `mcctl stop --all` | Stop all Minecraft servers (except router) |

## Test plan
- [x] `mcctl up` starts router and all servers
- [x] `mcctl down` stops all containers
- [x] `mcctl start --all` starts all MC servers without affecting router
- [x] `mcctl stop --all` stops all MC servers without affecting router
- [x] `-a` short flag works for `--all`

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)