### PR TITLE
feat: Add mcctl exec command for RCON execution (#58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,12 @@ mcctl delete              # Interactive: shows server list
 mcctl delete myserver     # CLI: deletes myserver
 mcctl delete myserver --force  # Force delete even with players online
 
+# Infrastructure management
+mcctl up                  # Start all (mc-router + all servers)
+mcctl down                # Stop all infrastructure
+mcctl start --all         # Start all MC servers (not router)
+mcctl stop --all          # Stop all MC servers (not router)
+
 # Server management
 mcctl status
 mcctl start myserver
@@ -641,30 +647,37 @@ BACKUP_AUTO_ON_STOP=true
 
 ## Common Tasks
 
-### Start/Stop All Servers
+### Start/Stop All Infrastructure
 
 ```bash
+# Using mcctl (recommended)
+mcctl up      # Start mc-router + all servers
+mcctl down    # Stop all infrastructure
+
+# Using docker compose directly
 cd platform
+docker compose up -d    # Start all
+docker compose down     # Stop all
+```
 
-# Start mc-router and all servers
-docker compose up -d
+### Start/Stop All Servers (not router)
 
-# Stop all
-docker compose down
-
-# View router logs
-docker logs -f mc-router
+```bash
+# Start/stop all MC servers (mc-router keeps running)
+mcctl start --all       # or mcctl start -a
+mcctl stop --all        # or mcctl stop -a
 ```
 
 ### Start/Stop Individual Server
 
 ```bash
+# Using mcctl (recommended)
+mcctl start myserver
+mcctl stop myserver
+
+# Using docker compose directly
 cd platform
-
-# Start specific server (replace <server-name> with your server name)
 docker compose up -d mc-<server-name>
-
-# Stop specific server
 docker compose stop mc-<server-name>
 
 # View server logs

--- a/README.md
+++ b/README.md
@@ -347,7 +347,25 @@ mcctl backup push -m "Before upgrade"
 mcctl backup restore abc1234
 ```
 
-### Docker Commands
+### Infrastructure Commands
+
+```bash
+# Start/stop all infrastructure (mc-router + all servers)
+mcctl up                   # Start everything
+mcctl down                 # Stop everything
+
+# Start/stop all MC servers (mc-router keeps running)
+mcctl start --all          # or mcctl start -a
+mcctl stop --all           # or mcctl stop -a
+
+# Individual server management
+mcctl start myserver
+mcctl stop myserver
+mcctl logs myserver
+mcctl console myserver
+```
+
+### Docker Commands (Alternative)
 
 ```bash
 cd platform

--- a/plan.md
+++ b/plan.md
@@ -21,7 +21,7 @@
 | Phase 4: Management CLI | [#8](https://github.com/smallmiro/minecraft-server-manager/issues/8), [#9](https://github.com/smallmiro/minecraft-server-manager/issues/9), [#12](https://github.com/smallmiro/minecraft-server-manager/issues/12) | 🔄 Open |
 | Phase 5: Documentation | [#10](https://github.com/smallmiro/minecraft-server-manager/issues/10), [#11](https://github.com/smallmiro/minecraft-server-manager/issues/11) | 🔄 Open |
 | Phase 6: npm Package | [#28](https://github.com/smallmiro/minecraft-server-manager/issues/28) | ✅ Closed |
-| Phase 7: CLI Interactive Mode | [#30](https://github.com/smallmiro/minecraft-server-manager/issues/30), [#31](https://github.com/smallmiro/minecraft-server-manager/issues/31), [#32](https://github.com/smallmiro/minecraft-server-manager/issues/32), [#33](https://github.com/smallmiro/minecraft-server-manager/issues/33), [#34](https://github.com/smallmiro/minecraft-server-manager/issues/34), [#35](https://github.com/smallmiro/minecraft-server-manager/issues/35), [#36](https://github.com/smallmiro/minecraft-server-manager/issues/36), [#37](https://github.com/smallmiro/minecraft-server-manager/issues/37), [#38](https://github.com/smallmiro/minecraft-server-manager/issues/38), [#39](https://github.com/smallmiro/minecraft-server-manager/issues/39), [#40](https://github.com/smallmiro/minecraft-server-manager/issues/40), [#54](https://github.com/smallmiro/minecraft-server-manager/issues/54) | 🔄 Open |
+| Phase 7: CLI Interactive Mode | [#30](https://github.com/smallmiro/minecraft-server-manager/issues/30), [#31](https://github.com/smallmiro/minecraft-server-manager/issues/31), [#32](https://github.com/smallmiro/minecraft-server-manager/issues/32), [#33](https://github.com/smallmiro/minecraft-server-manager/issues/33), [#34](https://github.com/smallmiro/minecraft-server-manager/issues/34), [#35](https://github.com/smallmiro/minecraft-server-manager/issues/35), [#36](https://github.com/smallmiro/minecraft-server-manager/issues/36), [#37](https://github.com/smallmiro/minecraft-server-manager/issues/37), [#38](https://github.com/smallmiro/minecraft-server-manager/issues/38), [#39](https://github.com/smallmiro/minecraft-server-manager/issues/39), [#40](https://github.com/smallmiro/minecraft-server-manager/issues/40), [#54](https://github.com/smallmiro/minecraft-server-manager/issues/54), [#56](https://github.com/smallmiro/minecraft-server-manager/issues/56) ✅ | 🔄 Open |
 
 ---
 
@@ -428,6 +428,12 @@ mcctl.sh console <server>         - RCON console
 mcctl.sh world list               - List worlds/locks
 mcctl.sh world assign <w> <s>     - Assign world to server config
 mcctl.sh world release <w>        - Force release world lock
+
+# Infrastructure management (added in #56)
+mcctl up                          - Start all infrastructure (router + servers)
+mcctl down                        - Stop all infrastructure
+mcctl start --all                 - Start all MC servers (not router)
+mcctl stop --all                  - Stop all MC servers (not router)
 
 # Manual override (bypasses mc-router auto-management)
 mcctl.sh start <server>           - Force start server

--- a/platform/services/cli/src/commands/exec.ts
+++ b/platform/services/cli/src/commands/exec.ts
@@ -1,0 +1,39 @@
+import { Paths, log } from '@minecraft-docker/shared';
+import { ShellExecutor } from '../lib/shell.js';
+
+export interface ExecCommandOptions {
+  root?: string;
+  serverName?: string;
+  command?: string[];
+}
+
+/**
+ * Execute RCON command on a server
+ */
+export async function execCommand(options: ExecCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  if (!options.serverName) {
+    log.error('Server name is required');
+    log.info('Usage: mcctl exec <server> <command...>');
+    return 1;
+  }
+
+  if (!options.command || options.command.length === 0) {
+    log.error('Command is required');
+    log.info('Usage: mcctl exec <server> <command...>');
+    log.info('Examples:');
+    log.info('  mcctl exec myserver say "Hello!"');
+    log.info('  mcctl exec myserver give Player diamond 64');
+    log.info('  mcctl exec myserver list');
+    return 1;
+  }
+
+  const shell = new ShellExecutor(paths);
+  return shell.execRcon(options.serverName, options.command);
+}

--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -4,3 +4,4 @@ export { createCommand, type CreateCommandOptions } from './create.js';
 export { deleteCommand, type DeleteCommandOptions } from './delete.js';
 export { worldCommand, type WorldCommandOptions } from './world.js';
 export { backupCommand, type BackupCommandOptions } from './backup.js';
+export { execCommand, type ExecCommandOptions } from './exec.js';

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -8,6 +8,7 @@ import {
   deleteCommand,
   worldCommand,
   backupCommand,
+  execCommand,
 } from './commands/index.js';
 import { ShellExecutor } from './lib/shell.js';
 
@@ -34,6 +35,7 @@ ${colors.cyan('Commands:')}
   ${colors.bold('stop')} <server> [--all]      Stop a server (--all for all servers)
   ${colors.bold('logs')} <server> [lines]      View server logs
   ${colors.bold('console')} <server>           Connect to RCON console
+  ${colors.bold('exec')} <server> <cmd...>     Execute RCON command
 
 ${colors.cyan('World Management:')}
   ${colors.bold('world list')} [--json]        List worlds and lock status
@@ -74,6 +76,8 @@ ${colors.cyan('Examples:')}
   mcctl create myserver -t FORGE -v 1.20.4
   mcctl status --json
   mcctl logs myserver -f
+  mcctl exec myserver say "Hello!"   # Execute RCON command
+  mcctl exec myserver list           # List online players
 `);
 }
 
@@ -297,6 +301,15 @@ async function main(): Promise<void> {
         if (flags['lines']) mcctlArgs.push('-n', flags['lines'] as string);
 
         exitCode = await shell.mcctl(mcctlArgs);
+        break;
+      }
+
+      case 'exec': {
+        exitCode = await execCommand({
+          root: rootDir,
+          serverName: positional[0],
+          command: positional.slice(1),
+        });
         break;
       }
 

--- a/platform/services/cli/src/lib/shell.ts
+++ b/platform/services/cli/src/lib/shell.ts
@@ -135,6 +135,30 @@ export class ShellExecutor {
   }
 
   /**
+   * Execute RCON command on a server
+   */
+  async execRcon(server: string, command: string[]): Promise<number> {
+    const containerName = server.startsWith('mc-') ? server : `mc-${server}`;
+
+    return new Promise((resolve) => {
+      const child = spawn('docker', ['exec', containerName, 'rcon-cli', ...command], {
+        cwd: this.paths.root,
+        stdio: 'inherit',
+        env: { ...process.env, ...this.env },
+      });
+
+      child.on('close', (code) => {
+        resolve(code ?? 0);
+      });
+
+      child.on('error', (err) => {
+        log.error(`Failed to execute RCON command: ${err.message}`);
+        resolve(1);
+      });
+    });
+  }
+
+  /**
    * Start all infrastructure (router + all servers)
    */
   async up(): Promise<number> {


### PR DESCRIPTION
## Summary

- Add `mcctl exec` command for executing RCON commands on servers
- Pass-through implementation using `docker exec mc-<server> rcon-cli`

## Changes

- Add `execRcon()` method to `ShellExecutor`
- Create `commands/exec.ts` with usage validation
- Add exec case to CLI routing in `index.ts`
- Update help text with examples

## Usage

```bash
mcctl exec <server> <command...>

# Examples
mcctl exec myserver say "Hello!"
mcctl exec myserver give Player diamond 64
mcctl exec myserver list
mcctl exec myserver time set day
```

## Test Plan

- [x] Build successful
- [x] Help text displays correctly
- [x] Error handling for missing server name
- [x] Error handling for missing command
- [x] Docker exec integration (container error when not running - expected)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)