### PR TITLE
feat: Add mcctl config command (#59)

### DIFF
--- a/platform/services/cli/src/commands/config.ts
+++ b/platform/services/cli/src/commands/config.ts
@@ -1,0 +1,125 @@
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { ShellExecutor } from '../lib/shell.js';
+
+export interface ConfigCommandOptions {
+  root?: string;
+  serverName?: string;
+  key?: string;
+  value?: string;
+  json?: boolean;
+  // Shortcut flags
+  cheats?: boolean;
+  noCheats?: boolean;
+  pvp?: boolean;
+  noPvp?: boolean;
+  commandBlock?: boolean;
+  noCommandBlock?: boolean;
+}
+
+// Shortcut flag mappings
+const SHORTCUTS: Record<string, { key: string; value: string }> = {
+  cheats: { key: 'ALLOW_CHEATS', value: 'true' },
+  noCheats: { key: 'ALLOW_CHEATS', value: 'false' },
+  pvp: { key: 'PVP', value: 'true' },
+  noPvp: { key: 'PVP', value: 'false' },
+  commandBlock: { key: 'ENABLE_COMMAND_BLOCK', value: 'true' },
+  noCommandBlock: { key: 'ENABLE_COMMAND_BLOCK', value: 'false' },
+};
+
+/**
+ * View or modify server configuration
+ */
+export async function configCommand(options: ConfigCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  if (!options.serverName) {
+    log.error('Server name is required');
+    log.info('Usage: mcctl config <server> [key] [value]');
+    log.info('       mcctl config <server> --cheats');
+    return 1;
+  }
+
+  const shell = new ShellExecutor(paths);
+
+  // Check if server exists
+  const config = shell.readConfig(options.serverName);
+  if (config === null) {
+    log.error(`Server '${options.serverName}' not found`);
+    return 1;
+  }
+
+  // Handle shortcut flags
+  for (const [flagName, mapping] of Object.entries(SHORTCUTS)) {
+    if (options[flagName as keyof ConfigCommandOptions]) {
+      const success = shell.writeConfigValue(options.serverName, mapping.key, mapping.value);
+      if (success) {
+        console.log(colors.green(`✓ ${mapping.key}=${mapping.value}`));
+        log.info('Restart server to apply changes: mcctl stop <server> && mcctl start <server>');
+        return 0;
+      } else {
+        log.error(`Failed to update ${mapping.key}`);
+        return 1;
+      }
+    }
+  }
+
+  // View all config
+  if (!options.key) {
+    if (options.json) {
+      console.log(JSON.stringify(config, null, 2));
+    } else {
+      console.log(colors.bold(`\nConfiguration for ${options.serverName}:\n`));
+      for (const [key, value] of Object.entries(config)) {
+        console.log(`  ${colors.cyan(key)}=${value}`);
+      }
+      console.log('');
+    }
+    return 0;
+  }
+
+  // View specific key
+  if (!options.value) {
+    const currentValue = config[options.key];
+    if (currentValue === undefined) {
+      log.error(`Key '${options.key}' not found in config`);
+      return 1;
+    }
+    if (options.json) {
+      console.log(JSON.stringify({ [options.key]: currentValue }));
+    } else {
+      console.log(`${options.key}=${currentValue}`);
+    }
+    return 0;
+  }
+
+  // Set config value
+  const oldValue = config[options.key];
+  const success = shell.writeConfigValue(options.serverName, options.key, options.value);
+
+  if (success) {
+    if (options.json) {
+      console.log(JSON.stringify({
+        server: options.serverName,
+        key: options.key,
+        oldValue: oldValue ?? null,
+        newValue: options.value,
+      }));
+    } else {
+      if (oldValue !== undefined) {
+        console.log(colors.green(`✓ ${options.key}: ${oldValue} → ${options.value}`));
+      } else {
+        console.log(colors.green(`✓ ${options.key}=${options.value} (added)`));
+      }
+      log.info('Restart server to apply changes: mcctl stop <server> && mcctl start <server>');
+    }
+    return 0;
+  } else {
+    log.error(`Failed to update ${options.key}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -5,3 +5,4 @@ export { deleteCommand, type DeleteCommandOptions } from './delete.js';
 export { worldCommand, type WorldCommandOptions } from './world.js';
 export { backupCommand, type BackupCommandOptions } from './backup.js';
 export { execCommand, type ExecCommandOptions } from './exec.js';
+export { configCommand, type ConfigCommandOptions } from './config.js';

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -9,6 +9,7 @@ import {
   worldCommand,
   backupCommand,
   execCommand,
+  configCommand,
 } from './commands/index.js';
 import { ShellExecutor } from './lib/shell.js';
 
@@ -36,6 +37,12 @@ ${colors.cyan('Commands:')}
   ${colors.bold('logs')} <server> [lines]      View server logs
   ${colors.bold('console')} <server>           Connect to RCON console
   ${colors.bold('exec')} <server> <cmd...>     Execute RCON command
+  ${colors.bold('config')} <server> [key] [val]  View/set server config
+
+${colors.cyan('Config Shortcuts:')}
+  --cheats, --no-cheats      Enable/disable cheats (ALLOW_CHEATS)
+  --pvp, --no-pvp            Enable/disable PvP
+  --command-block            Enable/disable command blocks
 
 ${colors.cyan('World Management:')}
   ${colors.bold('world list')} [--json]        List worlds and lock status
@@ -78,6 +85,9 @@ ${colors.cyan('Examples:')}
   mcctl logs myserver -f
   mcctl exec myserver say "Hello!"   # Execute RCON command
   mcctl exec myserver list           # List online players
+  mcctl config myserver              # View all config
+  mcctl config myserver --cheats     # Enable cheats
+  mcctl config myserver MOTD "Welcome!"  # Set MOTD
 `);
 }
 
@@ -309,6 +319,23 @@ async function main(): Promise<void> {
           root: rootDir,
           serverName: positional[0],
           command: positional.slice(1),
+        });
+        break;
+      }
+
+      case 'config': {
+        exitCode = await configCommand({
+          root: rootDir,
+          serverName: positional[0],
+          key: positional[1],
+          value: positional[2],
+          json: flags['json'] === true,
+          cheats: flags['cheats'] === true,
+          noCheats: flags['no-cheats'] === true,
+          pvp: flags['pvp'] === true,
+          noPvp: flags['no-pvp'] === true,
+          commandBlock: flags['command-block'] === true,
+          noCommandBlock: flags['no-command-block'] === true,
         });
         break;
       }


### PR DESCRIPTION
## Summary
- Add `mcctl config` command to view and modify server `config.env` files
- Support direct key-value modification: `mcctl config <server> <key> <value>`
- Implement shortcut flags for common settings: `--cheats`, `--no-cheats`, `--pvp`, `--no-pvp`, `--command-block`, `--no-command-block`
- Add JSON output support with `--json` flag

## Changes
- **commands/config.ts**: New config command implementation with shortcut flag mappings
- **lib/shell.ts**: Add `readConfig()`, `writeConfigValue()`, `getConfigPath()` methods for config.env manipulation
- **commands/index.ts**: Export configCommand
- **index.ts**: Add routing, help text, Config Shortcuts section, and examples

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] `mcctl config` shows usage without server name
- [x] `mcctl config nonexistent` shows "Server not found"
- [x] `mcctl config <server>` displays all config
- [x] `mcctl config <server> <key>` displays specific value
- [x] `mcctl config <server> --cheats` enables ALLOW_CHEATS
- [x] `mcctl config <server> --no-pvp` disables PVP
- [x] `mcctl config <server> KEY VALUE` sets custom value
- [x] `mcctl config <server> --json` outputs JSON format

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)