### PR TITLE
feat(cli): add player management commands (#67)

### DIFF
--- a/platform/services/cli/src/commands/ban.ts
+++ b/platform/services/cli/src/commands/ban.ts
@@ -1,0 +1,528 @@
+import { join } from 'node:path';
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { ShellExecutor } from '../lib/shell.js';
+import { isContainerRunning, execRconWithOutput, getContainerName } from '../lib/rcon.js';
+import {
+  readBannedPlayersJson,
+  writeBannedPlayersJson,
+  readBannedIpsJson,
+  writeBannedIpsJson,
+  findBannedPlayerByName,
+  findBannedIp,
+  createTimestamp,
+  type BannedPlayerEntry,
+  type BannedIpEntry,
+} from '../lib/player-json.js';
+
+export interface BanCommandOptions {
+  root?: string;
+  serverName?: string;
+  subCommand?: 'list' | 'add' | 'remove' | 'ip';
+  target?: string; // player name or IP
+  reason?: string;
+  ipAction?: 'list' | 'add' | 'remove';
+  json?: boolean;
+}
+
+/**
+ * Manage server bans
+ */
+export async function banCommand(options: BanCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  if (!options.serverName) {
+    log.error('Server name is required');
+    log.info('Usage: mcctl ban <server> <list|add|remove|ip> [player/ip] [reason]');
+    return 1;
+  }
+
+  if (!options.subCommand) {
+    log.error('Action is required: list, add, remove, ip');
+    log.info('Usage: mcctl ban <server> <list|add|remove|ip> [player/ip] [reason]');
+    return 1;
+  }
+
+  const shell = new ShellExecutor(paths);
+  const config = shell.readConfig(options.serverName);
+
+  if (config === null) {
+    log.error(`Server '${options.serverName}' not found`);
+    return 1;
+  }
+
+  const containerName = getContainerName(options.serverName);
+  const isRunning = await isContainerRunning(containerName);
+  const bannedPlayersPath = join(paths.servers, options.serverName, 'data', 'banned-players.json');
+  const bannedIpsPath = join(paths.servers, options.serverName, 'data', 'banned-ips.json');
+
+  switch (options.subCommand) {
+    case 'list':
+      return await listBannedPlayers(options, bannedPlayersPath, containerName, isRunning);
+
+    case 'add':
+      if (!options.target) {
+        log.error('Player name is required for ban');
+        log.info('Usage: mcctl ban <server> add <player> [reason]');
+        return 1;
+      }
+      return await banPlayer(options, bannedPlayersPath, containerName, isRunning);
+
+    case 'remove':
+      if (!options.target) {
+        log.error('Player name is required for unban');
+        log.info('Usage: mcctl ban <server> remove <player>');
+        return 1;
+      }
+      return await unbanPlayer(options, bannedPlayersPath, containerName, isRunning);
+
+    case 'ip':
+      return await handleIpBan(options, bannedIpsPath, containerName, isRunning);
+
+    default:
+      log.error(`Unknown action: ${options.subCommand}`);
+      log.info('Valid actions: list, add, remove, ip');
+      return 1;
+  }
+}
+
+/**
+ * List banned players
+ */
+async function listBannedPlayers(
+  options: BanCommandOptions,
+  bannedPlayersPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  let players: BannedPlayerEntry[] = [];
+  let source = 'json';
+
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['banlist', 'players']);
+    if (result.code === 0) {
+      // Parse output - format varies by MC version
+      const match = result.output.match(/:\s*(.+)$/);
+      if (match && match[1] && !match[1].includes('There are no')) {
+        const names = match[1]
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        players = names.map((name) => ({
+          uuid: '',
+          name,
+          created: '',
+          source: 'rcon',
+          expires: 'forever',
+          reason: '',
+        }));
+        source = 'rcon';
+      }
+    }
+  }
+
+  // Fallback to JSON
+  if (players.length === 0 || source !== 'rcon') {
+    players = await readBannedPlayersJson(bannedPlayersPath);
+    source = 'json';
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        server: options.serverName,
+        running: isRunning,
+        players: players.map((p) => ({
+          name: p.name,
+          reason: p.reason,
+          created: p.created,
+        })),
+        source,
+      })
+    );
+  } else {
+    console.log(colors.bold(`\nBanned Players for ${options.serverName}:\n`));
+    if (players.length === 0) {
+      console.log('  (none)');
+    } else {
+      for (const player of players) {
+        const reason = player.reason ? ` - ${player.reason}` : '';
+        console.log(`  ${colors.red(player.name)}${colors.dim(reason)}`);
+      }
+    }
+    console.log('');
+    if (!isRunning) {
+      log.warn('Server is not running. Showing bans from JSON file');
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Ban a player
+ */
+async function banPlayer(
+  options: BanCommandOptions,
+  bannedPlayersPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const playerName = options.target!;
+  const reason = options.reason || 'Banned by operator';
+
+  // Check if already banned
+  const bannedPlayers = await readBannedPlayersJson(bannedPlayersPath);
+  if (findBannedPlayerByName(bannedPlayers, playerName)) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          success: false,
+          error: 'already_banned',
+          player: playerName,
+          server: options.serverName,
+        })
+      );
+    } else {
+      log.warn(`${playerName} is already banned`);
+    }
+    return 0;
+  }
+
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  if (isRunning) {
+    const rconCmd = reason ? ['ban', playerName, reason] : ['ban', playerName];
+    const result = await execRconWithOutput(containerName, rconCmd);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  // Update JSON file for non-running server
+  if (!isRunning) {
+    const newEntry: BannedPlayerEntry = {
+      uuid: '', // Will be populated by server on start
+      name: playerName,
+      created: createTimestamp(),
+      source: 'mcctl',
+      expires: 'forever',
+      reason,
+    };
+    bannedPlayers.push(newEntry);
+    await writeBannedPlayersJson(bannedPlayersPath, bannedPlayers);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        player: playerName,
+        reason,
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`${playerName} has been banned (applied immediately)`));
+    } else if (isRunning && !rconSuccess) {
+      console.log(colors.yellow(`RCON: ${rconMessage}`));
+    } else {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`Ban saved. Will apply on next start.`));
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Unban a player
+ */
+async function unbanPlayer(
+  options: BanCommandOptions,
+  bannedPlayersPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const playerName = options.target!;
+
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['pardon', playerName]);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  // Update JSON file
+  const bannedPlayers = await readBannedPlayersJson(bannedPlayersPath);
+  const filteredPlayers = bannedPlayers.filter(
+    (p) => p.name.toLowerCase() !== playerName.toLowerCase()
+  );
+  if (filteredPlayers.length !== bannedPlayers.length) {
+    await writeBannedPlayersJson(bannedPlayersPath, filteredPlayers);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        player: playerName,
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`${playerName} has been unbanned (applied immediately)`));
+    } else if (isRunning && !rconSuccess) {
+      console.log(colors.yellow(`RCON: ${rconMessage}`));
+    } else {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`Unban saved. Will apply on next start.`));
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Handle IP ban commands
+ */
+async function handleIpBan(
+  options: BanCommandOptions,
+  bannedIpsPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const ipAction = options.ipAction;
+
+  if (!ipAction) {
+    log.error('IP action is required: list, add, remove');
+    log.info('Usage: mcctl ban <server> ip <list|add|remove> [ip] [reason]');
+    return 1;
+  }
+
+  switch (ipAction) {
+    case 'list':
+      return await listBannedIps(options, bannedIpsPath, containerName, isRunning);
+
+    case 'add':
+      if (!options.target) {
+        log.error('IP address is required');
+        log.info('Usage: mcctl ban <server> ip add <ip> [reason]');
+        return 1;
+      }
+      return await banIp(options, bannedIpsPath, containerName, isRunning);
+
+    case 'remove':
+      if (!options.target) {
+        log.error('IP address is required');
+        log.info('Usage: mcctl ban <server> ip remove <ip>');
+        return 1;
+      }
+      return await unbanIp(options, bannedIpsPath, containerName, isRunning);
+
+    default:
+      log.error(`Unknown IP action: ${ipAction}`);
+      return 1;
+  }
+}
+
+/**
+ * List banned IPs
+ */
+async function listBannedIps(
+  options: BanCommandOptions,
+  bannedIpsPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  let ips: BannedIpEntry[] = [];
+  let source = 'json';
+
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['banlist', 'ips']);
+    if (result.code === 0) {
+      const match = result.output.match(/:\s*(.+)$/);
+      if (match && match[1] && !match[1].includes('There are no')) {
+        const ipList = match[1]
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        ips = ipList.map((ip) => ({
+          ip,
+          created: '',
+          source: 'rcon',
+          expires: 'forever',
+          reason: '',
+        }));
+        source = 'rcon';
+      }
+    }
+  }
+
+  if (ips.length === 0 || source !== 'rcon') {
+    ips = await readBannedIpsJson(bannedIpsPath);
+    source = 'json';
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        server: options.serverName,
+        running: isRunning,
+        ips: ips.map((entry) => ({
+          ip: entry.ip,
+          reason: entry.reason,
+          created: entry.created,
+        })),
+        source,
+      })
+    );
+  } else {
+    console.log(colors.bold(`\nBanned IPs for ${options.serverName}:\n`));
+    if (ips.length === 0) {
+      console.log('  (none)');
+    } else {
+      for (const entry of ips) {
+        const reason = entry.reason ? ` - ${entry.reason}` : '';
+        console.log(`  ${colors.red(entry.ip)}${colors.dim(reason)}`);
+      }
+    }
+    console.log('');
+  }
+
+  return 0;
+}
+
+/**
+ * Ban an IP
+ */
+async function banIp(
+  options: BanCommandOptions,
+  bannedIpsPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const ip = options.target!;
+  const reason = options.reason || 'Banned by operator';
+
+  const bannedIps = await readBannedIpsJson(bannedIpsPath);
+  if (findBannedIp(bannedIps, ip)) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          success: false,
+          error: 'already_banned',
+          ip,
+          server: options.serverName,
+        })
+      );
+    } else {
+      log.warn(`${ip} is already banned`);
+    }
+    return 0;
+  }
+
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  if (isRunning) {
+    const rconCmd = reason ? ['ban-ip', ip, reason] : ['ban-ip', ip];
+    const result = await execRconWithOutput(containerName, rconCmd);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  if (!isRunning) {
+    const newEntry: BannedIpEntry = {
+      ip,
+      created: createTimestamp(),
+      source: 'mcctl',
+      expires: 'forever',
+      reason,
+    };
+    bannedIps.push(newEntry);
+    await writeBannedIpsJson(bannedIpsPath, bannedIps);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        ip,
+        reason,
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`${ip} has been banned (applied immediately)`));
+    } else if (!isRunning) {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`IP ban saved. Will apply on next start.`));
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Unban an IP
+ */
+async function unbanIp(
+  options: BanCommandOptions,
+  bannedIpsPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const ip = options.target!;
+
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['pardon-ip', ip]);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  const bannedIps = await readBannedIpsJson(bannedIpsPath);
+  const filteredIps = bannedIps.filter((entry) => entry.ip !== ip);
+  if (filteredIps.length !== bannedIps.length) {
+    await writeBannedIpsJson(bannedIpsPath, filteredIps);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        ip,
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`${ip} has been unbanned (applied immediately)`));
+    } else if (!isRunning) {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`IP unban saved. Will apply on next start.`));
+    }
+  }
+
+  return 0;
+}

--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -9,3 +9,7 @@ export { configCommand, type ConfigCommandOptions } from './config.js';
 export { opCommand, type OpCommandOptions } from './op.js';
 export { serverBackupCommand, type ServerBackupOptions } from './server-backup.js';
 export { serverRestoreCommand, type ServerRestoreOptions } from './server-restore.js';
+export { whitelistCommand, type WhitelistCommandOptions } from './whitelist.js';
+export { banCommand, type BanCommandOptions } from './ban.js';
+export { kickCommand, type KickCommandOptions } from './kick.js';
+export { playerOnlineCommand, type PlayerOnlineCommandOptions } from './player-online.js';

--- a/platform/services/cli/src/commands/kick.ts
+++ b/platform/services/cli/src/commands/kick.ts
@@ -1,0 +1,91 @@
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { ShellExecutor } from '../lib/shell.js';
+import { isContainerRunning, execRconWithOutput, getContainerName } from '../lib/rcon.js';
+
+export interface KickCommandOptions {
+  root?: string;
+  serverName?: string;
+  playerName?: string;
+  reason?: string;
+  json?: boolean;
+}
+
+/**
+ * Kick a player from the server
+ */
+export async function kickCommand(options: KickCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  if (!options.serverName) {
+    log.error('Server name is required');
+    log.info('Usage: mcctl kick <server> <player> [reason]');
+    return 1;
+  }
+
+  if (!options.playerName) {
+    log.error('Player name is required');
+    log.info('Usage: mcctl kick <server> <player> [reason]');
+    return 1;
+  }
+
+  const shell = new ShellExecutor(paths);
+  const config = shell.readConfig(options.serverName);
+
+  if (config === null) {
+    log.error(`Server '${options.serverName}' not found`);
+    return 1;
+  }
+
+  const containerName = getContainerName(options.serverName);
+  const isRunning = await isContainerRunning(containerName);
+
+  if (!isRunning) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          success: false,
+          error: 'server_not_running',
+          server: options.serverName,
+        })
+      );
+    } else {
+      log.error('Server is not running. Cannot kick players from a stopped server.');
+    }
+    return 1;
+  }
+
+  const playerName = options.playerName;
+  const reason = options.reason || 'Kicked by operator';
+
+  // Execute kick via RCON
+  const rconCmd = reason ? ['kick', playerName, reason] : ['kick', playerName];
+  const result = await execRconWithOutput(containerName, rconCmd);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: result.code === 0,
+        player: playerName,
+        reason,
+        server: options.serverName,
+        message: result.output.trim(),
+      })
+    );
+  } else {
+    if (result.code === 0) {
+      console.log(colors.green(`${playerName} has been kicked from the server`));
+      if (reason !== 'Kicked by operator') {
+        console.log(colors.dim(`Reason: ${reason}`));
+      }
+    } else {
+      log.error(`Failed to kick player: ${result.output.trim()}`);
+    }
+  }
+
+  return result.code === 0 ? 0 : 1;
+}

--- a/platform/services/cli/src/commands/op.ts
+++ b/platform/services/cli/src/commands/op.ts
@@ -1,6 +1,6 @@
 import { Paths, log, colors } from '@minecraft-docker/shared';
 import { ShellExecutor } from '../lib/shell.js';
-import { spawn } from 'node:child_process';
+import { isContainerRunning, execRconWithOutput, getContainerName } from '../lib/rcon.js';
 
 export interface OpCommandOptions {
   root?: string;
@@ -8,63 +8,6 @@ export interface OpCommandOptions {
   subCommand?: 'add' | 'remove' | 'list';
   playerName?: string;
   json?: boolean;
-}
-
-/**
- * Check if a Docker container is running
- */
-async function isContainerRunning(containerName: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const child = spawn('docker', ['inspect', '-f', '{{.State.Running}}', containerName], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    let output = '';
-    child.stdout.on('data', (data) => {
-      output += data.toString();
-    });
-
-    child.on('close', (code) => {
-      resolve(code === 0 && output.trim() === 'true');
-    });
-
-    child.on('error', () => {
-      resolve(false);
-    });
-  });
-}
-
-/**
- * Execute RCON command and capture output
- */
-async function execRconWithOutput(
-  containerName: string,
-  command: string[]
-): Promise<{ code: number; output: string }> {
-  return new Promise((resolve) => {
-    const child = spawn('docker', ['exec', containerName, 'rcon-cli', ...command], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    let output = '';
-    let errorOutput = '';
-
-    child.stdout.on('data', (data) => {
-      output += data.toString();
-    });
-
-    child.stderr.on('data', (data) => {
-      errorOutput += data.toString();
-    });
-
-    child.on('close', (code) => {
-      resolve({ code: code ?? 1, output: output || errorOutput });
-    });
-
-    child.on('error', (err) => {
-      resolve({ code: 1, output: err.message });
-    });
-  });
 }
 
 /**
@@ -98,9 +41,7 @@ export async function opCommand(options: OpCommandOptions): Promise<number> {
     return 1;
   }
 
-  const containerName = options.serverName.startsWith('mc-')
-    ? options.serverName
-    : `mc-${options.serverName}`;
+  const containerName = getContainerName(options.serverName);
 
   const isRunning = await isContainerRunning(containerName);
 

--- a/platform/services/cli/src/commands/player-online.ts
+++ b/platform/services/cli/src/commands/player-online.ts
@@ -1,0 +1,207 @@
+import { Paths, log, colors, getRunningMcContainers } from '@minecraft-docker/shared';
+import { ShellExecutor } from '../lib/shell.js';
+import { isContainerRunning, execRconWithOutput, getContainerName } from '../lib/rcon.js';
+
+export interface PlayerOnlineCommandOptions {
+  root?: string;
+  serverName?: string;
+  all?: boolean;
+  json?: boolean;
+}
+
+interface OnlinePlayer {
+  name: string;
+  server: string;
+}
+
+interface ServerOnlineInfo {
+  server: string;
+  running: boolean;
+  players: string[];
+  playerCount: number;
+  maxPlayers: number;
+}
+
+/**
+ * Show online players
+ */
+export async function playerOnlineCommand(options: PlayerOnlineCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  if (options.all) {
+    return await listAllOnlinePlayers(paths, options);
+  }
+
+  if (!options.serverName) {
+    log.error('Server name is required (or use --all for all servers)');
+    log.info('Usage: mcctl player online <server>');
+    log.info('       mcctl player online --all');
+    return 1;
+  }
+
+  const shell = new ShellExecutor(paths);
+  const config = shell.readConfig(options.serverName);
+
+  if (config === null) {
+    log.error(`Server '${options.serverName}' not found`);
+    return 1;
+  }
+
+  const containerName = getContainerName(options.serverName);
+  const isRunning = await isContainerRunning(containerName);
+
+  if (!isRunning) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          server: options.serverName,
+          running: false,
+          players: [],
+          playerCount: 0,
+        })
+      );
+    } else {
+      log.warn(`Server '${options.serverName}' is not running`);
+    }
+    return 0;
+  }
+
+  const serverInfo = await getServerOnlineInfo(containerName, options.serverName);
+
+  if (options.json) {
+    console.log(JSON.stringify(serverInfo));
+  } else {
+    console.log(colors.bold(`\nOnline Players for ${options.serverName}:\n`));
+    console.log(
+      `  Status: ${colors.green('Running')} (${serverInfo.playerCount}/${serverInfo.maxPlayers})`
+    );
+    console.log('');
+    if (serverInfo.players.length === 0) {
+      console.log('  No players online');
+    } else {
+      for (const player of serverInfo.players) {
+        console.log(`  ${colors.cyan(player)}`);
+      }
+    }
+    console.log('');
+  }
+
+  return 0;
+}
+
+/**
+ * List online players from all running servers
+ */
+async function listAllOnlinePlayers(
+  paths: Paths,
+  options: PlayerOnlineCommandOptions
+): Promise<number> {
+  const containers = getRunningMcContainers();
+
+  if (containers.length === 0) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          servers: [],
+          totalPlayers: 0,
+        })
+      );
+    } else {
+      log.warn('No running servers found');
+    }
+    return 0;
+  }
+
+  const serverInfos: ServerOnlineInfo[] = [];
+  const allPlayers: OnlinePlayer[] = [];
+
+  for (const container of containers) {
+    const serverName = container.replace(/^mc-/, '');
+    const info = await getServerOnlineInfo(container, serverName);
+    serverInfos.push(info);
+
+    for (const player of info.players) {
+      allPlayers.push({ name: player, server: serverName });
+    }
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        servers: serverInfos,
+        totalPlayers: allPlayers.length,
+        players: allPlayers,
+      })
+    );
+  } else {
+    console.log(colors.bold('\nOnline Players (All Servers):\n'));
+
+    if (allPlayers.length === 0) {
+      console.log('  No players online on any server');
+    } else {
+      console.log(`  Total: ${colors.cyan(String(allPlayers.length))} players\n`);
+
+      for (const info of serverInfos) {
+        if (info.players.length > 0) {
+          console.log(
+            `  ${colors.bold(info.server)} (${info.playerCount}/${info.maxPlayers}):`
+          );
+          for (const player of info.players) {
+            console.log(`    ${colors.cyan(player)}`);
+          }
+          console.log('');
+        }
+      }
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Get online player information for a server
+ */
+async function getServerOnlineInfo(
+  containerName: string,
+  serverName: string
+): Promise<ServerOnlineInfo> {
+  const result = await execRconWithOutput(containerName, ['list']);
+
+  let players: string[] = [];
+  let playerCount = 0;
+  let maxPlayers = 20;
+
+  if (result.code === 0) {
+    // Parse "There are X of a max of Y players online: player1, player2"
+    // or "There are X/Y players online: player1, player2"
+    const countMatch = result.output.match(
+      /There are (\d+)(?:\s+of a max of\s+|\/)(\d+) players? online/i
+    );
+    if (countMatch && countMatch[1] && countMatch[2]) {
+      playerCount = parseInt(countMatch[1], 10);
+      maxPlayers = parseInt(countMatch[2], 10);
+    }
+
+    // Extract player names after the colon
+    const playersMatch = result.output.match(/:\s*(.+)$/);
+    if (playersMatch && playersMatch[1]) {
+      players = playersMatch[1]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+  }
+
+  return {
+    server: serverName,
+    running: true,
+    players,
+    playerCount,
+    maxPlayers,
+  };
+}

--- a/platform/services/cli/src/commands/whitelist.ts
+++ b/platform/services/cli/src/commands/whitelist.ts
@@ -1,0 +1,426 @@
+import { join } from 'node:path';
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import { ShellExecutor } from '../lib/shell.js';
+import { isContainerRunning, execRconWithOutput, getContainerName } from '../lib/rcon.js';
+import {
+  readPlayerJson,
+  writePlayerJson,
+  findPlayerByName,
+  type PlayerEntry,
+} from '../lib/player-json.js';
+
+export interface WhitelistCommandOptions {
+  root?: string;
+  serverName?: string;
+  subCommand?: 'list' | 'add' | 'remove' | 'on' | 'off' | 'status';
+  playerName?: string;
+  json?: boolean;
+}
+
+/**
+ * Manage server whitelist
+ */
+export async function whitelistCommand(options: WhitelistCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  if (!options.serverName) {
+    log.error('Server name is required');
+    log.info('Usage: mcctl whitelist <server> <list|add|remove|on|off|status> [player]');
+    return 1;
+  }
+
+  if (!options.subCommand) {
+    log.error('Action is required: list, add, remove, on, off, status');
+    log.info('Usage: mcctl whitelist <server> <list|add|remove|on|off|status> [player]');
+    return 1;
+  }
+
+  const shell = new ShellExecutor(paths);
+  const config = shell.readConfig(options.serverName);
+
+  if (config === null) {
+    log.error(`Server '${options.serverName}' not found`);
+    return 1;
+  }
+
+  const containerName = getContainerName(options.serverName);
+  const isRunning = await isContainerRunning(containerName);
+  const whitelistJsonPath = join(paths.servers, options.serverName, 'data', 'whitelist.json');
+
+  switch (options.subCommand) {
+    case 'list':
+      return await listWhitelist(options, config, whitelistJsonPath, containerName, isRunning);
+
+    case 'add':
+      if (!options.playerName) {
+        log.error('Player name is required for add');
+        log.info('Usage: mcctl whitelist <server> add <player>');
+        return 1;
+      }
+      return await addToWhitelist(
+        shell,
+        options,
+        config,
+        whitelistJsonPath,
+        containerName,
+        isRunning
+      );
+
+    case 'remove':
+      if (!options.playerName) {
+        log.error('Player name is required for remove');
+        log.info('Usage: mcctl whitelist <server> remove <player>');
+        return 1;
+      }
+      return await removeFromWhitelist(
+        shell,
+        options,
+        config,
+        whitelistJsonPath,
+        containerName,
+        isRunning
+      );
+
+    case 'on':
+      return await enableWhitelist(shell, options, containerName, isRunning);
+
+    case 'off':
+      return await disableWhitelist(shell, options, containerName, isRunning);
+
+    case 'status':
+      return await whitelistStatus(options, config, containerName, isRunning);
+
+    default:
+      log.error(`Unknown action: ${options.subCommand}`);
+      log.info('Valid actions: list, add, remove, on, off, status');
+      return 1;
+  }
+}
+
+/**
+ * List whitelisted players
+ */
+async function listWhitelist(
+  options: WhitelistCommandOptions,
+  config: Record<string, string>,
+  whitelistJsonPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  let players: PlayerEntry[] = [];
+  let source = 'json';
+
+  if (isRunning) {
+    // Try RCON first for accurate data
+    const result = await execRconWithOutput(containerName, ['whitelist', 'list']);
+    if (result.code === 0) {
+      // Parse RCON output: "There are X whitelisted players: player1, player2"
+      const match = result.output.match(/:\s*(.+)$/);
+      if (match && match[1]) {
+        const names = match[1]
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        players = names.map((name) => ({ uuid: '', name }));
+        source = 'rcon';
+      }
+    }
+  }
+
+  // Fallback to JSON file
+  if (players.length === 0 || source !== 'rcon') {
+    players = await readPlayerJson(whitelistJsonPath);
+    source = 'json';
+  }
+
+  // Also check config.env WHITELIST
+  const configWhitelist = config['WHITELIST']
+    ? config['WHITELIST'].split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        server: options.serverName,
+        running: isRunning,
+        players: players.map((p) => p.name),
+        configWhitelist,
+        source,
+      })
+    );
+  } else {
+    console.log(colors.bold(`\nWhitelist for ${options.serverName}:\n`));
+    if (players.length === 0) {
+      console.log('  (none)');
+    } else {
+      for (const player of players) {
+        console.log(`  ${colors.cyan(player.name)}`);
+      }
+    }
+    console.log('');
+    if (!isRunning) {
+      log.warn('Server is not running. Showing whitelist from JSON file');
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Add player to whitelist
+ */
+async function addToWhitelist(
+  shell: ShellExecutor,
+  options: WhitelistCommandOptions,
+  config: Record<string, string>,
+  whitelistJsonPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const playerName = options.playerName!;
+
+  // Read current whitelist
+  const players = await readPlayerJson(whitelistJsonPath);
+
+  // Check if already whitelisted
+  if (findPlayerByName(players, playerName)) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          success: false,
+          error: 'already_whitelisted',
+          player: playerName,
+          server: options.serverName,
+        })
+      );
+    } else {
+      log.warn(`${playerName} is already whitelisted`);
+    }
+    return 0;
+  }
+
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  // Execute RCON if server is running
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['whitelist', 'add', playerName]);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  // Update config.env WHITELIST
+  const currentConfigList = config['WHITELIST']
+    ? config['WHITELIST'].split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+  if (!currentConfigList.some((n) => n.toLowerCase() === playerName.toLowerCase())) {
+    const newList = [...currentConfigList, playerName].join(',');
+    shell.writeConfigValue(options.serverName!, 'WHITELIST', newList);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        player: playerName,
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`${playerName} added to whitelist (applied immediately)`));
+    } else if (isRunning && !rconSuccess) {
+      console.log(colors.yellow(`RCON: ${rconMessage}`));
+      console.log(colors.green(`Config updated. Will apply on server restart.`));
+    } else {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`Config updated. Changes will apply on next start.`));
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Remove player from whitelist
+ */
+async function removeFromWhitelist(
+  shell: ShellExecutor,
+  options: WhitelistCommandOptions,
+  config: Record<string, string>,
+  whitelistJsonPath: string,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const playerName = options.playerName!;
+
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  // Execute RCON if server is running
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['whitelist', 'remove', playerName]);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  // Update config.env WHITELIST
+  const currentConfigList = config['WHITELIST']
+    ? config['WHITELIST'].split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+  const newConfigList = currentConfigList.filter(
+    (n) => n.toLowerCase() !== playerName.toLowerCase()
+  );
+  shell.writeConfigValue(options.serverName!, 'WHITELIST', newConfigList.join(','));
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        player: playerName,
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`${playerName} removed from whitelist (applied immediately)`));
+    } else if (isRunning && !rconSuccess) {
+      console.log(colors.yellow(`RCON: ${rconMessage}`));
+      console.log(colors.green(`Config updated. Will apply on server restart.`));
+    } else {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`Config updated. Changes will apply on next start.`));
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Enable whitelist
+ */
+async function enableWhitelist(
+  shell: ShellExecutor,
+  options: WhitelistCommandOptions,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['whitelist', 'on']);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  // Update config.env
+  shell.writeConfigValue(options.serverName!, 'ENABLE_WHITELIST', 'true');
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        action: 'enable',
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`Whitelist enabled (applied immediately)`));
+    } else if (!isRunning) {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`Config updated. Whitelist will be enabled on next start.`));
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Disable whitelist
+ */
+async function disableWhitelist(
+  shell: ShellExecutor,
+  options: WhitelistCommandOptions,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  let rconSuccess = false;
+  let rconMessage = '';
+
+  if (isRunning) {
+    const result = await execRconWithOutput(containerName, ['whitelist', 'off']);
+    rconSuccess = result.code === 0;
+    rconMessage = result.output.trim();
+  }
+
+  // Update config.env
+  shell.writeConfigValue(options.serverName!, 'ENABLE_WHITELIST', 'false');
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        action: 'disable',
+        server: options.serverName,
+        rcon: isRunning ? { success: rconSuccess, message: rconMessage } : null,
+        running: isRunning,
+      })
+    );
+  } else {
+    if (isRunning && rconSuccess) {
+      console.log(colors.green(`Whitelist disabled (applied immediately)`));
+    } else if (!isRunning) {
+      console.log(colors.yellow(`Server is not running.`));
+      console.log(colors.green(`Config updated. Whitelist will be disabled on next start.`));
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Show whitelist status
+ */
+async function whitelistStatus(
+  options: WhitelistCommandOptions,
+  config: Record<string, string>,
+  containerName: string,
+  isRunning: boolean
+): Promise<number> {
+  const enabled = config['ENABLE_WHITELIST']?.toLowerCase() === 'true';
+  const whitelistPlayers = config['WHITELIST']
+    ? config['WHITELIST'].split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        server: options.serverName,
+        enabled,
+        playerCount: whitelistPlayers.length,
+        running: isRunning,
+      })
+    );
+  } else {
+    console.log(colors.bold(`\nWhitelist Status for ${options.serverName}:\n`));
+    console.log(`  Enabled: ${enabled ? colors.green('Yes') : colors.red('No')}`);
+    console.log(`  Players: ${colors.cyan(String(whitelistPlayers.length))}`);
+    console.log(`  Running: ${isRunning ? colors.green('Yes') : colors.yellow('No')}`);
+    console.log('');
+  }
+
+  return 0;
+}

--- a/platform/services/cli/src/lib/player-json.ts
+++ b/platform/services/cli/src/lib/player-json.ts
@@ -1,0 +1,142 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+/**
+ * Player entry in Minecraft JSON files (whitelist.json, ops.json, etc.)
+ */
+export interface PlayerEntry {
+  uuid: string;
+  name: string;
+}
+
+/**
+ * Banned player entry
+ */
+export interface BannedPlayerEntry {
+  uuid: string;
+  name: string;
+  created: string;
+  source: string;
+  expires: string;
+  reason: string;
+}
+
+/**
+ * Banned IP entry
+ */
+export interface BannedIpEntry {
+  ip: string;
+  created: string;
+  source: string;
+  expires: string;
+  reason: string;
+}
+
+/**
+ * Read player JSON file (whitelist.json, ops.json)
+ */
+export async function readPlayerJson(path: string): Promise<PlayerEntry[]> {
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  try {
+    const content = await readFile(path, 'utf-8');
+    const data = JSON.parse(content);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write player JSON file
+ */
+export async function writePlayerJson(path: string, entries: PlayerEntry[]): Promise<void> {
+  const content = JSON.stringify(entries, null, 2);
+  await writeFile(path, content, 'utf-8');
+}
+
+/**
+ * Read banned players JSON file
+ */
+export async function readBannedPlayersJson(path: string): Promise<BannedPlayerEntry[]> {
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  try {
+    const content = await readFile(path, 'utf-8');
+    const data = JSON.parse(content);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write banned players JSON file
+ */
+export async function writeBannedPlayersJson(
+  path: string,
+  entries: BannedPlayerEntry[]
+): Promise<void> {
+  const content = JSON.stringify(entries, null, 2);
+  await writeFile(path, content, 'utf-8');
+}
+
+/**
+ * Read banned IPs JSON file
+ */
+export async function readBannedIpsJson(path: string): Promise<BannedIpEntry[]> {
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  try {
+    const content = await readFile(path, 'utf-8');
+    const data = JSON.parse(content);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write banned IPs JSON file
+ */
+export async function writeBannedIpsJson(path: string, entries: BannedIpEntry[]): Promise<void> {
+  const content = JSON.stringify(entries, null, 2);
+  await writeFile(path, content, 'utf-8');
+}
+
+/**
+ * Find player by name in entries (case-insensitive)
+ */
+export function findPlayerByName(entries: PlayerEntry[], name: string): PlayerEntry | undefined {
+  return entries.find((entry) => entry.name.toLowerCase() === name.toLowerCase());
+}
+
+/**
+ * Find banned player by name (case-insensitive)
+ */
+export function findBannedPlayerByName(
+  entries: BannedPlayerEntry[],
+  name: string
+): BannedPlayerEntry | undefined {
+  return entries.find((entry) => entry.name.toLowerCase() === name.toLowerCase());
+}
+
+/**
+ * Find banned IP
+ */
+export function findBannedIp(entries: BannedIpEntry[], ip: string): BannedIpEntry | undefined {
+  return entries.find((entry) => entry.ip === ip);
+}
+
+/**
+ * Create ISO timestamp string
+ */
+export function createTimestamp(): string {
+  return new Date().toISOString().replace('T', ' ').replace('Z', ' +0000');
+}

--- a/platform/services/cli/src/lib/rcon.ts
+++ b/platform/services/cli/src/lib/rcon.ts
@@ -1,0 +1,74 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Result of an RCON command execution
+ */
+export interface RconResult {
+  code: number;
+  output: string;
+}
+
+/**
+ * Check if a Docker container is running
+ */
+export async function isContainerRunning(containerName: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn('docker', ['inspect', '-f', '{{.State.Running}}', containerName], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    child.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    child.on('close', (code) => {
+      resolve(code === 0 && output.trim() === 'true');
+    });
+
+    child.on('error', () => {
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Execute RCON command and capture output
+ */
+export async function execRconWithOutput(
+  containerName: string,
+  command: string[]
+): Promise<RconResult> {
+  return new Promise((resolve) => {
+    const child = spawn('docker', ['exec', containerName, 'rcon-cli', ...command], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    let errorOutput = '';
+
+    child.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      errorOutput += data.toString();
+    });
+
+    child.on('close', (code) => {
+      resolve({ code: code ?? 1, output: output || errorOutput });
+    });
+
+    child.on('error', (err) => {
+      resolve({ code: 1, output: err.message });
+    });
+  });
+}
+
+/**
+ * Get container name from server name
+ * Ensures the container name has the 'mc-' prefix
+ */
+export function getContainerName(serverName: string): string {
+  return serverName.startsWith('mc-') ? serverName : `mc-${serverName}`;
+}


### PR DESCRIPTION
## Summary

Implement comprehensive player management commands for the mcctl CLI:

- **`mcctl whitelist <server> <action> [player]`** - Manage server whitelist
  - Actions: list, add, remove, on, off, status
  - Updates both RCON (if running) and config.env for persistence

- **`mcctl ban <server> <action> [target]`** - Manage player/IP bans  
  - Actions: list, add, remove
  - IP actions: ip list, ip add, ip remove
  - Supports ban reasons

- **`mcctl kick <server> <player> [reason]`** - Kick players from server
  - Requires server to be running

- **`mcctl player online <server> / --all`** - List online players
  - Single server or all servers
  - Shows player count and max players

### Key Features

- **Dual-update pattern**: RCON for immediate effect + config.env for persistence
- **Consistent error handling**: Proper exit codes and error messages
- **JSON output support**: `--json` flag for all commands
- **Common utilities extracted**:
  - `lib/rcon.ts` - RCON execution helpers
  - `lib/player-json.ts` - Minecraft JSON file utilities

### Files Changed

- New: `commands/whitelist.ts`, `commands/ban.ts`, `commands/kick.ts`, `commands/player-online.ts`
- New: `lib/rcon.ts`, `lib/player-json.ts`
- Modified: `commands/op.ts` (refactored to use common utilities)
- Modified: `commands/index.ts`, `index.ts` (exports and routing)

## Test plan

- [ ] Test `mcctl whitelist <server> list` - List whitelisted players
- [ ] Test `mcctl whitelist <server> add <player>` - Add player to whitelist
- [ ] Test `mcctl whitelist <server> remove <player>` - Remove from whitelist
- [ ] Test `mcctl whitelist <server> on/off` - Enable/disable whitelist
- [ ] Test `mcctl ban <server> list` - List banned players
- [ ] Test `mcctl ban <server> add <player> [reason]` - Ban player
- [ ] Test `mcctl ban <server> remove <player>` - Unban player
- [ ] Test `mcctl ban <server> ip list` - List banned IPs
- [ ] Test `mcctl kick <server> <player> [reason]` - Kick player
- [ ] Test `mcctl player online <server>` - List online players
- [ ] Test `mcctl player online --all` - List online players on all servers
- [ ] Verify JSON output with `--json` flag

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)