### PR TITLE
feat(cli): add detailed server monitoring with real-time updates (#68)

### DIFF
--- a/platform/services/cli/src/commands/status.ts
+++ b/platform/services/cli/src/commands/status.ts
@@ -4,8 +4,27 @@ import {
   log,
   checkDocker,
   getPlatformStatus,
+  getDetailedServerInfoWithPlayers,
+  getRouterDetailInfo,
+  formatBytes,
+  getMcContainers,
+  containerExists,
 } from '@minecraft-docker/shared';
-import type { PlatformStatus } from '@minecraft-docker/shared';
+import type {
+  PlatformStatus,
+  DetailedServerInfo,
+  RouterDetailInfo,
+} from '@minecraft-docker/shared';
+import { ShellExecutor } from '../lib/shell.js';
+
+export interface StatusCommandOptions {
+  json?: boolean;
+  root?: string;
+  detail?: boolean;
+  watch?: boolean;
+  interval?: number;
+  serverName?: string;
+}
 
 /**
  * Format status output as JSON
@@ -15,7 +34,7 @@ function formatJson(status: PlatformStatus): string {
 }
 
 /**
- * Format status output as human-readable table
+ * Format basic status output as human-readable table
  */
 function formatTable(status: PlatformStatus): void {
   console.log('');
@@ -72,12 +91,266 @@ function formatTable(status: PlatformStatus): void {
 }
 
 /**
+ * Format detailed server info
+ */
+function formatDetailedServer(info: DetailedServerInfo): void {
+  const statusColor = info.status === 'running' ? colors.green : colors.red;
+
+  console.log(`  ${colors.bold(info.name)}`);
+  console.log(`    Container: ${info.container}`);
+  console.log(`    Status:    ${statusColor(info.status)} (${info.health})`);
+  console.log(`    Hostname:  ${info.hostname}`);
+
+  if (info.type) {
+    console.log(`    Type:      ${info.type}`);
+  }
+  if (info.version) {
+    console.log(`    Version:   ${info.version}`);
+  }
+  if (info.memory) {
+    console.log(`    Memory:    ${info.memory}`);
+  }
+  if (info.uptime) {
+    console.log(`    Uptime:    ${info.uptime}`);
+  }
+
+  if (info.stats) {
+    const memUsed = formatBytes(info.stats.memoryUsage);
+    const memLimit = formatBytes(info.stats.memoryLimit);
+    const memPercent = info.stats.memoryPercent.toFixed(1);
+    const cpuPercent = info.stats.cpuPercent.toFixed(1);
+    console.log(`    Resources: ${memUsed} / ${memLimit} (${memPercent}%) | CPU: ${cpuPercent}%`);
+  }
+
+  if (info.players) {
+    const playerList =
+      info.players.players.length > 0
+        ? info.players.players.join(', ')
+        : 'none';
+    console.log(
+      `    Players:   ${colors.cyan(String(info.players.online))}/${info.players.max} - ${playerList}`
+    );
+  }
+
+  console.log('');
+}
+
+/**
+ * Format detailed status output
+ */
+async function formatDetailedTable(
+  status: PlatformStatus,
+  shell: ShellExecutor
+): Promise<void> {
+  console.log('');
+  console.log(colors.bold('=== Detailed Server Status ==='));
+  console.log('');
+
+  // Infrastructure section
+  console.log(colors.cyan('INFRASTRUCTURE'));
+  console.log('');
+
+  // Router
+  const routerInfo = getRouterDetailInfo();
+  const routerColor = routerInfo.status === 'running' ? colors.green : colors.red;
+  console.log(`  ${colors.bold('mc-router')}`);
+  console.log(`    Status:    ${routerColor(routerInfo.status)} (${routerInfo.health})`);
+  console.log(`    Port:      ${routerInfo.port}`);
+  console.log(`    Mode:      ${routerInfo.mode || 'unknown'}`);
+  if (routerInfo.uptime) {
+    console.log(`    Uptime:    ${routerInfo.uptime}`);
+  }
+  if (routerInfo.routes.length > 0) {
+    console.log(`    Routes:    ${routerInfo.routes.length} configured`);
+    for (const route of routerInfo.routes) {
+      const targetColor = route.serverStatus === 'running' ? colors.green : colors.yellow;
+      console.log(`      - ${route.hostname} → ${targetColor(route.target)}`);
+    }
+  }
+  console.log('');
+
+  // Avahi
+  const avahiColor = status.avahi_daemon.status === 'running' ? colors.green : colors.red;
+  console.log(`  ${colors.bold('avahi-daemon')}`);
+  console.log(`    Status:    ${avahiColor(status.avahi_daemon.status)}`);
+  console.log(`    Type:      ${status.avahi_daemon.type}`);
+  console.log('');
+
+  // Servers section
+  console.log(colors.cyan('MINECRAFT SERVERS'));
+  console.log('');
+
+  if (status.servers.length === 0) {
+    console.log('  No Minecraft servers configured');
+  } else {
+    for (const server of status.servers) {
+      // Get config.env for type/version/memory
+      const configEnv = shell.readConfig(server.name);
+      const envMap: Record<string, string> = {};
+      if (configEnv) {
+        if (configEnv.TYPE) envMap['TYPE'] = configEnv.TYPE;
+        if (configEnv.VERSION) envMap['VERSION'] = configEnv.VERSION;
+        if (configEnv.MEMORY) envMap['MEMORY'] = configEnv.MEMORY;
+      }
+
+      const detailedInfo = await getDetailedServerInfoWithPlayers(
+        server.container,
+        envMap
+      );
+      formatDetailedServer(detailedInfo);
+    }
+  }
+}
+
+/**
+ * Format single server status
+ */
+async function formatSingleServerStatus(
+  serverName: string,
+  shell: ShellExecutor,
+  json: boolean
+): Promise<number> {
+  const containerName = `mc-${serverName}`;
+
+  if (!containerExists(containerName)) {
+    log.error(`Server '${serverName}' not found`);
+    return 1;
+  }
+
+  // Get config.env for type/version/memory
+  const configEnv = shell.readConfig(serverName);
+  const envMap: Record<string, string> = {};
+  if (configEnv) {
+    if (configEnv.TYPE) envMap['TYPE'] = configEnv.TYPE;
+    if (configEnv.VERSION) envMap['VERSION'] = configEnv.VERSION;
+    if (configEnv.MEMORY) envMap['MEMORY'] = configEnv.MEMORY;
+  }
+
+  const detailedInfo = await getDetailedServerInfoWithPlayers(containerName, envMap);
+
+  if (json) {
+    console.log(JSON.stringify(detailedInfo, null, 2));
+  } else {
+    console.log('');
+    console.log(colors.bold(`=== Server: ${serverName} ===`));
+    console.log('');
+    formatDetailedServer(detailedInfo);
+  }
+
+  return 0;
+}
+
+/**
+ * Format router status
+ */
+function formatRouterStatus(json: boolean): number {
+  const routerInfo = getRouterDetailInfo();
+
+  if (json) {
+    console.log(JSON.stringify(routerInfo, null, 2));
+    return 0;
+  }
+
+  console.log('');
+  console.log(colors.bold('=== mc-router Status ==='));
+  console.log('');
+
+  const statusColor = routerInfo.status === 'running' ? colors.green : colors.red;
+  console.log(`  Status:    ${statusColor(routerInfo.status)} (${routerInfo.health})`);
+  console.log(`  Port:      ${routerInfo.port}`);
+  console.log(`  Mode:      ${routerInfo.mode || 'unknown'}`);
+
+  if (routerInfo.uptime) {
+    console.log(`  Uptime:    ${routerInfo.uptime}`);
+  }
+
+  console.log('');
+  console.log(colors.cyan('ROUTING TABLE'));
+  console.log('');
+
+  if (routerInfo.routes.length === 0) {
+    console.log('  No routes configured');
+  } else {
+    console.log(
+      `  ${'HOSTNAME'.padEnd(40)} ${'TARGET'.padEnd(25)} STATUS`
+    );
+    console.log(
+      `  ${'--------'.padEnd(40)} ${'------'.padEnd(25)} ------`
+    );
+
+    for (const route of routerInfo.routes) {
+      const statusColor = route.serverStatus === 'running' ? colors.green : colors.yellow;
+      console.log(
+        `  ${route.hostname.padEnd(40)} ${route.target.padEnd(25)} ${statusColor(route.serverStatus)}`
+      );
+    }
+  }
+
+  console.log('');
+  return 0;
+}
+
+/**
+ * Clear screen and move cursor to top
+ */
+function clearScreen(): void {
+  process.stdout.write('\x1B[2J\x1B[H');
+}
+
+/**
+ * Watch mode with periodic refresh
+ */
+async function watchMode(
+  options: StatusCommandOptions,
+  paths: Paths,
+  shell: ShellExecutor
+): Promise<number> {
+  const intervalMs = (options.interval || 5) * 1000;
+
+  const refresh = async (): Promise<void> => {
+    clearScreen();
+
+    const timestamp = new Date().toLocaleTimeString();
+    console.log(colors.dim(`Last update: ${timestamp} (interval: ${options.interval || 5}s, press Ctrl+C to exit)`));
+
+    if (options.serverName === 'router') {
+      formatRouterStatus(false);
+    } else if (options.serverName) {
+      await formatSingleServerStatus(options.serverName, shell, false);
+    } else {
+      const status = getPlatformStatus();
+      if (options.detail) {
+        await formatDetailedTable(status, shell);
+      } else {
+        formatTable(status);
+      }
+    }
+  };
+
+  // Initial display
+  await refresh();
+
+  // Set up periodic refresh
+  const intervalId = setInterval(refresh, intervalMs);
+
+  // Handle Ctrl+C gracefully
+  process.on('SIGINT', () => {
+    clearInterval(intervalId);
+    console.log('\n');
+    log.info('Watch mode stopped');
+    process.exit(0);
+  });
+
+  // Keep running indefinitely
+  return new Promise(() => {
+    // Never resolves - runs until SIGINT
+  });
+}
+
+/**
  * Status command
  */
-export async function statusCommand(options: {
-  json?: boolean;
-  root?: string;
-}): Promise<number> {
+export async function statusCommand(options: StatusCommandOptions): Promise<number> {
   const paths = new Paths(options.root);
 
   // Check if initialized
@@ -92,14 +365,63 @@ export async function statusCommand(options: {
     return 1;
   }
 
+  const shell = new ShellExecutor(paths);
+
+  // Watch mode
+  if (options.watch) {
+    return watchMode(options, paths, shell);
+  }
+
+  // Single router status
+  if (options.serverName === 'router') {
+    return formatRouterStatus(options.json || false);
+  }
+
+  // Single server status
+  if (options.serverName) {
+    return formatSingleServerStatus(options.serverName, shell, options.json || false);
+  }
+
   // Get platform status
   const status = getPlatformStatus();
 
   // Output
   if (options.json) {
-    console.log(formatJson(status));
+    if (options.detail) {
+      // For detailed JSON, include all the extra info
+      const detailedServers: DetailedServerInfo[] = [];
+      for (const server of status.servers) {
+        const configEnv = shell.readConfig(server.name);
+        const envMap: Record<string, string> = {};
+        if (configEnv) {
+          if (configEnv.TYPE) envMap['TYPE'] = configEnv.TYPE;
+          if (configEnv.VERSION) envMap['VERSION'] = configEnv.VERSION;
+          if (configEnv.MEMORY) envMap['MEMORY'] = configEnv.MEMORY;
+        }
+        const detailed = await getDetailedServerInfoWithPlayers(server.container, envMap);
+        detailedServers.push(detailed);
+      }
+      const routerDetail = getRouterDetailInfo();
+      console.log(
+        JSON.stringify(
+          {
+            router: routerDetail,
+            avahi_daemon: status.avahi_daemon,
+            servers: detailedServers,
+          },
+          null,
+          2
+        )
+      );
+    } else {
+      console.log(formatJson(status));
+    }
   } else {
-    formatTable(status);
+    if (options.detail) {
+      await formatDetailedTable(status, shell);
+    } else {
+      formatTable(status);
+    }
   }
 
   return 0;

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -38,7 +38,9 @@ ${colors.cyan('Commands:')}
   ${colors.bold('down')}                       Stop all infrastructure
   ${colors.bold('create')} <name> [options]    Create a new server
   ${colors.bold('delete')} <name> [--force]    Delete a server (preserves world data)
-  ${colors.bold('status')} [--json]            Show status of all servers
+  ${colors.bold('status')} [options]            Show status of all servers
+  ${colors.bold('status')} <server>             Show detailed status of a server
+  ${colors.bold('status')} router               Show mc-router status with routes
   ${colors.bold('start')} <server> [--all]     Start a server (--all for all servers)
   ${colors.bold('stop')} <server> [--all]      Stop a server (--all for all servers)
   ${colors.bold('logs')} <server> [lines]      View server logs
@@ -108,6 +110,11 @@ ${colors.cyan('Create Options:')}
   -w, --world NAME           Use existing world (symlink)
   --no-start                 Create without starting
 
+${colors.cyan('Status Options:')}
+  --detail, -d               Show detailed info (memory, CPU, players)
+  --watch, -W                Real-time monitoring mode
+  --interval <sec>           Watch refresh interval (default: 5)
+
 ${colors.cyan('Global Options:')}
   --root <path>              Custom data directory
   --json                     Output in JSON format
@@ -122,6 +129,11 @@ ${colors.cyan('Examples:')}
   mcctl stop --all                   # Stop all MC servers
   mcctl create myserver -t FORGE -v 1.20.4
   mcctl status --json
+  mcctl status --detail              # Show detailed info
+  mcctl status --watch               # Real-time monitoring
+  mcctl status --watch --interval 2  # Watch with 2s refresh
+  mcctl status myserver              # Single server status
+  mcctl status router                # mc-router status
   mcctl logs myserver -f
   mcctl exec myserver say "Hello!"   # Execute RCON command
   mcctl exec myserver list           # List online players
@@ -189,6 +201,8 @@ function parseArgs(args: string[]): {
         m: 'message',
         y: 'yes',
         a: 'all',
+        d: 'detail',
+        W: 'watch',
       };
 
       const longKey = flagMap[key] ?? key;
@@ -260,6 +274,10 @@ async function main(): Promise<void> {
         exitCode = await statusCommand({
           json: flags['json'] === true,
           root: rootDir,
+          detail: flags['detail'] === true,
+          watch: flags['watch'] === true,
+          interval: flags['interval'] ? parseInt(flags['interval'] as string, 10) : undefined,
+          serverName: positional[0],
         });
         break;
 

--- a/platform/services/shared/src/docker/index.ts
+++ b/platform/services/shared/src/docker/index.ts
@@ -1,5 +1,16 @@
 import { spawn, execSync } from 'node:child_process';
-import type { ContainerStatus, HealthStatus, ServerInfo, RouterInfo, PlatformStatus } from '../types/index.js';
+import type {
+  ContainerStatus,
+  HealthStatus,
+  ServerInfo,
+  RouterInfo,
+  PlatformStatus,
+  ContainerStats,
+  PlayerListResult,
+  DetailedServerInfo,
+  RouterDetailInfo,
+  RouteInfo,
+} from '../types/index.js';
 
 /**
  * Execute a command and return stdout
@@ -302,4 +313,242 @@ export function execScriptInteractive(
       resolve(1);
     });
   });
+}
+
+/**
+ * Get container resource stats (memory, CPU)
+ */
+export function getContainerStats(container: string): ContainerStats | null {
+  // docker stats --no-stream --format "{{.MemUsage}},{{.CPUPerc}}"
+  // Example output: "2.1GiB / 4GiB,15.23%"
+  const result = execCommand('docker', [
+    'stats',
+    '--no-stream',
+    '--format',
+    '{{.MemUsage}},{{.CPUPerc}}',
+    container,
+  ]);
+
+  if (!result) return null;
+
+  try {
+    const [memUsage, cpuPerc] = result.split(',');
+    if (!memUsage || !cpuPerc) return null;
+
+    // Parse memory: "2.1GiB / 4GiB" or "512MiB / 4GiB"
+    const memParts = memUsage.split('/').map((s) => s.trim());
+    if (memParts.length !== 2) return null;
+
+    const parseMemory = (mem: string): number => {
+      const match = mem.match(/^([\d.]+)\s*(B|KiB|MiB|GiB|TiB|KB|MB|GB|TB)?$/i);
+      if (!match || !match[1]) return 0;
+      const value = parseFloat(match[1]);
+      const unit = (match[2] ?? 'B').toUpperCase();
+      const multipliers: Record<string, number> = {
+        B: 1,
+        KIB: 1024,
+        MIB: 1024 ** 2,
+        GIB: 1024 ** 3,
+        TIB: 1024 ** 4,
+        KB: 1000,
+        MB: 1000 ** 2,
+        GB: 1000 ** 3,
+        TB: 1000 ** 4,
+      };
+      return value * (multipliers[unit] || 1);
+    };
+
+    const memoryUsage = parseMemory(memParts[0]!);
+    const memoryLimit = parseMemory(memParts[1]!);
+    const memoryPercent = memoryLimit > 0 ? (memoryUsage / memoryLimit) * 100 : 0;
+
+    // Parse CPU: "15.23%" or "0.00%"
+    const cpuPercent = parseFloat(cpuPerc.replace('%', '')) || 0;
+
+    return {
+      memoryUsage,
+      memoryLimit,
+      memoryPercent,
+      cpuPercent,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get container uptime (time since start)
+ */
+export function getContainerUptime(container: string): { uptime: string; seconds: number } | null {
+  // docker inspect --format '{{.State.StartedAt}}'
+  const result = execCommand('docker', [
+    'inspect',
+    '--format',
+    '{{.State.StartedAt}}',
+    container,
+  ]);
+
+  if (!result || result === '0001-01-01T00:00:00Z') return null;
+
+  try {
+    const startedAt = new Date(result);
+    const now = new Date();
+    const diffMs = now.getTime() - startedAt.getTime();
+    const diffSeconds = Math.floor(diffMs / 1000);
+
+    // Format uptime
+    const days = Math.floor(diffSeconds / 86400);
+    const hours = Math.floor((diffSeconds % 86400) / 3600);
+    const minutes = Math.floor((diffSeconds % 3600) / 60);
+
+    let uptime = '';
+    if (days > 0) uptime += `${days}d `;
+    if (hours > 0 || days > 0) uptime += `${hours}h `;
+    uptime += `${minutes}m`;
+
+    return { uptime: uptime.trim(), seconds: diffSeconds };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get online players via RCON
+ */
+export async function getOnlinePlayers(container: string): Promise<PlayerListResult | null> {
+  try {
+    const result = execSync(`docker exec ${container} rcon-cli list`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    // Parse: "There are 3 of a max of 20 players online: Notch, Steve, Alex"
+    // Or: "There are 0 of a max of 20 players online:"
+    const countMatch = result.match(/There are (\d+)(?:\s+of a max of\s+|\/)(\d+) players? online/i);
+    if (!countMatch || !countMatch[1] || !countMatch[2]) return null;
+
+    const online = parseInt(countMatch[1], 10);
+    const max = parseInt(countMatch[2], 10);
+
+    // Extract player names after the colon
+    const playersMatch = result.match(/:\s*(.*)$/);
+    let players: string[] = [];
+    if (playersMatch && playersMatch[1]) {
+      players = playersMatch[1]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+
+    return { online, max, players };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get detailed server info
+ */
+export function getDetailedServerInfo(container: string, configEnv?: Record<string, string>): DetailedServerInfo {
+  const basic = getServerInfo(container);
+  const detailed: DetailedServerInfo = { ...basic };
+
+  // Only get extended info if container is running
+  if (basic.status === 'running') {
+    // Get stats
+    const stats = getContainerStats(container);
+    if (stats) {
+      detailed.stats = stats;
+    }
+
+    // Get uptime
+    const uptimeInfo = getContainerUptime(container);
+    if (uptimeInfo) {
+      detailed.uptime = uptimeInfo.uptime;
+      detailed.uptimeSeconds = uptimeInfo.seconds;
+    }
+  }
+
+  // Get config info if provided
+  if (configEnv) {
+    detailed.type = configEnv['TYPE'];
+    detailed.version = configEnv['VERSION'];
+    detailed.memory = configEnv['MEMORY'];
+  }
+
+  return detailed;
+}
+
+/**
+ * Get detailed server info with players (async)
+ */
+export async function getDetailedServerInfoWithPlayers(
+  container: string,
+  configEnv?: Record<string, string>
+): Promise<DetailedServerInfo> {
+  const detailed = getDetailedServerInfo(container, configEnv);
+
+  // Get players if running
+  if (detailed.status === 'running') {
+    const players = await getOnlinePlayers(container);
+    if (players) {
+      detailed.players = players;
+    }
+  }
+
+  return detailed;
+}
+
+/**
+ * Get router detailed info
+ */
+export function getRouterDetailInfo(): RouterDetailInfo {
+  const basic = getRouterInfo();
+  const detailed: RouterDetailInfo = {
+    ...basic,
+    routes: [],
+    mode: '--in-docker (auto-discovery)',
+  };
+
+  // Get uptime
+  if (basic.status === 'running') {
+    const uptimeInfo = getContainerUptime('mc-router');
+    if (uptimeInfo) {
+      detailed.uptime = uptimeInfo.uptime;
+      detailed.uptimeSeconds = uptimeInfo.seconds;
+    }
+  }
+
+  // Get routes from all mc-* containers
+  const containers = getMcContainers();
+  for (const container of containers) {
+    const hostname = getContainerHostname(container);
+    if (hostname && hostname !== '-') {
+      // hostname might be comma-separated (e.g., "server.local,server.192.168.1.10.nip.io")
+      const hostnames = hostname.split(',').map((h) => h.trim());
+      const serverStatus = getContainerStatus(container);
+
+      for (const h of hostnames) {
+        detailed.routes.push({
+          hostname: h,
+          target: `${container}:25565`,
+          serverStatus,
+        });
+      }
+    }
+  }
+
+  return detailed;
+}
+
+/**
+ * Format bytes to human readable string
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
 }

--- a/platform/services/shared/src/index.ts
+++ b/platform/services/shared/src/index.ts
@@ -16,6 +16,12 @@ export {
   type BackupStatus,
   type PlayerInfo,
   type CommandResult,
+  // New detailed types
+  type ContainerStats,
+  type PlayerListResult,
+  type DetailedServerInfo,
+  type RouterDetailInfo,
+  type RouteInfo,
 } from './types/index.js';
 
 // Re-export utilities
@@ -40,6 +46,14 @@ export {
   getContainerLogs,
   execScript,
   execScriptInteractive,
+  // New detailed functions
+  getContainerStats,
+  getContainerUptime,
+  getOnlinePlayers,
+  getDetailedServerInfo,
+  getDetailedServerInfoWithPlayers,
+  getRouterDetailInfo,
+  formatBytes,
 } from './docker/index.js';
 
 // Re-export domain layer (Value Objects and Entities)

--- a/platform/services/shared/src/types/index.ts
+++ b/platform/services/shared/src/types/index.ts
@@ -120,3 +120,50 @@ export interface CommandResult<T = void> {
   error?: string;
   code?: number;
 }
+
+/**
+ * Container stats types
+ */
+export interface ContainerStats {
+  memoryUsage: number;  // bytes
+  memoryLimit: number;  // bytes
+  memoryPercent: number; // 0-100
+  cpuPercent: number;   // 0-100
+}
+
+export interface PlayerListResult {
+  online: number;
+  max: number;
+  players: string[];
+}
+
+/**
+ * Detailed server info
+ */
+export interface DetailedServerInfo extends ServerInfo {
+  type?: string;
+  version?: string;
+  memory?: string;
+  uptime?: string;
+  uptimeSeconds?: number;
+  players?: PlayerListResult;
+  stats?: ContainerStats;
+  worldName?: string;
+  worldSize?: string;
+}
+
+/**
+ * Router detail info
+ */
+export interface RouterDetailInfo extends RouterInfo {
+  uptime?: string;
+  uptimeSeconds?: number;
+  routes: RouteInfo[];
+  mode?: string;
+}
+
+export interface RouteInfo {
+  hostname: string;
+  target: string;
+  serverStatus: ContainerStatus;
+}


### PR DESCRIPTION
## Summary

- **Detailed status mode** (`--detail`): Shows comprehensive server information including memory usage, CPU, players online, uptime, server type/version
- **Watch mode** (`--watch`): Real-time monitoring with auto-refresh (default 5s, configurable via `--interval`)
- **Single server status** (`mcctl status <server>`): View detailed info for a specific server
- **Router status** (`mcctl status router`): View mc-router status with complete routing table

## Changes

### New Types (shared/src/types/index.ts)
- `ContainerStats`: Memory/CPU statistics
- `PlayerListResult`: Online player info
- `DetailedServerInfo`: Extended server information
- `RouterDetailInfo`: Router with routes
- `RouteInfo`: Individual route entry

### New Utilities (shared/src/docker/index.ts)
- `getContainerStats()`: Parse Docker stats output
- `getContainerUptime()`: Calculate uptime from container start
- `getOnlinePlayers()`: RCON list command with parsing
- `getDetailedServerInfo()`: Aggregate all server info
- `getDetailedServerInfoWithPlayers()`: Async version with player data
- `getRouterDetailInfo()`: Router status with routes
- `formatBytes()`: Human-readable byte formatting

### CLI Updates (cli/src/commands/status.ts)
- Extended `statusCommand` with new options
- Detailed table formatting with colors
- Watch mode with screen clear and interval refresh
- Single server and router status views

## Test plan

- [ ] `mcctl status` - Basic status (unchanged behavior)
- [ ] `mcctl status --detail` - Detailed view with memory/CPU/players
- [ ] `mcctl status --watch` - Real-time updates (Ctrl+C to exit)
- [ ] `mcctl status --watch --interval 2` - 2 second refresh
- [ ] `mcctl status myserver` - Single server detailed info
- [ ] `mcctl status router` - Router with routing table
- [ ] `mcctl status --json --detail` - JSON output with detailed info

## Related Issue

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)