### PR TITLE
docs: add Admin Service (mcctl-api, mcctl-console) design documents

### DIFF
--- a/.claude/issues/admin-service-overview.md
+++ b/.claude/issues/admin-service-overview.md
@@ -1,28 +1,28 @@
 # Admin Service Implementation Overview
 
-웹 기반 관리 콘솔 서비스 구현을 위한 이슈 목록입니다.
+List of issues for implementing the web-based management console service.
 
-## 관련 문서
+## Related Documents
 - [mcctl-api PRD](../../platform/services/mcctl-api/prd.md)
 - [mcctl-api Plan](../../platform/services/mcctl-api/plan.md)
 - [mcctl-console PRD](../../platform/services/mcctl-console/prd.md)
 - [mcctl-console Plan](../../platform/services/mcctl-console/plan.md)
 
-## 이슈 목록
+## Issue List
 
-### Phase 8.1: Shared 패키지 확장
+### Phase 8.1: Shared Package Extension
 - [ ] issue-8.1.1-user-repository-port.md
 - [ ] issue-8.1.2-yaml-user-repository.md
 - [ ] issue-8.1.3-sqlite-user-repository.md
 - [ ] issue-8.1.4-api-prompt-adapter.md
 
-### Phase 8.2: CLI Admin 명령어
+### Phase 8.2: CLI Admin Commands
 - [ ] issue-8.2.1-admin-init.md
 - [ ] issue-8.2.2-admin-user.md
 - [ ] issue-8.2.3-admin-api.md
 - [ ] issue-8.2.4-admin-service.md
 
-### Phase 8.3: mcctl-api 서비스
+### Phase 8.3: mcctl-api Service
 - [ ] issue-8.3.1-api-project-setup.md
 - [ ] issue-8.3.2-api-auth-plugin.md
 - [ ] issue-8.3.3-api-server-routes.md
@@ -31,7 +31,7 @@
 - [ ] issue-8.3.6-api-swagger.md
 - [ ] issue-8.3.7-api-dockerfile.md
 
-### Phase 8.4: mcctl-console 서비스
+### Phase 8.4: mcctl-console Service
 - [ ] issue-8.4.1-console-project-setup.md
 - [ ] issue-8.4.2-console-nextauth.md
 - [ ] issue-8.4.3-console-bff-proxy.md
@@ -39,6 +39,6 @@
 - [ ] issue-8.4.5-console-server-pages.md
 - [ ] issue-8.4.6-console-dockerfile.md
 
-### Phase 8.5: 통합 및 테스트
+### Phase 8.5: Integration and Testing
 - [ ] issue-8.5.1-docker-compose.md
 - [ ] issue-8.5.2-e2e-tests.md

--- a/.claude/issues/issue-8.1.1-user-repository-port.md
+++ b/.claude/issues/issue-8.1.1-user-repository-port.md
@@ -1,22 +1,22 @@
-# Issue: IUserRepository 포트 정의
+# Issue: IUserRepository Port Definition
 
 ## Phase
-8.1.1 - Shared 패키지 확장
+8.1.1 - Shared Package Extension
 
-## 제목
+## Title
 feat(shared): Add IUserRepository port interface
 
-## 설명
-Admin Service 사용자 관리를 위한 `IUserRepository` 포트 인터페이스를 정의합니다.
+## Description
+Define the `IUserRepository` port interface for Admin Service user management.
 
-## 작업 내용
-- [ ] `src/application/ports/outbound/IUserRepository.ts` 생성
-- [ ] User 인터페이스 정의
-- [ ] IUserRepository 인터페이스 정의
-- [ ] index.ts에 export 추가
-- [ ] 단위 테스트 작성
+## Tasks
+- [ ] Create `src/application/ports/outbound/IUserRepository.ts`
+- [ ] Define User interface
+- [ ] Define IUserRepository interface
+- [ ] Add export to index.ts
+- [ ] Write unit tests
 
-## 인터페이스 정의
+## Interface Definition
 
 ```typescript
 export interface User {
@@ -37,10 +37,10 @@ export interface IUserRepository {
 }
 ```
 
-## 관련 문서
+## Related Documents
 - [shared PRD](../../platform/services/shared/prd.md) - Section 4.1
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:shared`

--- a/.claude/issues/issue-8.1.2-yaml-user-repository.md
+++ b/.claude/issues/issue-8.1.2-yaml-user-repository.md
@@ -1,27 +1,27 @@
-# Issue: YamlUserRepository 어댑터 구현
+# Issue: YamlUserRepository Adapter Implementation
 
 ## Phase
-8.1.2 - Shared 패키지 확장
+8.1.2 - Shared Package Extension
 
-## 제목
+## Title
 feat(shared): Implement YamlUserRepository adapter
 
-## 설명
-`.mcctl-admin.yml` 파일 기반 사용자 저장소 어댑터를 구현합니다.
+## Description
+Implement a YAML file-based user repository adapter using `.mcctl-admin.yml`.
 
-## 선행 작업
-- #8.1.1 IUserRepository 포트 정의
+## Prerequisites
+- #8.1.1 IUserRepository port definition
 
-## 작업 내용
-- [ ] `src/infrastructure/adapters/YamlUserRepository.ts` 생성
-- [ ] IUserRepository 구현
-- [ ] 파일 읽기/쓰기 구현
-- [ ] bcrypt 비밀번호 해싱
-- [ ] 파일 잠금 처리
-- [ ] index.ts에 export 추가
-- [ ] 단위 테스트 작성
+## Tasks
+- [ ] Create `src/infrastructure/adapters/YamlUserRepository.ts`
+- [ ] Implement IUserRepository interface
+- [ ] Implement file read/write operations
+- [ ] bcrypt password hashing
+- [ ] File locking handling
+- [ ] Add export to index.ts
+- [ ] Write unit tests
 
-## 설정 파일 구조
+## Configuration File Structure
 
 ```yaml
 # ~/.minecraft-servers/.mcctl-admin.yml
@@ -34,10 +34,10 @@ users:
     role: "operator"
 ```
 
-## 관련 문서
+## Related Documents
 - [shared PRD](../../platform/services/shared/prd.md) - Section 4.2
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:shared`

--- a/.claude/issues/issue-8.2.1-admin-init.md
+++ b/.claude/issues/issue-8.2.1-admin-init.md
@@ -1,30 +1,30 @@
-# Issue: mcctl admin init 명령어
+# Issue: mcctl admin init Command
 
 ## Phase
-8.2.1 - CLI Admin 명령어
+8.2.1 - CLI Admin Commands
 
-## 제목
+## Title
 feat(cli): Add `mcctl admin init` command for Admin Service initialization
 
-## 설명
-Admin Service 초기 설정을 위한 대화형 `mcctl admin init` 명령어를 구현합니다.
+## Description
+Implement an interactive `mcctl admin init` command for Admin Service initial setup.
 
-## 선행 작업
-- #8.1.1 IUserRepository 포트 정의
-- #8.1.2 YamlUserRepository 어댑터 구현
+## Prerequisites
+- #8.1.1 IUserRepository port definition
+- #8.1.2 YamlUserRepository adapter implementation
 
-## 작업 내용
-- [ ] `src/commands/admin/index.ts` - 메인 라우터
-- [ ] `src/commands/admin/init.ts` - 초기화 명령어
-- [ ] `.mcctl-admin.yml` 설정 파일 생성
-- [ ] 관리자 계정 생성 프롬프트
-- [ ] API 접근 모드 선택
-- [ ] API 키 자동 생성
-- [ ] `src/lib/admin-config.ts` - 설정 관리
-- [ ] index.ts에 admin 라우팅 추가
-- [ ] 테스트
+## Tasks
+- [ ] `src/commands/admin/index.ts` - Main router
+- [ ] `src/commands/admin/init.ts` - Init command
+- [ ] Create `.mcctl-admin.yml` configuration file
+- [ ] Admin account creation prompt
+- [ ] API access mode selection
+- [ ] Auto-generate API key
+- [ ] `src/lib/admin-config.ts` - Configuration management
+- [ ] Add admin routing to index.ts
+- [ ] Tests
 
-## 대화형 플로우
+## Interactive Flow
 
 ```
 $ mcctl admin init
@@ -51,7 +51,7 @@ $ mcctl admin init
    Console: http://localhost:3000
 ```
 
-## 생성되는 설정 파일
+## Generated Configuration File
 
 ```yaml
 # ~/.minecraft-servers/.mcctl-admin.yml
@@ -79,10 +79,10 @@ users:
     role: "admin"
 ```
 
-## 관련 문서
+## Related Documents
 - [mcctl-api PRD](../../platform/services/mcctl-api/prd.md) - Section 4
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:cli`

--- a/.claude/issues/issue-8.3.1-api-project-setup.md
+++ b/.claude/issues/issue-8.3.1-api-project-setup.md
@@ -1,25 +1,25 @@
-# Issue: mcctl-api 프로젝트 기반 구조
+# Issue: mcctl-api Project Foundation
 
 ## Phase
-8.3.1 - mcctl-api 서비스
+8.3.1 - mcctl-api Service
 
-## 제목
+## Title
 feat(mcctl-api): Setup project foundation
 
-## 설명
-mcctl-api REST API 서비스의 기본 프로젝트 구조를 설정합니다.
+## Description
+Set up the basic project structure for the mcctl-api REST API service.
 
-## 작업 내용
-- [ ] `package.json` 생성 (`@minecraft-docker/mcctl-api`)
-- [ ] `tsconfig.json` 설정
-- [ ] `src/index.ts` - 진입점
-- [ ] `src/server.ts` - Fastify 서버 설정
-- [ ] `src/config.ts` - 환경 변수 로더
-- [ ] `src/di/container.ts` - DI 컨테이너
-- [ ] pnpm-workspace.yaml에 패키지 추가
-- [ ] 빌드 테스트
+## Tasks
+- [ ] Create `package.json` (`@minecraft-docker/mcctl-api`)
+- [ ] Configure `tsconfig.json`
+- [ ] `src/index.ts` - Entry point
+- [ ] `src/server.ts` - Fastify server setup
+- [ ] `src/config.ts` - Environment variable loader
+- [ ] `src/di/container.ts` - DI container
+- [ ] Add package to pnpm-workspace.yaml
+- [ ] Build test
 
-## 의존성
+## Dependencies
 
 ```json
 {
@@ -31,19 +31,19 @@ mcctl-api REST API 서비스의 기본 프로젝트 구조를 설정합니다.
 }
 ```
 
-## 환경 변수
+## Environment Variables
 
-| 변수 | 설명 | 기본값 |
-|------|------|--------|
-| `MCCTL_ROOT` | 데이터 디렉토리 | `/data` |
-| `API_PORT` | 리스닝 포트 | `3001` |
-| `API_ACCESS_MODE` | 접근 모드 | `internal` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MCCTL_ROOT` | Data directory | `/data` |
+| `API_PORT` | Listening port | `3001` |
+| `API_ACCESS_MODE` | Access mode | `internal` |
 
-## 관련 문서
+## Related Documents
 - [mcctl-api PRD](../../platform/services/mcctl-api/prd.md)
 - [mcctl-api Plan](../../platform/services/mcctl-api/plan.md) - Phase 1
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:mcctl-api`

--- a/.claude/issues/issue-8.3.2-api-auth-plugin.md
+++ b/.claude/issues/issue-8.3.2-api-auth-plugin.md
@@ -1,38 +1,38 @@
-# Issue: mcctl-api 인증 플러그인 구현
+# Issue: mcctl-api Authentication Plugin
 
 ## Phase
-8.3.2 - mcctl-api 서비스
+8.3.2 - mcctl-api Service
 
-## 제목
+## Title
 feat(mcctl-api): Implement authentication plugin with 5 access modes
 
-## 설명
-5가지 접근 모드를 지원하는 Fastify 인증 플러그인을 구현합니다.
+## Description
+Implement a Fastify authentication plugin supporting 5 access modes.
 
-## 선행 작업
-- #8.3.1 mcctl-api 프로젝트 기반 구조
+## Prerequisites
+- #8.3.1 mcctl-api project foundation
 
-## 작업 내용
-- [ ] `src/plugins/auth.ts` 생성
-- [ ] `internal` 모드 - Docker 네트워크 검증
-- [ ] `api-key` 모드 - X-API-Key 헤더 검증
-- [ ] `ip-whitelist` 모드 - IP 화이트리스트
-- [ ] `api-key-ip` 모드 - 복합 인증
-- [ ] `open` 모드 - 인증 없음 (개발용)
-- [ ] `src/plugins/error-handler.ts` - 에러 핸들러
-- [ ] 단위 테스트
+## Tasks
+- [ ] Create `src/plugins/auth.ts`
+- [ ] `internal` mode - Docker network verification
+- [ ] `api-key` mode - X-API-Key header verification
+- [ ] `ip-whitelist` mode - IP whitelist
+- [ ] `api-key-ip` mode - Combined authentication
+- [ ] `open` mode - No authentication (development only)
+- [ ] `src/plugins/error-handler.ts` - Error handler
+- [ ] Unit tests
 
-## 접근 모드 상세
+## Access Mode Details
 
-| 모드 | 포트 노출 | 인증 방식 |
-|------|----------|----------|
-| `internal` | 없음 | Docker 네트워크만 |
-| `api-key` | 3001 | X-API-Key 헤더 |
-| `ip-whitelist` | 3001 | IP 검증 |
-| `api-key-ip` | 3001 | 둘 다 |
-| `open` | 3001 | 없음 (개발용) |
+| Mode | Port Exposure | Authentication |
+|------|---------------|----------------|
+| `internal` | None | Docker network only |
+| `api-key` | 3001 | X-API-Key header |
+| `ip-whitelist` | 3001 | IP verification |
+| `api-key-ip` | 3001 | Both |
+| `open` | 3001 | None (dev only) |
 
-## 구현 예시
+## Implementation Example
 
 ```typescript
 export interface AuthPluginOptions {
@@ -43,10 +43,10 @@ export interface AuthPluginOptions {
 }
 ```
 
-## 관련 문서
+## Related Documents
 - [mcctl-api PRD](../../platform/services/mcctl-api/prd.md) - Section 4
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:mcctl-api`

--- a/.claude/issues/issue-8.3.3-api-server-routes.md
+++ b/.claude/issues/issue-8.3.3-api-server-routes.md
@@ -1,48 +1,48 @@
-# Issue: mcctl-api 서버 관리 API 라우트
+# Issue: mcctl-api Server Management API Routes
 
 ## Phase
-8.3.3 - mcctl-api 서비스
+8.3.3 - mcctl-api Service
 
-## 제목
+## Title
 feat(mcctl-api): Implement server management API routes
 
-## 설명
-서버 관리를 위한 REST API 엔드포인트를 구현합니다.
+## Description
+Implement REST API endpoints for server management.
 
-## 선행 작업
-- #8.3.1 mcctl-api 프로젝트 기반 구조
-- #8.3.2 mcctl-api 인증 플러그인
+## Prerequisites
+- #8.3.1 mcctl-api project foundation
+- #8.3.2 mcctl-api authentication plugin
 
-## 작업 내용
-- [ ] `src/routes/servers.ts` 생성
-- [ ] `GET /api/servers` - 서버 목록
-- [ ] `GET /api/servers/:name` - 서버 상세
-- [ ] `POST /api/servers` - 서버 생성
-- [ ] `DELETE /api/servers/:name` - 서버 삭제
-- [ ] `POST /api/servers/:name/start` - 서버 시작
-- [ ] `POST /api/servers/:name/stop` - 서버 중지
-- [ ] `POST /api/servers/:name/restart` - 서버 재시작
-- [ ] `GET /api/servers/:name/logs` - 서버 로그
-- [ ] `POST /api/servers/:name/exec` - RCON 명령 실행
-- [ ] 스키마 정의 (Zod/TypeBox)
-- [ ] 단위 테스트
-- [ ] 통합 테스트
+## Tasks
+- [ ] Create `src/routes/servers.ts`
+- [ ] `GET /api/servers` - List servers
+- [ ] `GET /api/servers/:name` - Server details
+- [ ] `POST /api/servers` - Create server
+- [ ] `DELETE /api/servers/:name` - Delete server
+- [ ] `POST /api/servers/:name/start` - Start server
+- [ ] `POST /api/servers/:name/stop` - Stop server
+- [ ] `POST /api/servers/:name/restart` - Restart server
+- [ ] `GET /api/servers/:name/logs` - Server logs
+- [ ] `POST /api/servers/:name/exec` - Execute RCON command
+- [ ] Schema definitions (Zod/TypeBox)
+- [ ] Unit tests
+- [ ] Integration tests
 
-## API 엔드포인트
+## API Endpoints
 
-| Method | Endpoint | 설명 |
-|--------|----------|------|
-| GET | `/api/servers` | 서버 목록 |
-| GET | `/api/servers/:name` | 서버 상세 |
-| POST | `/api/servers` | 서버 생성 |
-| DELETE | `/api/servers/:name` | 서버 삭제 |
-| POST | `/api/servers/:name/start` | 시작 |
-| POST | `/api/servers/:name/stop` | 중지 |
-| POST | `/api/servers/:name/restart` | 재시작 |
-| GET | `/api/servers/:name/logs` | 로그 |
-| POST | `/api/servers/:name/exec` | RCON 실행 |
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/servers` | List servers |
+| GET | `/api/servers/:name` | Server details |
+| POST | `/api/servers` | Create server |
+| DELETE | `/api/servers/:name` | Delete server |
+| POST | `/api/servers/:name/start` | Start |
+| POST | `/api/servers/:name/stop` | Stop |
+| POST | `/api/servers/:name/restart` | Restart |
+| GET | `/api/servers/:name/logs` | Logs |
+| POST | `/api/servers/:name/exec` | RCON execute |
 
-## 응답 예시
+## Response Example
 
 ```json
 // GET /api/servers
@@ -61,10 +61,10 @@ feat(mcctl-api): Implement server management API routes
 }
 ```
 
-## 관련 문서
+## Related Documents
 - [mcctl-api PRD](../../platform/services/mcctl-api/prd.md) - Section 5.1
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:mcctl-api`

--- a/.claude/issues/issue-8.4.1-console-project-setup.md
+++ b/.claude/issues/issue-8.4.1-console-project-setup.md
@@ -1,28 +1,28 @@
-# Issue: mcctl-console 프로젝트 기반 구조
+# Issue: mcctl-console Project Foundation
 
 ## Phase
-8.4.1 - mcctl-console 서비스
+8.4.1 - mcctl-console Service
 
-## 제목
+## Title
 feat(mcctl-console): Setup Next.js project foundation
 
-## 설명
-mcctl-console 관리 콘솔 서비스의 기본 Next.js 프로젝트 구조를 설정합니다.
+## Description
+Set up the basic Next.js project structure for the mcctl-console management console service.
 
-## 작업 내용
-- [ ] `package.json` 생성 (`@minecraft-docker/mcctl-console`)
-- [ ] `tsconfig.json` 설정
-- [ ] `next.config.js` 설정
-- [ ] `tailwind.config.js` 설정
-- [ ] `src/app/layout.tsx` - 루트 레이아웃
-- [ ] `src/app/page.tsx` - 홈 (대시보드 리다이렉트)
+## Tasks
+- [ ] Create `package.json` (`@minecraft-docker/mcctl-console`)
+- [ ] Configure `tsconfig.json`
+- [ ] Configure `next.config.js`
+- [ ] Configure `tailwind.config.js`
+- [ ] `src/app/layout.tsx` - Root layout
+- [ ] `src/app/page.tsx` - Home (dashboard redirect)
 - [ ] `src/components/layout/Sidebar.tsx`
 - [ ] `src/components/layout/Header.tsx`
-- [ ] shadcn/ui 설정
-- [ ] pnpm-workspace.yaml에 패키지 추가
-- [ ] 빌드 테스트
+- [ ] Setup shadcn/ui
+- [ ] Add package to pnpm-workspace.yaml
+- [ ] Build test
 
-## 의존성
+## Dependencies
 
 ```json
 {
@@ -35,7 +35,7 @@ mcctl-console 관리 콘솔 서비스의 기본 Next.js 프로젝트 구조를 �
 }
 ```
 
-## UI 컬러 팔레트 (다크 테마)
+## UI Color Palette (Dark Theme)
 
 ```css
 :root {
@@ -49,11 +49,11 @@ mcctl-console 관리 콘솔 서비스의 기본 Next.js 프로젝트 구조를 �
 }
 ```
 
-## 관련 문서
+## Related Documents
 - [mcctl-console PRD](../../platform/services/mcctl-console/prd.md)
 - [mcctl-console Plan](../../platform/services/mcctl-console/plan.md) - Phase 1
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:mcctl-console`

--- a/.claude/issues/issue-8.4.2-console-nextauth.md
+++ b/.claude/issues/issue-8.4.2-console-nextauth.md
@@ -1,47 +1,47 @@
-# Issue: mcctl-console NextAuth 인증 시스템
+# Issue: mcctl-console NextAuth Authentication System
 
 ## Phase
-8.4.2 - mcctl-console 서비스
+8.4.2 - mcctl-console Service
 
-## 제목
+## Title
 feat(mcctl-console): Implement NextAuth.js authentication
 
-## 설명
-NextAuth.js를 사용하여 Credentials Provider 기반 인증 시스템을 구현합니다.
+## Description
+Implement Credentials Provider based authentication system using NextAuth.js.
 
-## 선행 작업
-- #8.4.1 mcctl-console 프로젝트 기반 구조
-- #8.3.1 mcctl-api 프로젝트 기반 구조
+## Prerequisites
+- #8.4.1 mcctl-console project foundation
+- #8.3.1 mcctl-api project foundation
 
-## 작업 내용
-- [ ] `src/auth/auth.ts` - NextAuth 설정
-- [ ] `src/auth/auth.config.ts` - 설정 분리
-- [ ] `src/app/login/page.tsx` - 로그인 페이지
-- [ ] Credentials Provider 구현 (mcctl-api 통해 인증)
-- [ ] 세션 관리
-- [ ] 역할별 권한 체크 미들웨어
-- [ ] 테스트
+## Tasks
+- [ ] `src/auth/auth.ts` - NextAuth configuration
+- [ ] `src/auth/auth.config.ts` - Configuration separation
+- [ ] `src/app/login/page.tsx` - Login page
+- [ ] Implement Credentials Provider (authenticate via mcctl-api)
+- [ ] Session management
+- [ ] Role-based permission check middleware
+- [ ] Tests
 
-## 역할별 권한
+## Role-based Permissions
 
-| 역할 | 서버 | 월드 | 플레이어 | 백업 |
-|------|------|------|---------|------|
-| admin | 모든 권한 | 모든 권한 | 모든 권한 | 모든 권한 |
-| operator | 조회/시작/중지 | 조회 | 모든 권한 | 조회 |
-| viewer | 조회만 | 조회만 | 조회만 | 조회만 |
+| Role | Servers | Worlds | Players | Backup |
+|------|---------|--------|---------|--------|
+| admin | All permissions | All permissions | All permissions | All permissions |
+| operator | View/Start/Stop | View | All permissions | View |
+| viewer | View only | View only | View only | View only |
 
-## 환경 변수
+## Environment Variables
 
-| 변수 | 설명 |
-|------|------|
-| `NEXTAUTH_SECRET` | 암호화 키 (필수) |
-| `NEXTAUTH_URL` | 외부 접근 URL |
-| `INTERNAL_API_URL` | mcctl-api 내부 URL |
+| Variable | Description |
+|----------|-------------|
+| `NEXTAUTH_SECRET` | Encryption key (required) |
+| `NEXTAUTH_URL` | External access URL |
+| `INTERNAL_API_URL` | mcctl-api internal URL |
 
-## 관련 문서
+## Related Documents
 - [mcctl-console PRD](../../platform/services/mcctl-console/prd.md) - Section 5
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:mcctl-console`

--- a/.claude/issues/issue-8.4.4-console-dashboard.md
+++ b/.claude/issues/issue-8.4.4-console-dashboard.md
@@ -1,30 +1,30 @@
-# Issue: mcctl-console 대시보드 페이지
+# Issue: mcctl-console Dashboard Page
 
 ## Phase
-8.4.4 - mcctl-console 서비스
+8.4.4 - mcctl-console Service
 
-## 제목
+## Title
 feat(mcctl-console): Implement dashboard page with server overview
 
-## 설명
-서버 현황을 한눈에 볼 수 있는 대시보드 페이지를 구현합니다.
+## Description
+Implement a dashboard page that provides an at-a-glance view of server status.
 
-## 선행 작업
-- #8.4.1 mcctl-console 프로젝트 기반 구조
-- #8.4.2 mcctl-console NextAuth 인증
-- #8.4.3 mcctl-console BFF 프록시
+## Prerequisites
+- #8.4.1 mcctl-console project foundation
+- #8.4.2 mcctl-console NextAuth authentication
+- #8.4.3 mcctl-console BFF proxy
 
-## 작업 내용
-- [ ] `src/app/dashboard/page.tsx` - 대시보드 페이지
-- [ ] `src/components/server/ServerCard.tsx` - 서버 카드 컴포넌트
-- [ ] `src/components/server/ServerStats.tsx` - 통계 위젯
-- [ ] `src/components/server/PlayerList.tsx` - 온라인 플레이어 목록
-- [ ] `src/hooks/useServers.ts` - 서버 데이터 훅 (React Query)
-- [ ] 실시간 상태 업데이트 (polling)
-- [ ] 반응형 디자인
-- [ ] 테스트
+## Tasks
+- [ ] `src/app/dashboard/page.tsx` - Dashboard page
+- [ ] `src/components/server/ServerCard.tsx` - Server card component
+- [ ] `src/components/server/ServerStats.tsx` - Stats widget
+- [ ] `src/components/server/PlayerList.tsx` - Online player list
+- [ ] `src/hooks/useServers.ts` - Server data hook (React Query)
+- [ ] Real-time status updates (polling)
+- [ ] Responsive design
+- [ ] Tests
 
-## 대시보드 레이아웃
+## Dashboard Layout
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -32,7 +32,7 @@ feat(mcctl-console): Implement dashboard page with server overview
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐           │
-│  │ 서버 수     │ │ 온라인      │ │ 메모리 사용  │           │
+│  │ Servers     │ │ Online      │ │ Memory      │           │
 │  │ 3 / 5      │ │ 12 players  │ │ 8.2GB/16GB  │           │
 │  └─────────────┘ └─────────────┘ └─────────────┘           │
 │                                                             │
@@ -47,7 +47,7 @@ feat(mcctl-console): Implement dashboard page with server overview
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## 컴포넌트 Props
+## Component Props
 
 ```typescript
 interface ServerCardProps {
@@ -61,10 +61,10 @@ interface ServerCardProps {
 }
 ```
 
-## 관련 문서
+## Related Documents
 - [mcctl-console PRD](../../platform/services/mcctl-console/prd.md) - Section 4
 
-## 라벨
+## Labels
 - `phase:8-admin`
 - `type:feature`
 - `package:mcctl-console`

--- a/plan.md
+++ b/plan.md
@@ -1833,75 +1833,75 @@ pnpm test
 > **Milestone**: TBD
 > **Status**: Planned
 
-웹 기반 관리 콘솔 서비스의 구현 계획입니다. MSA 원칙에 따라 두 개의 독립 서비스로 구성됩니다.
+Implementation plan for web-based management console service. Consists of two independent services following MSA principles.
 
-### 8.1 서비스 구조
+### 8.1 Service Structure
 
 ```
 platform/services/
 ├── mcctl-api/              # @minecraft-docker/mcctl-api
-│   ├── prd.md              # API 서비스 PRD
-│   ├── plan.md             # API 서비스 Plan
+│   ├── prd.md              # API service PRD
+│   ├── plan.md             # API service Plan
 │   └── src/
 │
 └── mcctl-console/          # @minecraft-docker/mcctl-console
-    ├── prd.md              # Console 서비스 PRD
-    ├── plan.md             # Console 서비스 Plan
+    ├── prd.md              # Console service PRD
+    ├── plan.md             # Console service Plan
     └── src/
 ```
 
-### 8.2 세부 계획 문서
+### 8.2 Detailed Plan Documents
 
-각 서비스는 독립적인 구현 계획을 가집니다:
+Each service has independent implementation plans:
 
 - **mcctl-api**: [Plan](platform/services/mcctl-api/plan.md) - Fastify REST API
 - **mcctl-console**: [Plan](platform/services/mcctl-console/plan.md) - Next.js BFF + UI
 
-### 8.3 구현 순서
+### 8.3 Implementation Order
 
-#### Phase 8.1: Shared 패키지 확장
-- [ ] `IUserRepository` 포트 추가
-- [ ] `YamlUserRepository` 어댑터 구현
-- [ ] `SqliteUserRepository` 어댑터 구현
-- [ ] `ApiPromptAdapter` 구현
+#### Phase 8.1: Shared Package Extension
+- [ ] Add `IUserRepository` port
+- [ ] Implement `YamlUserRepository` adapter
+- [ ] Implement `SqliteUserRepository` adapter
+- [ ] Implement `ApiPromptAdapter`
 
-#### Phase 8.2: CLI Admin 명령어
-- [ ] `mcctl admin init` - 초기 설정
-- [ ] `mcctl admin user` - 사용자 관리
-- [ ] `mcctl admin api` - API 설정
-- [ ] `mcctl admin service` - 서비스 관리
+#### Phase 8.2: CLI Admin Commands
+- [ ] `mcctl admin init` - Initial setup
+- [ ] `mcctl admin user` - User management
+- [ ] `mcctl admin api` - API settings
+- [ ] `mcctl admin service` - Service management
 
-#### Phase 8.3: mcctl-api 서비스
-- [ ] Fastify 서버 구조
-- [ ] 인증 플러그인 (5가지 접근 모드)
-- [ ] REST API 라우트
+#### Phase 8.3: mcctl-api Service
+- [ ] Fastify server structure
+- [ ] Authentication plugin (5 access modes)
+- [ ] REST API routes
 - [ ] OpenAPI/Swagger
 - [ ] Dockerfile
 
-#### Phase 8.4: mcctl-console 서비스
-- [ ] Next.js 프로젝트 설정
-- [ ] NextAuth.js 인증
-- [ ] BFF 프록시
-- [ ] 대시보드 UI
+#### Phase 8.4: mcctl-console Service
+- [ ] Next.js project setup
+- [ ] NextAuth.js authentication
+- [ ] BFF proxy
+- [ ] Dashboard UI
 - [ ] Dockerfile
 
-#### Phase 8.5: 통합 및 테스트
-- [ ] Docker Compose 통합
-- [ ] E2E 테스트
+#### Phase 8.5: Integration and Testing
+- [ ] Docker Compose integration
+- [ ] E2E tests
 
 ### 8.4 Verification
 
 ```bash
-# 1. 초기화
+# 1. Initialize
 mcctl admin init
 
-# 2. 서비스 시작
+# 2. Start services
 mcctl admin start
 
-# 3. Console 접근
+# 3. Access Console
 open http://localhost:3000
 
-# 4. API 테스트 (api-key 모드)
+# 4. API test (api-key mode)
 curl -H "X-API-Key: mctk_xxx" http://localhost:3001/api/servers
 ```
 

--- a/platform/services/cli/plan.md
+++ b/platform/services/cli/plan.md
@@ -1,50 +1,50 @@
 # Implementation Plan: mcctl CLI
 
-## 상위 문서
-- [전체 프로젝트 Plan](../../../plan.md) - Phase 6, 7
+## Parent Document
+- [Project Plan](../../../plan.md) - Phase 6, 7
 
-## 개요
+## Overview
 
-mcctl CLI 도구의 구현 계획입니다. 현재 구현이 완료된 상태입니다.
+Implementation plan for the mcctl CLI tool. Currently fully implemented.
 
-## 구현 현황
+## Implementation Status
 
-### Phase 1: 기반 구조 ✅
-- [x] `package.json` 생성 (`@minecraft-docker/mcctl`)
-- [x] `tsconfig.json` 설정
-- [x] CLI 진입점 (`src/index.ts`)
-- [x] DI 컨테이너 (`src/di/container.ts`)
+### Phase 1: Foundation ✅
+- [x] Create `package.json` (`@minecraft-docker/mcctl`)
+- [x] Configure `tsconfig.json`
+- [x] CLI entry point (`src/index.ts`)
+- [x] DI container (`src/di/container.ts`)
 
-### Phase 2: 기본 명령어 ✅
-- [x] `mcctl init` - 플랫폼 초기화
-- [x] `mcctl status` - 서버 상태
-- [x] `mcctl create` - 서버 생성
-- [x] `mcctl delete` - 서버 삭제
-- [x] `mcctl start/stop` - 서버 시작/중지
-- [x] `mcctl logs` - 로그 조회
+### Phase 2: Basic Commands ✅
+- [x] `mcctl init` - Platform initialization
+- [x] `mcctl status` - Server status
+- [x] `mcctl create` - Server creation
+- [x] `mcctl delete` - Server deletion
+- [x] `mcctl start/stop` - Server start/stop
+- [x] `mcctl logs` - Log viewing
 
-### Phase 3: 대화형 모드 ✅
-- [x] `@clack/prompts` 통합
-- [x] `ClackPromptAdapter` 구현
-- [x] 대화형 서버 생성
-- [x] 대화형 서버 삭제
+### Phase 3: Interactive Mode ✅
+- [x] `@clack/prompts` integration
+- [x] `ClackPromptAdapter` implementation
+- [x] Interactive server creation
+- [x] Interactive server deletion
 
-### Phase 4: 월드 관리 ✅
+### Phase 4: World Management ✅
 - [x] `mcctl world list`
 - [x] `mcctl world new`
 - [x] `mcctl world assign`
 - [x] `mcctl world release`
 
-### Phase 5: 플레이어 관리 ✅
-- [x] `mcctl player` - 통합 대화형 관리
+### Phase 5: Player Management ✅
+- [x] `mcctl player` - Unified interactive management
 - [x] `mcctl whitelist`
 - [x] `mcctl ban`
 - [x] `mcctl op`
 - [x] `mcctl kick`
-- [x] Mojang API 연동
-- [x] 플레이어 캐시 시스템
+- [x] Mojang API integration
+- [x] Player cache system
 
-### Phase 6: 백업 ✅
+### Phase 6: Backup ✅
 - [x] `mcctl backup status`
 - [x] `mcctl backup push`
 - [x] `mcctl backup history`
@@ -52,23 +52,23 @@ mcctl CLI 도구의 구현 계획입니다. 현재 구현이 완료된 상태입
 - [x] `mcctl server-backup`
 - [x] `mcctl server-restore`
 
-### Phase 7: 인프라 관리 ✅
-- [x] `mcctl up` - 전체 시작
-- [x] `mcctl down` - 전체 중지
+### Phase 7: Infrastructure Management ✅
+- [x] `mcctl up` - Start all
+- [x] `mcctl down` - Stop all
 - [x] `mcctl router start/stop/restart`
 
-## 향후 계획
+## Future Plans
 
-### Phase 8: Admin 명령어 (예정)
-- [ ] `mcctl admin init` - Admin 서비스 초기화
-- [ ] `mcctl admin start/stop` - 서비스 관리
-- [ ] `mcctl admin user` - 사용자 관리
-- [ ] `mcctl admin api` - API 설정
+### Phase 8: Admin Commands (Planned)
+- [ ] `mcctl admin init` - Admin service initialization
+- [ ] `mcctl admin start/stop` - Service management
+- [ ] `mcctl admin user` - User management
+- [ ] `mcctl admin api` - API settings
 
-→ 상세 계획: [mcctl-api Plan](../mcctl-api/plan.md), [mcctl-console Plan](../mcctl-console/plan.md)
+→ Detailed plans: [mcctl-api Plan](../mcctl-api/plan.md), [mcctl-console Plan](../mcctl-console/plan.md)
 
 ## Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 계획 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial plan |

--- a/platform/services/cli/prd.md
+++ b/platform/services/cli/prd.md
@@ -1,35 +1,35 @@
 # PRD: mcctl - CLI Tool
 
-## 상위 문서
-- [전체 프로젝트 PRD](../../../prd.md) - Section 9
+## Parent Document
+- [Project PRD](../../../prd.md) - Section 9
 
-## 1. 개요
+## 1. Overview
 
-### 1.1 목적
-마인크래프트 서버 관리를 위한 CLI(Command Line Interface) 도구입니다. 대화형 프롬프트와 명령어 인자를 모두 지원합니다.
+### 1.1 Purpose
+Command-line interface (CLI) tool for Minecraft server management. Supports both interactive prompts and command-line arguments.
 
-### 1.2 범위
-- 서버 생성/삭제/시작/중지
-- 월드 관리 (생성, 할당, 해제)
-- 플레이어 관리 (화이트리스트, 밴, OP, 킥)
-- 백업/복원
-- 플랫폼 초기화
+### 1.2 Scope
+- Server creation/deletion/start/stop
+- World management (create, assign, release)
+- Player management (whitelist, ban, OP, kick)
+- Backup/restore
+- Platform initialization
 
-### 1.3 비목표
-- 웹 UI 제공 (mcctl-console 담당)
-- REST API 제공 (mcctl-api 담당)
+### 1.3 Non-Goals
+- Web UI (handled by mcctl-console)
+- REST API (handled by mcctl-api)
 
-## 2. 기술 스택
+## 2. Tech Stack
 
-| 구성요소 | 기술 | 버전 |
-|---------|------|------|
+| Component | Technology | Version |
+|-----------|------------|---------|
 | Runtime | Node.js | 18+ |
 | Language | TypeScript | 5.x |
 | Prompts | @clack/prompts | 0.7.x |
 | Colors | picocolors | 1.x |
 | Shared | @minecraft-docker/shared | workspace |
 
-## 3. 아키텍처
+## 3. Architecture
 
 ### 3.1 Hexagonal Architecture
 
@@ -51,22 +51,22 @@
                           │
 ┌─────────────────────────▼───────────────────────────────────┐
 │                 INFRASTRUCTURE LAYER                         │
-│   ClackPromptAdapter (CLI 전용) + Shared Adapters            │
+│   ClackPromptAdapter (CLI-specific) + Shared Adapters        │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 디렉토리 구조
+### 3.2 Directory Structure
 
 ```
 platform/services/cli/
-├── prd.md                      # 이 문서
-├── plan.md                     # 구현 계획
-├── README.md                   # npm 패키지 설명
+├── prd.md                      # This document
+├── plan.md                     # Implementation plan
+├── README.md                   # npm package description
 ├── package.json                # @minecraft-docker/mcctl
 ├── tsconfig.json
 ├── src/
-│   ├── index.ts                # CLI 진입점
-│   ├── commands/               # 명령어 구현
+│   ├── index.ts                # CLI entry point
+│   ├── commands/               # Command implementations
 │   │   ├── create.ts
 │   │   ├── delete.ts
 │   │   ├── status.ts
@@ -79,63 +79,63 @@ platform/services/cli/
 │   │   ├── backup.ts
 │   │   └── ...
 │   ├── adapters/
-│   │   └── ClackPromptAdapter.ts  # CLI 전용 어댑터
+│   │   └── ClackPromptAdapter.ts  # CLI-specific adapter
 │   ├── di/
-│   │   └── container.ts        # DI 컨테이너
+│   │   └── container.ts        # DI container
 │   └── lib/
-│       ├── prompts/            # 재사용 프롬프트 컴포넌트
-│       ├── mojang-api.ts       # Mojang API 클라이언트
-│       └── player-cache.ts     # 플레이어 캐시
+│       ├── prompts/            # Reusable prompt components
+│       ├── mojang-api.ts       # Mojang API client
+│       └── player-cache.ts     # Player cache
 └── tests/
 ```
 
-## 4. 명령어 구조
+## 4. Command Structure
 
-### 4.1 서버 관리
+### 4.1 Server Management
 
-| 명령어 | 설명 |
-|--------|------|
-| `mcctl init` | 플랫폼 초기화 |
-| `mcctl create [name]` | 서버 생성 |
-| `mcctl delete [name]` | 서버 삭제 |
-| `mcctl status` | 서버 상태 조회 |
-| `mcctl start <name>` | 서버 시작 |
-| `mcctl stop <name>` | 서버 중지 |
-| `mcctl logs <name>` | 서버 로그 |
-| `mcctl console <name>` | RCON 콘솔 |
+| Command | Description |
+|---------|-------------|
+| `mcctl init` | Initialize platform |
+| `mcctl create [name]` | Create server |
+| `mcctl delete [name]` | Delete server |
+| `mcctl status` | View server status |
+| `mcctl start <name>` | Start server |
+| `mcctl stop <name>` | Stop server |
+| `mcctl logs <name>` | View server logs |
+| `mcctl console <name>` | RCON console |
 
-### 4.2 월드 관리
+### 4.2 World Management
 
-| 명령어 | 설명 |
-|--------|------|
-| `mcctl world list` | 월드 목록 |
-| `mcctl world new [name]` | 월드 생성 |
-| `mcctl world assign` | 월드 할당 |
-| `mcctl world release` | 월드 해제 |
+| Command | Description |
+|---------|-------------|
+| `mcctl world list` | List worlds |
+| `mcctl world new [name]` | Create world |
+| `mcctl world assign` | Assign world |
+| `mcctl world release` | Release world |
 
-### 4.3 플레이어 관리
+### 4.3 Player Management
 
-| 명령어 | 설명 |
-|--------|------|
-| `mcctl player` | 통합 플레이어 관리 (대화형) |
-| `mcctl player info <name>` | 플레이어 정보 |
-| `mcctl whitelist <server> <action>` | 화이트리스트 |
-| `mcctl ban <server> <action>` | 밴/언밴 |
-| `mcctl op <server> <action>` | OP 관리 |
-| `mcctl kick <server> <player>` | 킥 |
+| Command | Description |
+|---------|-------------|
+| `mcctl player` | Unified player management (interactive) |
+| `mcctl player info <name>` | Player info |
+| `mcctl whitelist <server> <action>` | Whitelist |
+| `mcctl ban <server> <action>` | Ban/unban |
+| `mcctl op <server> <action>` | OP management |
+| `mcctl kick <server> <player>` | Kick |
 
-### 4.4 백업
+### 4.4 Backup
 
-| 명령어 | 설명 |
-|--------|------|
-| `mcctl backup status` | 백업 상태 |
-| `mcctl backup push` | 백업 푸시 |
-| `mcctl backup history` | 백업 이력 |
-| `mcctl backup restore` | 백업 복원 |
+| Command | Description |
+|---------|-------------|
+| `mcctl backup status` | Backup status |
+| `mcctl backup push` | Push backup |
+| `mcctl backup history` | Backup history |
+| `mcctl backup restore` | Restore backup |
 
-## 5. 대화형 모드
+## 5. Interactive Mode
 
-### 5.1 서버 생성 플로우
+### 5.1 Server Creation Flow
 
 ```
 $ mcctl create
@@ -160,9 +160,9 @@ $ mcctl create
    Connect via: myserver.local:25565
 ```
 
-## 6. 의존성
+## 6. Dependencies
 
-### 6.1 내부 의존성
+### 6.1 Internal Dependencies
 
 ```json
 {
@@ -172,7 +172,7 @@ $ mcctl create
 }
 ```
 
-### 6.2 외부 의존성
+### 6.2 External Dependencies
 
 ```json
 {
@@ -183,15 +183,15 @@ $ mcctl create
 }
 ```
 
-## 7. 환경 변수
+## 7. Environment Variables
 
-| 변수 | 설명 | 기본값 |
-|------|------|--------|
-| `MCCTL_ROOT` | 데이터 디렉토리 | `~/minecraft-servers` |
-| `MCCTL_SUDO_PASSWORD` | sudo 비밀번호 (자동화용) | - |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MCCTL_ROOT` | Data directory | `~/minecraft-servers` |
+| `MCCTL_SUDO_PASSWORD` | sudo password (for automation) | - |
 
 ## 8. Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 PRD 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial PRD |

--- a/platform/services/mcctl-api/plan.md
+++ b/platform/services/mcctl-api/plan.md
@@ -1,102 +1,102 @@
 # Implementation Plan: mcctl-api
 
-## 상위 문서
-- [전체 프로젝트 Plan](../../../plan.md) - Phase 8
+## Parent Document
+- [Project Plan](../../../plan.md) - Phase 8
 
-## 개요
+## Overview
 
-mcctl-api REST API 서비스의 구현 계획입니다.
+Implementation plan for mcctl-api REST API service.
 
-## Phase 1: 프로젝트 기반 구조
+## Phase 1: Project Foundation
 
-### 1.1 패키지 설정
-- [ ] `package.json` 생성 (`@minecraft-docker/mcctl-api`)
-- [ ] `tsconfig.json` 설정
-- [ ] 의존성 설치 (fastify, @fastify/swagger)
-- [ ] pnpm-workspace.yaml에 패키지 추가
+### 1.1 Package Setup
+- [ ] Create `package.json` (`@minecraft-docker/mcctl-api`)
+- [ ] Configure `tsconfig.json`
+- [ ] Install dependencies (fastify, @fastify/swagger)
+- [ ] Add package to pnpm-workspace.yaml
 
-### 1.2 기본 서버 구조
-- [ ] `src/index.ts` - 진입점
-- [ ] `src/server.ts` - Fastify 서버 설정
-- [ ] `src/config.ts` - 환경 변수 로더
+### 1.2 Basic Server Structure
+- [ ] `src/index.ts` - Entry point
+- [ ] `src/server.ts` - Fastify server setup
+- [ ] `src/config.ts` - Environment variable loader
 
-### 1.3 DI 컨테이너
-- [ ] `src/di/container.ts` - 의존성 주입 컨테이너
-- [ ] shared 패키지의 Use Case, Repository 연결
+### 1.3 DI Container
+- [ ] `src/di/container.ts` - Dependency injection container
+- [ ] Connect shared package Use Cases and Repositories
 
-## Phase 2: 인증 플러그인
+## Phase 2: Authentication Plugin
 
-### 2.1 접근 모드 구현
-- [ ] `src/plugins/auth.ts` - 인증 플러그인
-- [ ] `internal` 모드 - Docker 네트워크 검증
-- [ ] `api-key` 모드 - X-API-Key 헤더 검증
-- [ ] `ip-whitelist` 모드 - IP 화이트리스트
-- [ ] `api-key-ip` 모드 - 복합 인증
-- [ ] `open` 모드 - 인증 없음 (개발용)
+### 2.1 Access Mode Implementation
+- [ ] `src/plugins/auth.ts` - Authentication plugin
+- [ ] `internal` mode - Docker network verification
+- [ ] `api-key` mode - X-API-Key header verification
+- [ ] `ip-whitelist` mode - IP whitelist
+- [ ] `api-key-ip` mode - Combined authentication
+- [ ] `open` mode - No authentication (development only)
 
-### 2.2 에러 핸들링
-- [ ] `src/plugins/error-handler.ts` - 통합 에러 핸들러
-- [ ] 표준 에러 응답 포맷
+### 2.2 Error Handling
+- [ ] `src/plugins/error-handler.ts` - Unified error handler
+- [ ] Standard error response format
 
-## Phase 3: API 라우트 구현
+## Phase 3: API Route Implementation
 
-### 3.1 서버 관리 API
+### 3.1 Server Management API
 - [ ] `src/routes/servers.ts`
-- [ ] `GET /api/servers` - 서버 목록
-- [ ] `GET /api/servers/:name` - 서버 상세
-- [ ] `POST /api/servers` - 서버 생성
-- [ ] `DELETE /api/servers/:name` - 서버 삭제
-- [ ] `POST /api/servers/:name/start` - 서버 시작
-- [ ] `POST /api/servers/:name/stop` - 서버 중지
-- [ ] `POST /api/servers/:name/restart` - 서버 재시작
-- [ ] `GET /api/servers/:name/logs` - 서버 로그
-- [ ] `POST /api/servers/:name/exec` - RCON 명령 실행
+- [ ] `GET /api/servers` - Server list
+- [ ] `GET /api/servers/:name` - Server details
+- [ ] `POST /api/servers` - Create server
+- [ ] `DELETE /api/servers/:name` - Delete server
+- [ ] `POST /api/servers/:name/start` - Start server
+- [ ] `POST /api/servers/:name/stop` - Stop server
+- [ ] `POST /api/servers/:name/restart` - Restart server
+- [ ] `GET /api/servers/:name/logs` - Server logs
+- [ ] `POST /api/servers/:name/exec` - RCON command execution
 
-### 3.2 월드 관리 API
+### 3.2 World Management API
 - [ ] `src/routes/worlds.ts`
-- [ ] `GET /api/worlds` - 월드 목록
-- [ ] `POST /api/worlds` - 월드 생성
-- [ ] `POST /api/worlds/:name/assign` - 월드 할당
-- [ ] `POST /api/worlds/:name/release` - 월드 해제
+- [ ] `GET /api/worlds` - World list
+- [ ] `POST /api/worlds` - Create world
+- [ ] `POST /api/worlds/:name/assign` - Assign world
+- [ ] `POST /api/worlds/:name/release` - Release world
 
-### 3.3 플레이어 관리 API
+### 3.3 Player Management API
 - [ ] `src/routes/players.ts`
-- [ ] 화이트리스트, 밴, OP, 킥 API
+- [ ] Whitelist, ban, OP, kick APIs
 
-### 3.4 백업 API
+### 3.4 Backup API
 - [ ] `src/routes/backup.ts`
-- [ ] 백업 상태, 푸시, 이력, 복원 API
+- [ ] Backup status, push, history, restore APIs
 
-### 3.5 시스템 API
+### 3.5 System API
 - [ ] `src/routes/health.ts`
-- [ ] 헬스 체크, mc-router 상태 API
+- [ ] Health check, mc-router status APIs
 
 ## Phase 4: Swagger/OpenAPI
 
-- [ ] `src/plugins/swagger.ts` - Swagger 플러그인
-- [ ] 스키마 정의
-- [ ] `/docs` 엔드포인트 설정
+- [ ] `src/plugins/swagger.ts` - Swagger plugin
+- [ ] Schema definitions
+- [ ] `/docs` endpoint setup
 
-## Phase 5: Docker 설정
+## Phase 5: Docker Setup
 
-- [ ] `Dockerfile` 작성
-- [ ] Multi-stage 빌드
+- [ ] Create `Dockerfile`
+- [ ] Multi-stage build
 - [ ] GitHub Actions CI/CD
 
-## Phase 6: 테스트
+## Phase 6: Testing
 
-- [ ] 단위 테스트 (vitest)
-- [ ] 통합 테스트 (supertest)
+- [ ] Unit tests (vitest)
+- [ ] Integration tests (supertest)
 
-## 완료 기준
+## Completion Criteria
 
-1. 모든 API 엔드포인트 구현 및 테스트 통과
-2. 5가지 접근 모드 정상 동작
-3. OpenAPI 문서 자동 생성
-4. Docker 이미지 빌드 성공
+1. All API endpoints implemented and tests passing
+2. All 5 access modes working correctly
+3. OpenAPI documentation auto-generated
+4. Docker image builds successfully
 
 ## Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 계획 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial plan |

--- a/platform/services/mcctl-api/prd.md
+++ b/platform/services/mcctl-api/prd.md
@@ -1,36 +1,36 @@
 # PRD: mcctl-api - REST API Service
 
-## 상위 문서
-- [전체 프로젝트 PRD](../../../prd.md) - Section 10
+## Parent Document
+- [Project PRD](../../../prd.md) - Section 10
 
-## 1. 개요
+## 1. Overview
 
-### 1.1 목적
-마인크래프트 서버 관리를 위한 내부 REST API 서비스입니다. mcctl CLI와 동일한 기능을 HTTP API로 제공합니다.
+### 1.1 Purpose
+Internal REST API service for Minecraft server management. Provides the same functionality as mcctl CLI via HTTP API.
 
-### 1.2 범위
-- 서버 관리 API (생성, 삭제, 시작, 중지)
-- 월드 관리 API (목록, 할당, 해제)
-- 플레이어 관리 API (화이트리스트, 밴, 킥, OP)
-- 백업 API (푸시, 복원, 이력)
-- 헬스 체크 API
+### 1.2 Scope
+- Server management API (create, delete, start, stop)
+- World management API (list, assign, release)
+- Player management API (whitelist, ban, kick, OP)
+- Backup API (push, restore, history)
+- Health check API
 
-### 1.3 비목표
-- 사용자 인터페이스 제공 (mcctl-console 담당)
-- 사용자 세션 관리 (mcctl-console 담당)
-- 직접적인 클라이언트 접근 지원 (BFF 패턴 사용)
+### 1.3 Non-Goals
+- User interface (handled by mcctl-console)
+- User session management (handled by mcctl-console)
+- Direct client access (uses BFF pattern)
 
-## 2. 기술 스택
+## 2. Tech Stack
 
-| 구성요소 | 기술 | 버전 |
-|---------|------|------|
+| Component | Technology | Version |
+|-----------|------------|---------|
 | Runtime | Node.js | 18+ |
 | Framework | Fastify | 4.x |
 | Language | TypeScript | 5.x |
 | API Docs | @fastify/swagger | 8.x |
 | Shared | @minecraft-docker/shared | workspace |
 
-## 3. 아키텍처
+## 3. Architecture
 
 ### 3.1 Hexagonal Architecture
 
@@ -58,52 +58,52 @@
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 디렉토리 구조
+### 3.2 Directory Structure
 
 ```
 platform/services/mcctl-api/
-├── prd.md                      # 이 문서
-├── plan.md                     # 구현 계획
+├── prd.md                      # This document
+├── plan.md                     # Implementation plan
 ├── package.json                # @minecraft-docker/mcctl-api
 ├── tsconfig.json
 ├── src/
-│   ├── index.ts                # 진입점
-│   ├── server.ts               # Fastify 서버 설정
-│   ├── config.ts               # 설정 로더
+│   ├── index.ts                # Entry point
+│   ├── server.ts               # Fastify server setup
+│   ├── config.ts               # Configuration loader
 │   ├── routes/
-│   │   ├── index.ts            # 라우트 등록
+│   │   ├── index.ts            # Route registration
 │   │   ├── servers.ts          # /api/servers/*
 │   │   ├── worlds.ts           # /api/worlds/*
 │   │   ├── players.ts          # /api/players/*
 │   │   ├── backup.ts           # /api/backup/*
 │   │   └── health.ts           # /api/health
 │   ├── plugins/
-│   │   ├── auth.ts             # API Key/IP 인증
-│   │   ├── swagger.ts          # OpenAPI 문서
-│   │   └── error-handler.ts    # 에러 핸들링
+│   │   ├── auth.ts             # API Key/IP authentication
+│   │   ├── swagger.ts          # OpenAPI documentation
+│   │   └── error-handler.ts    # Error handling
 │   ├── adapters/
-│   │   └── ApiPromptAdapter.ts # 비대화형 IPromptPort
+│   │   └── ApiPromptAdapter.ts # Non-interactive IPromptPort
 │   └── di/
-│       └── container.ts        # DI 컨테이너
+│       └── container.ts        # DI container
 ├── tests/
 │   ├── routes/
 │   └── plugins/
 └── Dockerfile
 ```
 
-## 4. API 접근 모드
+## 4. API Access Modes
 
-### 4.1 접근 모드 종류
+### 4.1 Access Mode Types
 
-| 모드 | 포트 노출 | 인증 방식 | 용도 |
-|------|----------|----------|------|
-| `internal` | 없음 (Docker 네트워크만) | 없음 | 기본값, mcctl-console 전용 |
-| `api-key` | 3001 노출 | X-API-Key 헤더 | 외부 도구 연동 |
-| `ip-whitelist` | 3001 노출 | IP 검증 | 신뢰된 네트워크 |
-| `api-key-ip` | 3001 노출 | 둘 다 | 최고 보안 |
-| `open` | 3001 노출 | 없음 | 개발 전용 |
+| Mode | Port Exposure | Authentication | Use Case |
+|------|---------------|----------------|----------|
+| `internal` | None (Docker network only) | None | Default, mcctl-console only |
+| `api-key` | 3001 exposed | X-API-Key header | External tool integration |
+| `ip-whitelist` | 3001 exposed | IP verification | Trusted networks |
+| `api-key-ip` | 3001 exposed | Both | Maximum security |
+| `open` | 3001 exposed | None | Development only |
 
-### 4.2 인증 플러그인 구현
+### 4.2 Authentication Plugin Implementation
 
 ```typescript
 // plugins/auth.ts
@@ -150,67 +150,67 @@ const authPlugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, option
 };
 ```
 
-## 5. API 엔드포인트
+## 5. API Endpoints
 
-### 5.1 서버 관리
+### 5.1 Server Management
 
-| Method | Endpoint | 설명 |
-|--------|----------|------|
-| GET | `/api/servers` | 서버 목록 |
-| GET | `/api/servers/:name` | 서버 상세 정보 |
-| POST | `/api/servers` | 서버 생성 |
-| DELETE | `/api/servers/:name` | 서버 삭제 |
-| POST | `/api/servers/:name/start` | 서버 시작 |
-| POST | `/api/servers/:name/stop` | 서버 중지 |
-| POST | `/api/servers/:name/restart` | 서버 재시작 |
-| GET | `/api/servers/:name/logs` | 서버 로그 |
-| POST | `/api/servers/:name/exec` | RCON 명령 실행 |
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/servers` | List servers |
+| GET | `/api/servers/:name` | Server details |
+| POST | `/api/servers` | Create server |
+| DELETE | `/api/servers/:name` | Delete server |
+| POST | `/api/servers/:name/start` | Start server |
+| POST | `/api/servers/:name/stop` | Stop server |
+| POST | `/api/servers/:name/restart` | Restart server |
+| GET | `/api/servers/:name/logs` | Server logs |
+| POST | `/api/servers/:name/exec` | Execute RCON command |
 
-### 5.2 월드 관리
+### 5.2 World Management
 
-| Method | Endpoint | 설명 |
-|--------|----------|------|
-| GET | `/api/worlds` | 월드 목록 |
-| POST | `/api/worlds` | 월드 생성 |
-| POST | `/api/worlds/:name/assign` | 월드 할당 |
-| POST | `/api/worlds/:name/release` | 월드 해제 |
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/worlds` | List worlds |
+| POST | `/api/worlds` | Create world |
+| POST | `/api/worlds/:name/assign` | Assign world |
+| POST | `/api/worlds/:name/release` | Release world |
 
-### 5.3 플레이어 관리
+### 5.3 Player Management
 
-| Method | Endpoint | 설명 |
-|--------|----------|------|
-| GET | `/api/servers/:name/players` | 온라인 플레이어 |
-| GET | `/api/players/:username` | 플레이어 정보 |
-| GET | `/api/servers/:name/whitelist` | 화이트리스트 |
-| POST | `/api/servers/:name/whitelist` | 화이트리스트 추가 |
-| DELETE | `/api/servers/:name/whitelist/:player` | 화이트리스트 제거 |
-| GET | `/api/servers/:name/bans` | 밴 목록 |
-| POST | `/api/servers/:name/bans` | 플레이어 밴 |
-| DELETE | `/api/servers/:name/bans/:player` | 밴 해제 |
-| POST | `/api/servers/:name/kick` | 플레이어 킥 |
-| GET | `/api/servers/:name/ops` | OP 목록 |
-| POST | `/api/servers/:name/ops` | OP 추가 |
-| DELETE | `/api/servers/:name/ops/:player` | OP 제거 |
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/servers/:name/players` | Online players |
+| GET | `/api/players/:username` | Player info |
+| GET | `/api/servers/:name/whitelist` | Whitelist |
+| POST | `/api/servers/:name/whitelist` | Add to whitelist |
+| DELETE | `/api/servers/:name/whitelist/:player` | Remove from whitelist |
+| GET | `/api/servers/:name/bans` | Ban list |
+| POST | `/api/servers/:name/bans` | Ban player |
+| DELETE | `/api/servers/:name/bans/:player` | Unban player |
+| POST | `/api/servers/:name/kick` | Kick player |
+| GET | `/api/servers/:name/ops` | OP list |
+| POST | `/api/servers/:name/ops` | Add OP |
+| DELETE | `/api/servers/:name/ops/:player` | Remove OP |
 
-### 5.4 백업
+### 5.4 Backup
 
-| Method | Endpoint | 설명 |
-|--------|----------|------|
-| GET | `/api/backup/status` | 백업 상태 |
-| POST | `/api/backup/push` | 백업 푸시 |
-| GET | `/api/backup/history` | 백업 이력 |
-| POST | `/api/backup/restore` | 백업 복원 |
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/backup/status` | Backup status |
+| POST | `/api/backup/push` | Push backup |
+| GET | `/api/backup/history` | Backup history |
+| POST | `/api/backup/restore` | Restore backup |
 
-### 5.5 시스템
+### 5.5 System
 
-| Method | Endpoint | 설명 |
-|--------|----------|------|
-| GET | `/api/health` | 헬스 체크 |
-| GET | `/api/router/status` | mc-router 상태 |
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/health` | Health check |
+| GET | `/api/router/status` | mc-router status |
 
-## 6. 응답 형식
+## 6. Response Format
 
-### 6.1 성공 응답
+### 6.1 Success Response
 
 ```json
 {
@@ -219,7 +219,7 @@ const authPlugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, option
 }
 ```
 
-### 6.2 에러 응답
+### 6.2 Error Response
 
 ```json
 {
@@ -231,31 +231,31 @@ const authPlugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, option
 }
 ```
 
-### 6.3 에러 코드
+### 6.3 Error Codes
 
-| 코드 | HTTP | 설명 |
-|------|------|------|
-| `UNAUTHORIZED` | 401 | 인증 실패 |
-| `FORBIDDEN` | 403 | 접근 거부 |
-| `NOT_FOUND` | 404 | 리소스 없음 |
-| `CONFLICT` | 409 | 리소스 충돌 (서버 실행 중 삭제 등) |
-| `INTERNAL_ERROR` | 500 | 내부 오류 |
+| Code | HTTP | Description |
+|------|------|-------------|
+| `UNAUTHORIZED` | 401 | Authentication failed |
+| `FORBIDDEN` | 403 | Access denied |
+| `NOT_FOUND` | 404 | Resource not found |
+| `CONFLICT` | 409 | Resource conflict (e.g., deleting running server) |
+| `INTERNAL_ERROR` | 500 | Internal error |
 
-## 7. 환경 변수
+## 7. Environment Variables
 
-| 변수 | 설명 | 기본값 |
-|------|------|--------|
-| `MCCTL_ROOT` | 데이터 디렉토리 | `/data` |
-| `API_ACCESS_MODE` | 접근 모드 | `internal` |
-| `API_KEY` | API 키 (api-key 모드) | - |
-| `API_KEY_HEADER` | API 키 헤더 이름 | `X-API-Key` |
-| `API_IP_WHITELIST` | IP 화이트리스트 (쉼표 구분) | - |
-| `API_PORT` | 리스닝 포트 | `3001` |
-| `USER_STORE_TYPE` | 사용자 저장소 타입 | `yaml` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MCCTL_ROOT` | Data directory | `/data` |
+| `API_ACCESS_MODE` | Access mode | `internal` |
+| `API_KEY` | API key (api-key mode) | - |
+| `API_KEY_HEADER` | API key header name | `X-API-Key` |
+| `API_IP_WHITELIST` | IP whitelist (comma-separated) | - |
+| `API_PORT` | Listening port | `3001` |
+| `USER_STORE_TYPE` | User storage type | `yaml` |
 
-## 8. 의존성
+## 8. Dependencies
 
-### 8.1 내부 의존성
+### 8.1 Internal Dependencies
 
 ```json
 {
@@ -265,7 +265,7 @@ const authPlugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, option
 }
 ```
 
-### 8.2 외부 의존성
+### 8.2 External Dependencies
 
 ```json
 {
@@ -278,27 +278,27 @@ const authPlugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, option
 }
 ```
 
-## 9. 테스트 계획
+## 9. Test Plan
 
-### 9.1 단위 테스트
-- 라우트 핸들러 테스트
-- 인증 플러그인 테스트
-- 에러 핸들러 테스트
+### 9.1 Unit Tests
+- Route handler tests
+- Authentication plugin tests
+- Error handler tests
 
-### 9.2 통합 테스트
-- supertest를 사용한 API 엔드포인트 테스트
-- 인증 모드별 접근 테스트
+### 9.2 Integration Tests
+- API endpoint tests with supertest
+- Access mode authentication tests
 
-### 9.3 수동 테스트
+### 9.3 Manual Tests
 
 ```bash
-# 헬스 체크
+# Health check
 curl http://localhost:3001/api/health
 
-# 서버 목록 (api-key 모드)
+# Server list (api-key mode)
 curl -H "X-API-Key: mctk_xxx" http://localhost:3001/api/servers
 
-# 서버 생성
+# Create server
 curl -X POST -H "Content-Type: application/json" \
   -H "X-API-Key: mctk_xxx" \
   -d '{"name":"myserver","type":"PAPER","version":"1.21.1"}' \
@@ -307,6 +307,6 @@ curl -X POST -H "Content-Type: application/json" \
 
 ## 10. Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 PRD 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial PRD |

--- a/platform/services/mcctl-console/plan.md
+++ b/platform/services/mcctl-console/plan.md
@@ -1,79 +1,79 @@
 # Implementation Plan: mcctl-console
 
-## 상위 문서
-- [전체 프로젝트 Plan](../../../plan.md) - Phase 8
+## Parent Document
+- [Project Plan](../../../plan.md) - Phase 8
 
-## 개요
+## Overview
 
-mcctl-console 관리 콘솔 서비스의 구현 계획입니다.
+Implementation plan for mcctl-console management console service.
 
-## Phase 1: 프로젝트 기반 구조
+## Phase 1: Project Foundation
 
-### 1.1 패키지 설정
-- [ ] `package.json` 생성 (`@minecraft-docker/mcctl-console`)
-- [ ] `tsconfig.json` 설정
-- [ ] `next.config.js` 설정
-- [ ] `tailwind.config.js` 설정
+### 1.1 Package Setup
+- [ ] Create `package.json` (`@minecraft-docker/mcctl-console`)
+- [ ] Configure `tsconfig.json`
+- [ ] Configure `next.config.js`
+- [ ] Configure `tailwind.config.js`
 
-### 1.2 기본 레이아웃
-- [ ] `src/app/layout.tsx` - 루트 레이아웃
-- [ ] `src/components/layout/Sidebar.tsx` - 사이드바
-- [ ] `src/components/layout/Header.tsx` - 헤더
+### 1.2 Basic Layout
+- [ ] `src/app/layout.tsx` - Root layout
+- [ ] `src/components/layout/Sidebar.tsx` - Sidebar
+- [ ] `src/components/layout/Header.tsx` - Header
 
-### 1.3 UI 컴포넌트
-- [ ] shadcn/ui 설정
-- [ ] 기본 컴포넌트 추가
+### 1.3 UI Components
+- [ ] Setup shadcn/ui
+- [ ] Add base components
 
-## Phase 2: 인증 시스템
+## Phase 2: Authentication System
 
-- [ ] NextAuth 설정
-- [ ] 로그인 페이지
-- [ ] 세션 관리
+- [ ] NextAuth configuration
+- [ ] Login page
+- [ ] Session management
 
-## Phase 3: BFF 프록시
+## Phase 3: BFF Proxy
 
-- [ ] API 프록시 라우트
-- [ ] API 클라이언트
-- [ ] React Query 설정
+- [ ] API proxy routes
+- [ ] API client
+- [ ] React Query setup
 
-## Phase 4: 대시보드
+## Phase 4: Dashboard
 
-- [ ] 대시보드 페이지
-- [ ] 통계 위젯
-- [ ] 서버 개요
+- [ ] Dashboard page
+- [ ] Stats widgets
+- [ ] Server overview
 
-## Phase 5: 서버 관리
+## Phase 5: Server Management
 
-- [ ] 서버 목록
-- [ ] 서버 상세
-- [ ] RCON 콘솔
+- [ ] Server list
+- [ ] Server details
+- [ ] RCON console
 
-## Phase 6: 월드/플레이어/백업 관리
+## Phase 6: World/Player/Backup Management
 
-- [ ] 월드 관리 페이지
-- [ ] 플레이어 관리 페이지
-- [ ] 백업 관리 페이지
+- [ ] World management page
+- [ ] Player management page
+- [ ] Backup management page
 
-## Phase 7: Docker 설정
+## Phase 7: Docker Setup
 
-- [ ] Dockerfile 작성
-- [ ] CI/CD 설정
+- [ ] Create Dockerfile
+- [ ] CI/CD setup
 
-## Phase 8: 테스트
+## Phase 8: Testing
 
-- [ ] 컴포넌트 테스트
-- [ ] E2E 테스트
+- [ ] Component tests
+- [ ] E2E tests
 
-## 완료 기준
+## Completion Criteria
 
-1. 모든 페이지 구현 및 정상 동작
-2. NextAuth 인증 정상 동작
-3. BFF 프록시 통한 API 호출 성공
-4. 반응형 디자인 (모바일 지원)
-5. Docker 이미지 빌드 성공
+1. All pages implemented and working correctly
+2. NextAuth authentication working
+3. BFF proxy API calls successful
+4. Responsive design (mobile support)
+5. Docker image builds successfully
 
 ## Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 계획 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial plan |

--- a/platform/services/mcctl-console/prd.md
+++ b/platform/services/mcctl-console/prd.md
@@ -1,30 +1,30 @@
 # PRD: mcctl-console - Management Console
 
-## 상위 문서
-- [전체 프로젝트 PRD](../../../prd.md) - Section 10
+## Parent Document
+- [Project PRD](../../../prd.md) - Section 10
 
-## 1. 개요
+## 1. Overview
 
-### 1.1 목적
-마인크래프트 서버 관리를 위한 웹 기반 관리 콘솔입니다. BFF(Backend-For-Frontend) 패턴을 사용하여 mcctl-api와 통신합니다.
+### 1.1 Purpose
+Web-based management console for Minecraft servers. Uses BFF (Backend-For-Frontend) pattern to communicate with mcctl-api.
 
-### 1.2 범위
-- 사용자 인증 및 세션 관리
-- 서버 관리 대시보드
-- 월드 관리 UI
-- 플레이어 관리 UI
-- 백업 관리 UI
-- BFF 프록시 (클라이언트 → mcctl-api)
+### 1.2 Scope
+- User authentication and session management
+- Server management dashboard
+- World management UI
+- Player management UI
+- Backup management UI
+- BFF proxy (client → mcctl-api)
 
-### 1.3 비목표
-- 직접 Docker API 호출 (mcctl-api 담당)
-- 사용자 정보 저장 (shared의 UserRepository 사용)
-- 외부 API 노출 (내부 통신만)
+### 1.3 Non-Goals
+- Direct Docker API calls (handled by mcctl-api)
+- User data storage (uses shared UserRepository)
+- External API exposure (internal communication only)
 
-## 2. 기술 스택
+## 2. Tech Stack
 
-| 구성요소 | 기술 | 버전 |
-|---------|------|------|
+| Component | Technology | Version |
+|-----------|------------|---------|
 | Framework | Next.js (App Router) | 14.x |
 | Language | TypeScript | 5.x |
 | Auth | NextAuth.js | 5.x |
@@ -33,9 +33,9 @@
 | State | React Query | 5.x |
 | Shared | @minecraft-docker/shared | workspace |
 
-## 3. 아키텍처
+## 3. Architecture
 
-### 3.1 BFF 패턴
+### 3.1 BFF Pattern
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -60,100 +60,100 @@
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 디렉토리 구조
+### 3.2 Directory Structure
 
 ```
 platform/services/mcctl-console/
-├── prd.md                      # 이 문서
-├── plan.md                     # 구현 계획
+├── prd.md                      # This document
+├── plan.md                     # Implementation plan
 ├── package.json                # @minecraft-docker/mcctl-console
 ├── tsconfig.json
 ├── next.config.js
 ├── tailwind.config.js
 ├── src/
 │   ├── app/
-│   │   ├── layout.tsx          # 루트 레이아웃
-│   │   ├── page.tsx            # 홈 (→ 대시보드 리다이렉트)
+│   │   ├── layout.tsx          # Root layout
+│   │   ├── page.tsx            # Home (→ dashboard redirect)
 │   │   ├── login/
-│   │   │   └── page.tsx        # 로그인 페이지
+│   │   │   └── page.tsx        # Login page
 │   │   ├── dashboard/
-│   │   │   └── page.tsx        # 대시보드
+│   │   │   └── page.tsx        # Dashboard
 │   │   ├── servers/
-│   │   │   ├── page.tsx        # 서버 목록
+│   │   │   ├── page.tsx        # Server list
 │   │   │   └── [name]/
-│   │   │       └── page.tsx    # 서버 상세
+│   │   │       └── page.tsx    # Server details
 │   │   ├── worlds/
-│   │   │   └── page.tsx        # 월드 관리
+│   │   │   └── page.tsx        # World management
 │   │   ├── players/
-│   │   │   └── page.tsx        # 플레이어 관리
+│   │   │   └── page.tsx        # Player management
 │   │   ├── backup/
-│   │   │   └── page.tsx        # 백업 관리
+│   │   │   └── page.tsx        # Backup management
 │   │   └── api/
 │   │       └── [...path]/
-│   │           └── route.ts    # BFF 프록시
+│   │           └── route.ts    # BFF proxy
 │   ├── components/
-│   │   ├── ui/                 # shadcn/ui 기본 컴포넌트
-│   │   ├── server/             # 서버 관련 컴포넌트
-│   │   ├── world/              # 월드 관련 컴포넌트
-│   │   ├── player/             # 플레이어 관련 컴포넌트
-│   │   └── layout/             # 레이아웃 컴포넌트
+│   │   ├── ui/                 # shadcn/ui base components
+│   │   ├── server/             # Server-related components
+│   │   ├── world/              # World-related components
+│   │   ├── player/             # Player-related components
+│   │   └── layout/             # Layout components
 │   ├── lib/
-│   │   ├── api-client.ts       # mcctl-api 클라이언트
-│   │   └── utils.ts            # 유틸리티
+│   │   ├── api-client.ts       # mcctl-api client
+│   │   └── utils.ts            # Utilities
 │   ├── hooks/
-│   │   ├── useServers.ts       # 서버 데이터 훅
-│   │   ├── useWorlds.ts        # 월드 데이터 훅
-│   │   └── usePlayers.ts       # 플레이어 데이터 훅
+│   │   ├── useServers.ts       # Server data hook
+│   │   ├── useWorlds.ts        # World data hook
+│   │   └── usePlayers.ts       # Player data hook
 │   └── auth/
-│       └── auth.ts             # NextAuth 설정
+│       └── auth.ts             # NextAuth configuration
 ├── tests/
 └── Dockerfile
 ```
 
-## 4. 페이지 구조
+## 4. Page Structure
 
-| 경로 | 페이지 | 설명 |
-|------|--------|------|
-| `/` | Home | 대시보드로 리다이렉트 |
-| `/login` | Login | 로그인 페이지 |
-| `/dashboard` | Dashboard | 전체 현황 대시보드 |
-| `/servers` | Server List | 서버 목록 및 관리 |
-| `/servers/:name` | Server Detail | 서버 상세 정보 |
-| `/worlds` | World Manager | 월드 목록 및 할당 |
-| `/players` | Player Manager | 플레이어 관리 |
-| `/backup` | Backup Manager | 백업 관리 |
+| Path | Page | Description |
+|------|------|-------------|
+| `/` | Home | Redirect to dashboard |
+| `/login` | Login | Login page |
+| `/dashboard` | Dashboard | Overall status dashboard |
+| `/servers` | Server List | Server list and management |
+| `/servers/:name` | Server Detail | Server details |
+| `/worlds` | World Manager | World list and assignment |
+| `/players` | Player Manager | Player management |
+| `/backup` | Backup Manager | Backup management |
 
-## 5. 인증
+## 5. Authentication
 
-### 5.1 NextAuth 설정
+### 5.1 NextAuth Configuration
 
-Credentials Provider를 사용하여 mcctl-api를 통해 사용자 인증합니다.
+Uses Credentials Provider to authenticate users via mcctl-api.
 
-### 5.2 역할별 권한
+### 5.2 Role-based Permissions
 
-| 역할 | 서버 | 월드 | 플레이어 | 백업 | 설정 |
-|------|------|------|---------|------|------|
-| admin | 모든 권한 | 모든 권한 | 모든 권한 | 모든 권한 | 모든 권한 |
-| operator | 조회/시작/중지 | 조회 | 모든 권한 | 조회 | 읽기 전용 |
-| viewer | 조회만 | 조회만 | 조회만 | 조회만 | 읽기 전용 |
+| Role | Servers | Worlds | Players | Backup | Settings |
+|------|---------|--------|---------|--------|----------|
+| admin | All | All | All | All | All |
+| operator | View/Start/Stop | View | All | View | Read-only |
+| viewer | View only | View only | View only | View only | Read-only |
 
-## 6. 환경 변수
+## 6. Environment Variables
 
-| 변수 | 설명 | 기본값 |
-|------|------|--------|
-| `INTERNAL_API_URL` | mcctl-api 내부 URL | `http://mcctl-api:3001` |
-| `NEXTAUTH_SECRET` | NextAuth 암호화 키 | - (필수) |
-| `NEXTAUTH_URL` | 외부 접근 URL | `http://localhost:3000` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `INTERNAL_API_URL` | mcctl-api internal URL | `http://mcctl-api:3001` |
+| `NEXTAUTH_SECRET` | NextAuth encryption key | - (required) |
+| `NEXTAUTH_URL` | External access URL | `http://localhost:3000` |
 
-## 7. UI/UX 가이드라인
+## 7. UI/UX Guidelines
 
-### 7.1 디자인 원칙
-- 심플하고 직관적인 인터페이스
-- 다크 모드 기본 (마인크래프트 테마)
-- 실시간 상태 업데이트
-- 반응형 디자인 (모바일 지원)
+### 7.1 Design Principles
+- Simple and intuitive interface
+- Dark mode default (Minecraft theme)
+- Real-time status updates
+- Responsive design (mobile support)
 
-### 7.2 컬러 팔레트
+### 7.2 Color Palette
 
 ```css
 :root {
@@ -167,9 +167,9 @@ Credentials Provider를 사용하여 mcctl-api를 통해 사용자 인증합니�
 }
 ```
 
-## 8. 의존성
+## 8. Dependencies
 
-### 8.1 내부 의존성
+### 8.1 Internal Dependencies
 
 ```json
 {
@@ -179,7 +179,7 @@ Credentials Provider를 사용하여 mcctl-api를 통해 사용자 인증합니�
 }
 ```
 
-### 8.2 외부 의존성
+### 8.2 External Dependencies
 
 ```json
 {
@@ -193,13 +193,13 @@ Credentials Provider를 사용하여 mcctl-api를 통해 사용자 인증합니�
 }
 ```
 
-## 9. 테스트 계획
+## 9. Test Plan
 
-- 컴포넌트 테스트 (React Testing Library)
-- E2E 테스트 (Playwright)
+- Component tests (React Testing Library)
+- E2E tests (Playwright)
 
 ## 10. Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 PRD 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial PRD |

--- a/platform/services/shared/plan.md
+++ b/platform/services/shared/plan.md
@@ -1,18 +1,18 @@
-# Implementation Plan: shared 패키지
+# Implementation Plan: shared Package
 
-## 상위 문서
-- [전체 프로젝트 Plan](../../../plan.md) - Phase 7
+## Parent Document
+- [Project Plan](../../../plan.md) - Phase 7
 
-## 개요
+## Overview
 
-shared 패키지의 구현 계획입니다. 현재 대부분 구현이 완료된 상태이며, Admin Service를 위한 확장이 필요합니다.
+Implementation plan for the shared package. Most features are already implemented, with extensions needed for the Admin Service.
 
-## 구현 현황
+## Implementation Status
 
-### Phase 1: 기반 구조 ✅
-- [x] `package.json` 생성 (`@minecraft-docker/shared`)
-- [x] `tsconfig.json` 설정
-- [x] 메인 export (`src/index.ts`)
+### Phase 1: Foundation ✅
+- [x] Create `package.json` (`@minecraft-docker/shared`)
+- [x] Configure `tsconfig.json`
+- [x] Main export (`src/index.ts`)
 
 ### Phase 2: Domain Layer ✅
 - [x] Value Objects
@@ -48,27 +48,27 @@ shared 패키지의 구현 계획입니다. 현재 대부분 구현이 완료된
   - [x] `getPlatformStatus()`
   - [x] `getDetailedServerInfoWithPlayers()`
 
-## 신규 계획 (Admin Service용)
+## New Plans (For Admin Service)
 
-### Phase 5: User Repository (예정)
-- [ ] `IUserRepository` 포트 정의
-- [ ] `YamlUserRepository` 어댑터 구현
-- [ ] `SqliteUserRepository` 어댑터 구현
-- [ ] 단위 테스트
+### Phase 5: User Repository (Planned)
+- [ ] Define `IUserRepository` port
+- [ ] Implement `YamlUserRepository` adapter
+- [ ] Implement `SqliteUserRepository` adapter
+- [ ] Unit tests
 
-### Phase 6: API Prompt Adapter (예정)
-- [ ] `ApiPromptAdapter` 구현
-- [ ] 비대화형 모드 에러 처리
-- [ ] 단위 테스트
+### Phase 6: API Prompt Adapter (Planned)
+- [ ] Implement `ApiPromptAdapter`
+- [ ] Non-interactive mode error handling
+- [ ] Unit tests
 
-## 완료 기준
+## Completion Criteria
 
-1. 모든 Use Case가 CLI와 API에서 재사용 가능
-2. 어댑터 교체로 동작 변경 가능 (DI)
-3. 단위 테스트 커버리지 80% 이상
+1. All Use Cases reusable by both CLI and API
+2. Behavior changes possible via adapter swap (DI)
+3. Unit test coverage 80% or higher
 
 ## Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 계획 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial plan |

--- a/platform/services/shared/prd.md
+++ b/platform/services/shared/prd.md
@@ -1,32 +1,32 @@
-# PRD: shared - 공통 패키지
+# PRD: shared - Common Package
 
-## 상위 문서
-- [전체 프로젝트 PRD](../../../prd.md) - Section 9
+## Parent Document
+- [Project PRD](../../../prd.md) - Section 9
 
-## 1. 개요
+## 1. Overview
 
-### 1.1 목적
-CLI, API, Console 서비스가 공유하는 도메인 로직, 유스케이스, 어댑터를 제공하는 핵심 패키지입니다.
+### 1.1 Purpose
+Core package providing shared domain logic, use cases, and adapters for CLI, API, and Console services.
 
-### 1.2 범위
+### 1.2 Scope
 - Domain Layer: Entities, Value Objects
 - Application Layer: Use Cases, Ports
-- Infrastructure Layer: 공통 Adapters (Shell, Repository)
-- 유틸리티 및 타입 정의
+- Infrastructure Layer: Common Adapters (Shell, Repository)
+- Utilities and type definitions
 
-### 1.3 비목표
-- CLI 전용 어댑터 (ClackPromptAdapter → cli 패키지)
-- Web 전용 어댑터 (WebPromptAdapter → mcctl-console)
-- API 전용 어댑터 (ApiPromptAdapter → mcctl-api)
+### 1.3 Non-Goals
+- CLI-specific adapters (ClackPromptAdapter → cli package)
+- Web-specific adapters (WebPromptAdapter → mcctl-console)
+- API-specific adapters (ApiPromptAdapter → mcctl-api)
 
-## 2. 기술 스택
+## 2. Tech Stack
 
-| 구성요소 | 기술 | 버전 |
-|---------|------|------|
+| Component | Technology | Version |
+|-----------|------------|---------|
 | Runtime | Node.js | 18+ |
 | Language | TypeScript | 5.x |
 
-## 3. 아키텍처
+## 3. Architecture
 
 ### 3.1 Hexagonal Architecture
 
@@ -47,7 +47,7 @@ CLI, API, Console 서비스가 공유하는 도메인 로직, 유스케이스, �
 │  │  - IShellPort (outbound)                               │  │
 │  │  - IServerRepository (outbound)                        │  │
 │  │  - IWorldRepository (outbound)                         │  │
-│  │  - IUserRepository (outbound) ← 신규                   │  │
+│  │  - IUserRepository (outbound) ← NEW                    │  │
 │  └───────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────┘
                           │
@@ -72,13 +72,13 @@ CLI, API, Console 서비스가 공유하는 도메인 로직, 유스케이스, �
 ┌─────────────────────────▼───────────────────────────────────┐
 │                 INFRASTRUCTURE LAYER                         │
 │  ┌───────────────────────────────────────────────────────┐  │
-│  │  Adapters (공통)                                       │  │
+│  │  Adapters (Common)                                     │  │
 │  │  - ShellAdapter                                        │  │
 │  │  - ServerRepository                                    │  │
 │  │  - WorldRepository                                     │  │
-│  │  - YamlUserRepository ← 신규                           │  │
-│  │  - SqliteUserRepository ← 신규                         │  │
-│  │  - ApiPromptAdapter ← 신규                             │  │
+│  │  - YamlUserRepository ← NEW                            │  │
+│  │  - SqliteUserRepository ← NEW                          │  │
+│  │  - ApiPromptAdapter ← NEW                              │  │
 │  └───────────────────────────────────────────────────────┘  │
 │  ┌───────────────────────────────────────────────────────┐  │
 │  │  Docker Utilities                                      │  │
@@ -88,19 +88,19 @@ CLI, API, Console 서비스가 공유하는 도메인 로직, 유스케이스, �
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 디렉토리 구조
+### 3.2 Directory Structure
 
 ```
 platform/services/shared/
-├── prd.md                      # 이 문서
-├── plan.md                     # 구현 계획
-├── README.md                   # npm 패키지 설명
+├── prd.md                      # This document
+├── plan.md                     # Implementation plan
+├── README.md                   # npm package description
 ├── package.json                # @minecraft-docker/shared
 ├── tsconfig.json
 ├── src/
-│   ├── index.ts                # 메인 export
+│   ├── index.ts                # Main export
 │   │
-│   ├── domain/                 # 도메인 레이어
+│   ├── domain/                 # Domain layer
 │   │   ├── entities/
 │   │   │   ├── Server.ts
 │   │   │   └── World.ts
@@ -111,39 +111,39 @@ platform/services/shared/
 │   │       ├── Memory.ts
 │   │       └── WorldOptions.ts
 │   │
-│   ├── application/            # 애플리케이션 레이어
+│   ├── application/            # Application layer
 │   │   ├── ports/
-│   │   │   ├── inbound/        # Use Case 인터페이스
-│   │   │   └── outbound/       # Repository 인터페이스
+│   │   │   ├── inbound/        # Use Case interfaces
+│   │   │   └── outbound/       # Repository interfaces
 │   │   │       ├── IPromptPort.ts
 │   │   │       ├── IShellPort.ts
 │   │   │       ├── IServerRepository.ts
 │   │   │       ├── IWorldRepository.ts
-│   │   │       └── IUserRepository.ts  ← 신규
+│   │   │       └── IUserRepository.ts  ← NEW
 │   │   └── use-cases/
 │   │       ├── CreateServerUseCase.ts
 │   │       ├── DeleteServerUseCase.ts
 │   │       └── ...
 │   │
-│   ├── infrastructure/         # 인프라 레이어
+│   ├── infrastructure/         # Infrastructure layer
 │   │   ├── adapters/
 │   │   │   ├── ShellAdapter.ts
 │   │   │   ├── ServerRepository.ts
 │   │   │   ├── WorldRepository.ts
-│   │   │   ├── YamlUserRepository.ts    ← 신규
-│   │   │   ├── SqliteUserRepository.ts  ← 신규
-│   │   │   └── ApiPromptAdapter.ts      ← 신규
+│   │   │   ├── YamlUserRepository.ts    ← NEW
+│   │   │   ├── SqliteUserRepository.ts  ← NEW
+│   │   │   └── ApiPromptAdapter.ts      ← NEW
 │   │   └── docker/
 │   │       └── index.ts
 │   │
-│   ├── types/                  # 타입 정의
-│   └── utils/                  # 유틸리티
+│   ├── types/                  # Type definitions
+│   └── utils/                  # Utilities
 └── tests/
 ```
 
-## 4. 신규 추가 항목 (Admin Service용)
+## 4. New Additions (For Admin Service)
 
-### 4.1 IUserRepository 포트
+### 4.1 IUserRepository Port
 
 ```typescript
 export interface User {
@@ -166,19 +166,19 @@ export interface IUserRepository {
 
 ### 4.2 YamlUserRepository
 
-`.mcctl-admin.yml` 파일의 `users` 섹션을 읽고 쓰는 어댑터.
+Adapter that reads and writes the `users` section of `.mcctl-admin.yml` file.
 
 ### 4.3 SqliteUserRepository
 
-`mcctl-admin.db` SQLite 데이터베이스를 사용하는 어댑터.
+Adapter that uses the `mcctl-admin.db` SQLite database.
 
 ### 4.4 ApiPromptAdapter
 
-API 컨텍스트용 비대화형 `IPromptPort` 구현. 대화형 프롬프트를 호출하면 에러를 발생시킴.
+Non-interactive `IPromptPort` implementation for API context. Throws an error when interactive prompts are called.
 
-## 5. 의존성
+## 5. Dependencies
 
-### 5.1 외부 의존성
+### 5.1 External Dependencies
 
 ```json
 {
@@ -189,7 +189,7 @@ API 컨텍스트용 비대화형 `IPromptPort` 구현. 대화형 프롬프트를
 }
 ```
 
-## 6. Export 구조
+## 6. Export Structure
 
 ```typescript
 // index.ts
@@ -206,6 +206,6 @@ export * from './utils';
 
 ## 7. Revision History
 
-| 버전 | 날짜 | 작성자 | 변경 내용 |
-|------|------|--------|----------|
-| 1.0.0 | 2025-01-25 | - | 초기 PRD 작성 |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2025-01-25 | - | Initial PRD |

--- a/prd.md
+++ b/prd.md
@@ -1487,23 +1487,23 @@ minecraft-server-manager/
 > **Milestone**: Phase 8
 > **Status**: Planned
 
-웹 기반 관리 콘솔 서비스입니다. MSA(Microservice Architecture) 원칙에 따라 두 개의 독립 서비스로 구성됩니다.
+Web-based management console service. Consists of two independent services following MSA (Microservice Architecture) principles.
 
-### 10.1 서비스 구성
+### 10.1 Service Components
 
-| 서비스 | 패키지 | 역할 |
-|--------|--------|------|
-| **mcctl-api** | `@minecraft-docker/mcctl-api` | 내부 REST API 서비스 |
-| **mcctl-console** | `@minecraft-docker/mcctl-console` | BFF + 관리 UI |
+| Service | Package | Role |
+|---------|---------|------|
+| **mcctl-api** | `@minecraft-docker/mcctl-api` | Internal REST API service |
+| **mcctl-console** | `@minecraft-docker/mcctl-console` | BFF + Management UI |
 
-### 10.2 세부 문서
+### 10.2 Detailed Documents
 
-각 서비스는 독립적인 PRD/Plan 문서를 가집니다:
+Each service has independent PRD/Plan documents:
 
 - **mcctl-api**: [PRD](platform/services/mcctl-api/prd.md) | [Plan](platform/services/mcctl-api/plan.md)
 - **mcctl-console**: [PRD](platform/services/mcctl-console/prd.md) | [Plan](platform/services/mcctl-console/plan.md)
 
-### 10.3 아키텍처 개요
+### 10.3 Architecture Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -1527,15 +1527,15 @@ minecraft-server-manager/
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 10.4 CLI 명령어 (`mcctl admin`)
+### 10.4 CLI Commands (`mcctl admin`)
 
 ```bash
-mcctl admin init              # 초기 설정
-mcctl admin start             # 서비스 시작
-mcctl admin stop              # 서비스 중지
-mcctl admin status            # 상태 확인
-mcctl admin user list         # 사용자 목록
-mcctl admin user add <name>   # 사용자 추가
+mcctl admin init              # Initial setup
+mcctl admin start             # Start services
+mcctl admin stop              # Stop services
+mcctl admin status            # Check status
+mcctl admin user list         # List users
+mcctl admin user add <name>   # Add user
 ```
 
 ## 11. Revision History


### PR DESCRIPTION
Add MSA-based Admin Service documentation for web management console:

- platform/services/mcctl-api/prd.md: REST API service PRD
- platform/services/mcctl-api/plan.md: API implementation plan
- platform/services/mcctl-console/prd.md: BFF + UI service PRD
- platform/services/mcctl-console/plan.md: Console implementation plan

Update root documents:
- prd.md: Add Section 10 (Admin Service) with links to service docs
- plan.md: Add Phase 8 (Admin Service) with implementation steps

Architecture:
- mcctl-api: Fastify REST API with 5 access modes
- mcctl-console: Next.js App Router with NextAuth.js
- Shared package: Common domain/use-cases for CLI and Web