### PR TITLE
feat: add mod management command (mcctl mod) (#103)

### DIFF
--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -15,3 +15,4 @@ export { kickCommand, type KickCommandOptions } from './kick.js';
 export { playerOnlineCommand, type PlayerOnlineCommandOptions } from './player-online.js';
 export { playerCommand, type PlayerCommandOptions } from './player.js';
 export { migrateCommand, type MigrateCommandOptions } from './migrate.js';
+export { modCommand, type ModCommandOptions } from './mod.js';

--- a/platform/services/cli/src/commands/mod.ts
+++ b/platform/services/cli/src/commands/mod.ts
@@ -1,0 +1,502 @@
+import { Paths, log, colors } from '@minecraft-docker/shared';
+import {
+  searchMods,
+  getProject,
+  formatDownloads,
+  getLoaderFromServerType,
+  type ModrinthProject,
+} from '../lib/modrinth-api.js';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+/**
+ * Mod command options
+ */
+export interface ModCommandOptions {
+  root?: string;
+  subCommand?: string;
+  serverName?: string;
+  modNames?: string[];
+  query?: string;
+  source?: 'modrinth' | 'curseforge' | 'spiget' | 'url';
+  json?: boolean;
+  force?: boolean;
+}
+
+/**
+ * Execute mod management command
+ */
+export async function modCommand(options: ModCommandOptions): Promise<number> {
+  const paths = new Paths(options.root);
+
+  // Check if initialized
+  if (!paths.isInitialized()) {
+    log.error('Platform not initialized. Run: mcctl init');
+    return 1;
+  }
+
+  const subCommand = options.subCommand ?? 'list';
+
+  switch (subCommand) {
+    case 'search':
+      return modSearch(options);
+
+    case 'add':
+      return modAdd(paths, options);
+
+    case 'list':
+      return modList(paths, options);
+
+    case 'remove':
+      return modRemove(paths, options);
+
+    case 'sources':
+      return modSources(options);
+
+    default:
+      log.error(`Unknown mod subcommand: ${subCommand}`);
+      console.log('Usage: mcctl mod [search|add|list|remove|sources]');
+      return 1;
+  }
+}
+
+/**
+ * Search mods on Modrinth
+ */
+async function modSearch(options: ModCommandOptions): Promise<number> {
+  const query = options.query;
+
+  if (!query) {
+    log.error('Search query required');
+    console.log('Usage: mcctl mod search <query>');
+    return 1;
+  }
+
+  try {
+    const result = await searchMods(query, { limit: 15 });
+
+    if (result.hits.length === 0) {
+      console.log(`No mods found for "${query}"`);
+      return 0;
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(result.hits, null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.bold(`Search results for "${query}" (${result.total_hits} total):`));
+    console.log('');
+
+    for (const mod of result.hits) {
+      const downloads = formatDownloads(mod.downloads);
+      const serverSide = mod.server_side === 'required' ? colors.green('server') :
+                        mod.server_side === 'optional' ? colors.yellow('server?') : '';
+      const clientSide = mod.client_side === 'required' ? colors.blue('client') :
+                        mod.client_side === 'optional' ? colors.dim('client?') : '';
+      const sides = [serverSide, clientSide].filter(Boolean).join(' ');
+
+      console.log(`  ${colors.cyan(mod.slug)} ${colors.dim(`(${downloads} downloads)`)}`);
+      console.log(`    ${mod.title} ${sides}`);
+      console.log(`    ${colors.dim(mod.description.slice(0, 80))}${mod.description.length > 80 ? '...' : ''}`);
+      console.log('');
+    }
+
+    console.log(colors.dim('Use: mcctl mod add <server> <mod-slug> to install'));
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Search failed: ${message}`);
+    return 1;
+  }
+}
+
+/**
+ * Add mod to server
+ */
+async function modAdd(
+  paths: Paths,
+  options: ModCommandOptions
+): Promise<number> {
+  const { serverName, modNames, source = 'modrinth' } = options;
+
+  if (!serverName) {
+    log.error('Server name required');
+    console.log('Usage: mcctl mod add <server> <mod...>');
+    return 1;
+  }
+
+  if (!modNames || modNames.length === 0) {
+    log.error('At least one mod name required');
+    console.log('Usage: mcctl mod add <server> <mod...>');
+    return 1;
+  }
+
+  // Check server exists
+  const serverDir = join(paths.servers, serverName);
+  const configPath = join(serverDir, 'config.env');
+
+  if (!existsSync(configPath)) {
+    log.error(`Server '${serverName}' not found`);
+    return 1;
+  }
+
+  try {
+    // Read current config
+    const configContent = await readFile(configPath, 'utf-8');
+    const config = parseEnvFile(configContent);
+
+    // Check server type supports mods
+    const serverType = config['TYPE'] || 'PAPER';
+    const loader = getLoaderFromServerType(serverType);
+
+    if (!loader) {
+      log.error(`Server type '${serverType}' may not support mods`);
+      console.log('Supported types: FORGE, NEOFORGE, FABRIC, QUILT, PAPER, SPIGOT');
+      if (!options.force) {
+        console.log('Use --force to add anyway');
+        return 1;
+      }
+    }
+
+    // Validate mods exist on Modrinth (if source is modrinth)
+    const validMods: ModrinthProject[] = [];
+    const invalidMods: string[] = [];
+
+    if (source === 'modrinth') {
+      console.log('');
+      console.log(colors.dim('Validating mods on Modrinth...'));
+
+      for (const modName of modNames) {
+        const project = await getProject(modName);
+        if (project) {
+          validMods.push(project);
+          console.log(`  ${colors.green('✓')} ${project.title} (${project.slug})`);
+        } else {
+          invalidMods.push(modName);
+          console.log(`  ${colors.red('✗')} ${modName} - not found`);
+        }
+      }
+
+      if (invalidMods.length > 0 && !options.force) {
+        console.log('');
+        log.error(`Some mods not found: ${invalidMods.join(', ')}`);
+        console.log('Use --force to add anyway');
+        return 1;
+      }
+    }
+
+    // Update config.env
+    const modsToAdd = source === 'modrinth' ? validMods.map(m => m.slug) : modNames;
+    const envKey = getEnvKeyForSource(source, serverType);
+    const currentMods = parseModList(config[envKey] || '');
+    const newMods = [...new Set([...currentMods, ...modsToAdd])];
+
+    config[envKey] = newMods.join(',');
+
+    // Write updated config
+    await writeFile(configPath, formatEnvFile(config));
+
+    console.log('');
+    console.log(colors.green(`✓ Added ${modsToAdd.length} mod(s) to ${serverName}`));
+    console.log('');
+
+    for (const mod of modsToAdd) {
+      console.log(`  ${colors.cyan(mod)}`);
+    }
+
+    console.log('');
+    console.log(colors.dim(`Config: ${envKey}=${newMods.join(',')}`));
+    console.log('');
+    console.log(colors.yellow('Restart the server to apply changes:'));
+    console.log(`  mcctl stop ${serverName} && mcctl start ${serverName}`);
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to add mods: ${message}`);
+    return 1;
+  }
+}
+
+/**
+ * List installed mods
+ */
+async function modList(
+  paths: Paths,
+  options: ModCommandOptions
+): Promise<number> {
+  const { serverName } = options;
+
+  if (!serverName) {
+    log.error('Server name required');
+    console.log('Usage: mcctl mod list <server>');
+    return 1;
+  }
+
+  // Check server exists
+  const serverDir = join(paths.servers, serverName);
+  const configPath = join(serverDir, 'config.env');
+
+  if (!existsSync(configPath)) {
+    log.error(`Server '${serverName}' not found`);
+    return 1;
+  }
+
+  try {
+    const configContent = await readFile(configPath, 'utf-8');
+    const config = parseEnvFile(configContent);
+    const serverType = config['TYPE'] || 'PAPER';
+
+    const sources = [
+      { key: 'MODRINTH_PROJECTS', name: 'Modrinth', mods: parseModList(config['MODRINTH_PROJECTS'] || '') },
+      { key: 'CURSEFORGE_FILES', name: 'CurseForge', mods: parseModList(config['CURSEFORGE_FILES'] || '') },
+      { key: 'SPIGET_RESOURCES', name: 'Spiget', mods: parseModList(config['SPIGET_RESOURCES'] || '') },
+      { key: 'MODS', name: 'URL', mods: parseModList(config['MODS'] || '') },
+      { key: 'PLUGINS', name: 'Plugins URL', mods: parseModList(config['PLUGINS'] || '') },
+    ];
+
+    const allMods = sources.flatMap(s => s.mods.map(m => ({ source: s.name, mod: m })));
+
+    if (options.json) {
+      console.log(JSON.stringify({ serverType, sources, total: allMods.length }, null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.bold(`Mods for ${serverName} (${serverType}):`));
+    console.log('');
+
+    if (allMods.length === 0) {
+      console.log('  No mods configured');
+      console.log('');
+      console.log(colors.dim('Use: mcctl mod add <server> <mod> to install mods'));
+      console.log('');
+      return 0;
+    }
+
+    for (const source of sources) {
+      if (source.mods.length > 0) {
+        console.log(`  ${colors.cyan(source.name)}:`);
+        for (const mod of source.mods) {
+          console.log(`    - ${mod}`);
+        }
+        console.log('');
+      }
+    }
+
+    console.log(colors.dim(`Total: ${allMods.length} mod(s)`));
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to list mods: ${message}`);
+    return 1;
+  }
+}
+
+/**
+ * Remove mod from server
+ */
+async function modRemove(
+  paths: Paths,
+  options: ModCommandOptions
+): Promise<number> {
+  const { serverName, modNames } = options;
+
+  if (!serverName) {
+    log.error('Server name required');
+    console.log('Usage: mcctl mod remove <server> <mod...>');
+    return 1;
+  }
+
+  if (!modNames || modNames.length === 0) {
+    log.error('At least one mod name required');
+    console.log('Usage: mcctl mod remove <server> <mod...>');
+    return 1;
+  }
+
+  const serverDir = join(paths.servers, serverName);
+  const configPath = join(serverDir, 'config.env');
+
+  if (!existsSync(configPath)) {
+    log.error(`Server '${serverName}' not found`);
+    return 1;
+  }
+
+  try {
+    const configContent = await readFile(configPath, 'utf-8');
+    const config = parseEnvFile(configContent);
+
+    let removed = 0;
+    const envKeys = ['MODRINTH_PROJECTS', 'CURSEFORGE_FILES', 'SPIGET_RESOURCES', 'MODS', 'PLUGINS'];
+
+    for (const modName of modNames) {
+      for (const key of envKeys) {
+        const mods = parseModList(config[key] || '');
+        const index = mods.findIndex(m => m.toLowerCase() === modName.toLowerCase());
+
+        if (index !== -1) {
+          mods.splice(index, 1);
+          config[key] = mods.join(',');
+          removed++;
+          console.log(`  ${colors.green('✓')} Removed ${modName} from ${key}`);
+          break;
+        }
+      }
+    }
+
+    if (removed === 0) {
+      log.warn('No mods were removed (not found in config)');
+      return 0;
+    }
+
+    await writeFile(configPath, formatEnvFile(config));
+
+    console.log('');
+    console.log(colors.green(`✓ Removed ${removed} mod(s) from ${serverName}`));
+    console.log('');
+    console.log(colors.yellow('Restart the server to apply changes:'));
+    console.log(`  mcctl stop ${serverName} && mcctl start ${serverName}`);
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to remove mods: ${message}`);
+    return 1;
+  }
+}
+
+/**
+ * Show available mod sources
+ */
+async function modSources(options: ModCommandOptions): Promise<number> {
+  const sources = [
+    {
+      name: 'Modrinth',
+      flag: '--modrinth (default)',
+      envKey: 'MODRINTH_PROJECTS',
+      description: 'Free, open-source mod platform. No API key required.',
+      example: 'mcctl mod add myserver sodium lithium',
+    },
+    {
+      name: 'CurseForge',
+      flag: '--curseforge',
+      envKey: 'CURSEFORGE_FILES',
+      description: 'Popular mod platform. Requires CF_API_KEY in .env',
+      example: 'mcctl mod add myserver --curseforge jei journeymap',
+    },
+    {
+      name: 'Spiget (SpigotMC)',
+      flag: '--spiget',
+      envKey: 'SPIGET_RESOURCES',
+      description: 'SpigotMC plugin repository. Use resource IDs.',
+      example: 'mcctl mod add myserver --spiget 9089',
+    },
+    {
+      name: 'URL',
+      flag: '--url',
+      envKey: 'MODS / PLUGINS',
+      description: 'Direct JAR file download URLs.',
+      example: 'mcctl mod add myserver --url https://example.com/mod.jar',
+    },
+  ];
+
+  if (options.json) {
+    console.log(JSON.stringify(sources, null, 2));
+    return 0;
+  }
+
+  console.log('');
+  console.log(colors.bold('Available Mod Sources:'));
+  console.log('');
+
+  for (const source of sources) {
+    console.log(`  ${colors.cyan(source.name)} ${colors.dim(source.flag)}`);
+    console.log(`    ${source.description}`);
+    console.log(`    Config: ${colors.yellow(source.envKey)}`);
+    console.log(`    ${colors.dim(source.example)}`);
+    console.log('');
+  }
+
+  return 0;
+}
+
+/**
+ * Parse env file content into key-value pairs
+ */
+function parseEnvFile(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1).trim();
+
+    // Remove quotes
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+/**
+ * Format key-value pairs back to env file
+ */
+function formatEnvFile(config: Record<string, string>): string {
+  return Object.entries(config)
+    .map(([key, value]) => {
+      // Quote values with spaces or special chars
+      if (value.includes(' ') || value.includes(',') || value.includes('\n')) {
+        return `${key}="${value}"`;
+      }
+      return `${key}=${value}`;
+    })
+    .join('\n') + '\n';
+}
+
+/**
+ * Parse mod list from env value
+ */
+function parseModList(value: string): string[] {
+  return value
+    .split(/[,\s\n]+/)
+    .map(m => m.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Get environment variable key for source
+ */
+function getEnvKeyForSource(source: string, serverType: string): string {
+  switch (source) {
+    case 'curseforge':
+      return 'CURSEFORGE_FILES';
+    case 'spiget':
+      return 'SPIGET_RESOURCES';
+    case 'url':
+      // Plugins for Paper/Spigot, Mods for Forge/Fabric
+      return ['PAPER', 'SPIGOT', 'BUKKIT', 'PURPUR'].includes(serverType.toUpperCase())
+        ? 'PLUGINS'
+        : 'MODS';
+    default:
+      return 'MODRINTH_PROJECTS';
+  }
+}

--- a/platform/services/cli/src/lib/modrinth-api.ts
+++ b/platform/services/cli/src/lib/modrinth-api.ts
@@ -1,0 +1,185 @@
+/**
+ * Modrinth API Client
+ * https://docs.modrinth.com/api-spec
+ */
+
+const MODRINTH_API = 'https://api.modrinth.com/v2';
+
+/**
+ * Modrinth project (mod/plugin)
+ */
+export interface ModrinthProject {
+  slug: string;
+  title: string;
+  description: string;
+  categories: string[];
+  client_side: 'required' | 'optional' | 'unsupported';
+  server_side: 'required' | 'optional' | 'unsupported';
+  project_type: 'mod' | 'modpack' | 'resourcepack' | 'shader';
+  downloads: number;
+  icon_url: string | null;
+  project_id: string;
+  author: string;
+  versions: string[];
+  follows: number;
+  date_created: string;
+  date_modified: string;
+  license: string;
+  gallery: string[];
+}
+
+/**
+ * Search result from Modrinth
+ */
+export interface ModrinthSearchResult {
+  hits: ModrinthProject[];
+  offset: number;
+  limit: number;
+  total_hits: number;
+}
+
+/**
+ * Project version info
+ */
+export interface ModrinthVersion {
+  id: string;
+  project_id: string;
+  name: string;
+  version_number: string;
+  changelog: string;
+  date_published: string;
+  downloads: number;
+  version_type: 'release' | 'beta' | 'alpha';
+  files: ModrinthFile[];
+  dependencies: ModrinthDependency[];
+  game_versions: string[];
+  loaders: string[];
+}
+
+export interface ModrinthFile {
+  hashes: { sha1: string; sha512: string };
+  url: string;
+  filename: string;
+  primary: boolean;
+  size: number;
+}
+
+export interface ModrinthDependency {
+  version_id: string | null;
+  project_id: string;
+  file_name: string | null;
+  dependency_type: 'required' | 'optional' | 'incompatible' | 'embedded';
+}
+
+/**
+ * Search mods on Modrinth
+ */
+export async function searchMods(
+  query: string,
+  options?: {
+    limit?: number;
+    offset?: number;
+    facets?: string[][];
+    index?: 'relevance' | 'downloads' | 'follows' | 'newest' | 'updated';
+  }
+): Promise<ModrinthSearchResult> {
+  const params = new URLSearchParams({
+    query,
+    limit: String(options?.limit ?? 10),
+    offset: String(options?.offset ?? 0),
+    index: options?.index ?? 'relevance',
+  });
+
+  if (options?.facets) {
+    params.set('facets', JSON.stringify(options.facets));
+  }
+
+  const response = await fetch(`${MODRINTH_API}/search?${params}`);
+
+  if (!response.ok) {
+    throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json() as Promise<ModrinthSearchResult>;
+}
+
+/**
+ * Get project by slug or ID
+ */
+export async function getProject(slugOrId: string): Promise<ModrinthProject | null> {
+  const response = await fetch(`${MODRINTH_API}/project/${slugOrId}`);
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json() as Promise<ModrinthProject>;
+}
+
+/**
+ * Get project versions
+ */
+export async function getProjectVersions(
+  slugOrId: string,
+  options?: {
+    loaders?: string[];
+    game_versions?: string[];
+    featured?: boolean;
+  }
+): Promise<ModrinthVersion[]> {
+  const params = new URLSearchParams();
+
+  if (options?.loaders) {
+    params.set('loaders', JSON.stringify(options.loaders));
+  }
+  if (options?.game_versions) {
+    params.set('game_versions', JSON.stringify(options.game_versions));
+  }
+  if (options?.featured !== undefined) {
+    params.set('featured', String(options.featured));
+  }
+
+  const url = `${MODRINTH_API}/project/${slugOrId}/version${params.toString() ? '?' + params : ''}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json() as Promise<ModrinthVersion[]>;
+}
+
+/**
+ * Format download count for display
+ */
+export function formatDownloads(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1)}K`;
+  }
+  return String(count);
+}
+
+/**
+ * Get loader type from server type
+ */
+export function getLoaderFromServerType(serverType: string): string | null {
+  const loaderMap: Record<string, string> = {
+    FORGE: 'forge',
+    NEOFORGE: 'neoforge',
+    FABRIC: 'fabric',
+    QUILT: 'quilt',
+    PAPER: 'paper',
+    SPIGOT: 'spigot',
+    BUKKIT: 'bukkit',
+    PURPUR: 'purpur',
+  };
+
+  return loaderMap[serverType.toUpperCase()] ?? null;
+}


### PR DESCRIPTION
## Summary
- Add `mcctl mod` command to manage mods and plugins for Minecraft servers

## Changes
- Add Modrinth API client (`lib/modrinth-api.ts`)
- Add mod command handler (`commands/mod.ts`)
- Register mod command in CLI
- Add help text for mod commands

## Commands Added
```bash
mcctl mod search <query>         # Search mods on Modrinth
mcctl mod add <srv> <mod...>     # Add mods to server
mcctl mod list <server>          # List configured mods
mcctl mod remove <srv> <mod...>  # Remove mods from server
mcctl mod sources                # Show available mod sources
```

## Supported Sources
| Source | Flag | Notes |
|--------|------|-------|
| Modrinth | --modrinth (default) | Free, no API key |
| CurseForge | --curseforge | Requires CF_API_KEY |
| Spiget | --spiget | SpigotMC plugins |
| URL | --url | Direct JAR download |

## Test Plan
- [x] `mcctl mod search sodium` - Search works
- [x] `mcctl mod sources` - Shows all sources
- [x] `mcctl mod add factory lithium` - Adds mod to config
- [x] `mcctl mod list factory` - Shows added mod
- [x] `mcctl mod remove factory lithium` - Removes mod from config

Closes #103

🤖 Generated with [Claude Code](https://claude.ai/code)