### PR TITLE
refactor: mod-source-modrinth에 Hexagonal Architecture 적용

### DIFF
--- a/platform/services/mod-source-modrinth/src/ModrinthAdapter.ts
+++ b/platform/services/mod-source-modrinth/src/ModrinthAdapter.ts
@@ -1,8 +1,15 @@
 /**
  * ModrinthAdapter - Modrinth API implementation of IModSourcePort
  *
- * This adapter provides access to Modrinth's mod repository.
- * https://docs.modrinth.com/api-spec
+ * This adapter composes infrastructure components to provide
+ * access to Modrinth's mod repository.
+ *
+ * Architecture:
+ * - ModrinthApiClient: HTTP requests to Modrinth API
+ * - ModrinthMapper: Raw API responses → Domain models
+ * - ModrinthAdapter: Orchestrates client and mapper, implements IModSourcePort
+ *
+ * @see https://docs.modrinth.com/api-spec
  */
 
 import type {
@@ -12,39 +19,44 @@ import type {
   ModSearchResult,
   ModSearchOptions,
   ModVersionOptions,
-  ModFile,
-  ModDependency,
-  ModProjectType,
 } from '@minecraft-docker/shared';
 
-import type {
-  ModrinthProjectRaw,
-  ModrinthSearchResultRaw,
-  ModrinthSearchHitRaw,
-  ModrinthVersionRaw,
-  ModrinthTeamMemberRaw,
-} from './types.js';
-
-const MODRINTH_API = 'https://api.modrinth.com/v2';
+import { ModrinthApiClient } from './infrastructure/api/index.js';
+import { ModrinthMapper } from './infrastructure/mappers/index.js';
 
 /**
  * Modrinth adapter implementing IModSourcePort
+ *
+ * Uses composition to combine API client and mapper.
+ * Follows Single Responsibility Principle - this class only
+ * orchestrates the components, not implement HTTP or mapping logic.
+ *
+ * @example
+ * ```typescript
+ * const adapter = new ModrinthAdapter();
+ * const result = await adapter.search('sodium');
+ * const project = await adapter.getProject('sodium');
+ * ```
  */
 export class ModrinthAdapter implements IModSourcePort {
   readonly sourceName = 'modrinth';
   readonly displayName = 'Modrinth';
 
+  private readonly apiClient: ModrinthApiClient;
+  private readonly mapper: ModrinthMapper;
+
+  constructor(
+    apiClient: ModrinthApiClient = new ModrinthApiClient(),
+    mapper: ModrinthMapper = new ModrinthMapper()
+  ) {
+    this.apiClient = apiClient;
+    this.mapper = mapper;
+  }
+
   /**
    * Search for mods on Modrinth
    */
   async search(query: string, options?: ModSearchOptions): Promise<ModSearchResult> {
-    const params = new URLSearchParams({
-      query,
-      limit: String(options?.limit ?? 10),
-      offset: String(options?.offset ?? 0),
-      index: options?.index ?? 'relevance',
-    });
-
     // Build facets for filtering
     const facets: string[][] = [];
     if (options?.gameVersions?.length) {
@@ -53,86 +65,53 @@ export class ModrinthAdapter implements IModSourcePort {
     if (options?.loaders?.length) {
       facets.push(options.loaders.map(l => `categories:${l}`));
     }
-    if (facets.length > 0) {
-      params.set('facets', JSON.stringify(facets));
-    }
 
-    const response = await fetch(`${MODRINTH_API}/search?${params}`);
+    const raw = await this.apiClient.search({
+      query,
+      limit: options?.limit,
+      offset: options?.offset,
+      index: options?.index,
+      facets: facets.length > 0 ? facets : undefined,
+    });
 
-    if (!response.ok) {
-      throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
-    }
-
-    const raw = (await response.json()) as ModrinthSearchResultRaw;
-
-    return {
-      hits: raw.hits.map(hit => this.mapSearchHitToProject(hit)),
-      totalHits: raw.total_hits,
-      offset: raw.offset,
-      limit: raw.limit,
-    };
+    return this.mapper.toSearchResult(raw);
   }
 
   /**
    * Get project details by slug or ID
    */
   async getProject(slugOrId: string): Promise<ModProject | null> {
-    const response = await fetch(`${MODRINTH_API}/project/${slugOrId}`);
+    const raw = await this.apiClient.getProject(slugOrId);
 
-    if (response.status === 404) {
+    if (!raw) {
       return null;
     }
 
-    if (!response.ok) {
-      throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
-    }
-
-    const raw = (await response.json()) as ModrinthProjectRaw;
-
     // Get author from team
-    const author = await this.getProjectAuthor(raw.team);
+    const members = await this.apiClient.getTeamMembers(raw.team);
+    const author = this.mapper.extractAuthor(members);
 
-    return this.mapProjectRawToProject(raw, author);
+    return this.mapper.toProject(raw, author);
   }
 
   /**
    * Get versions for a project
    */
   async getVersions(slugOrId: string, options?: ModVersionOptions): Promise<ModVersion[]> {
-    const params = new URLSearchParams();
+    const rawVersions = await this.apiClient.getVersions(slugOrId, {
+      loaders: options?.loaders,
+      gameVersions: options?.gameVersions,
+      featured: options?.featured,
+    });
 
-    if (options?.loaders?.length) {
-      params.set('loaders', JSON.stringify(options.loaders));
-    }
-    if (options?.gameVersions?.length) {
-      params.set('game_versions', JSON.stringify(options.gameVersions));
-    }
-    if (options?.featured !== undefined) {
-      params.set('featured', String(options.featured));
-    }
-
-    const url = `${MODRINTH_API}/project/${slugOrId}/version${params.toString() ? '?' + params : ''}`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
-    }
-
-    const raw = (await response.json()) as ModrinthVersionRaw[];
-
-    return raw.map(v => this.mapVersionRawToVersion(v));
+    return rawVersions.map(v => this.mapper.toVersion(v));
   }
 
   /**
    * Check if Modrinth API is available
    */
   async isAvailable(): Promise<boolean> {
-    try {
-      const response = await fetch(`${MODRINTH_API}/`);
-      return response.ok;
-    } catch {
-      return false;
-    }
+    return this.apiClient.isAvailable();
   }
 
   /**
@@ -147,115 +126,5 @@ export class ModrinthAdapter implements IModSourcePort {
    */
   formatForEnv(project: ModProject): string {
     return project.slug;
-  }
-
-  /**
-   * Get project author from team ID
-   */
-  private async getProjectAuthor(teamId: string): Promise<string> {
-    try {
-      const response = await fetch(`${MODRINTH_API}/team/${teamId}/members`);
-      if (!response.ok) {
-        return 'Unknown';
-      }
-
-      const members = (await response.json()) as ModrinthTeamMemberRaw[];
-      const owner = members.find(m => m.role === 'Owner') ?? members[0];
-      return owner?.user?.username ?? 'Unknown';
-    } catch {
-      return 'Unknown';
-    }
-  }
-
-  /**
-   * Map search hit to domain model
-   */
-  private mapSearchHitToProject(hit: ModrinthSearchHitRaw): ModProject {
-    return {
-      slug: hit.slug,
-      title: hit.title,
-      description: hit.description,
-      downloads: hit.downloads,
-      iconUrl: hit.icon_url,
-      serverSide: hit.server_side,
-      clientSide: hit.client_side,
-      projectType: this.mapProjectType(hit.project_type),
-      categories: hit.categories,
-      author: hit.author,
-      license: hit.license,
-      sourceId: hit.project_id,
-      sourceName: this.sourceName,
-    };
-  }
-
-  /**
-   * Map raw project to domain model
-   */
-  private mapProjectRawToProject(raw: ModrinthProjectRaw, author: string): ModProject {
-    return {
-      slug: raw.slug,
-      title: raw.title,
-      description: raw.description,
-      downloads: raw.downloads,
-      iconUrl: raw.icon_url,
-      serverSide: raw.server_side,
-      clientSide: raw.client_side,
-      projectType: this.mapProjectType(raw.project_type),
-      categories: raw.categories,
-      author,
-      license: raw.license.id,
-      sourceId: raw.id,
-      sourceName: this.sourceName,
-    };
-  }
-
-  /**
-   * Map raw version to domain model
-   */
-  private mapVersionRawToVersion(raw: ModrinthVersionRaw): ModVersion {
-    return {
-      id: raw.id,
-      projectId: raw.project_id,
-      name: raw.name,
-      versionNumber: raw.version_number,
-      versionType: raw.version_type,
-      gameVersions: raw.game_versions,
-      loaders: raw.loaders,
-      files: raw.files.map(
-        (f): ModFile => ({
-          url: f.url,
-          filename: f.filename,
-          size: f.size,
-          hashes: {
-            sha1: f.hashes.sha1,
-            sha512: f.hashes.sha512,
-          },
-          primary: f.primary,
-        })
-      ),
-      dependencies: raw.dependencies.map(
-        (d): ModDependency => ({
-          projectId: d.project_id,
-          dependencyType: d.dependency_type,
-          versionId: d.version_id ?? undefined,
-        })
-      ),
-      downloads: raw.downloads,
-      datePublished: raw.date_published,
-      changelog: raw.changelog || undefined,
-    };
-  }
-
-  /**
-   * Map Modrinth project type to domain type
-   */
-  private mapProjectType(type: string): ModProjectType {
-    const typeMap: Record<string, ModProjectType> = {
-      mod: 'mod',
-      modpack: 'modpack',
-      resourcepack: 'resourcepack',
-      shader: 'shader',
-    };
-    return typeMap[type] ?? 'mod';
   }
 }

--- a/platform/services/mod-source-modrinth/src/index.ts
+++ b/platform/services/mod-source-modrinth/src/index.ts
@@ -4,6 +4,20 @@
  * Modrinth adapter for the mod source system.
  * Auto-registers with ModSourceFactory on import.
  *
+ * Architecture:
+ * ```
+ * mod-source-modrinth/src/
+ * ├── infrastructure/
+ * │   ├── api/
+ * │   │   └── ModrinthApiClient.ts   # HTTP client (single responsibility)
+ * │   └── mappers/
+ * │       └── ModrinthMapper.ts      # Raw → Domain transformation
+ * │
+ * ├── types.ts                       # Raw Modrinth API types
+ * ├── ModrinthAdapter.ts             # IModSourcePort implementation (composition)
+ * └── index.ts                       # Auto-registration & exports
+ * ```
+ *
  * @example
  * ```typescript
  * // Just import to register
@@ -13,6 +27,15 @@
  * import { ModSourceFactory } from '@minecraft-docker/shared';
  * const modrinth = ModSourceFactory.get('modrinth');
  * ```
+ *
+ * @example
+ * ```typescript
+ * // Or use components directly for testing
+ * import { ModrinthApiClient, ModrinthMapper, ModrinthAdapter } from '@minecraft-docker/mod-source-modrinth';
+ *
+ * const mockClient = new MockModrinthApiClient();
+ * const adapter = new ModrinthAdapter(mockClient, new ModrinthMapper());
+ * ```
  */
 
 import { ModSourceFactory } from '@minecraft-docker/shared';
@@ -20,6 +43,10 @@ import { ModrinthAdapter } from './ModrinthAdapter.js';
 
 // Export the adapter class for direct use if needed
 export { ModrinthAdapter } from './ModrinthAdapter.js';
+
+// Export infrastructure components for advanced usage and testing
+export { ModrinthApiClient, ModrinthMapper } from './infrastructure/index.js';
+export type { ModrinthSearchParams, ModrinthVersionParams } from './infrastructure/index.js';
 
 // Export raw types for advanced usage
 export type * from './types.js';

--- a/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
@@ -1,0 +1,148 @@
+/**
+ * ModrinthApiClient - HTTP client for Modrinth API
+ *
+ * Single responsibility: Make HTTP requests to Modrinth API
+ * Returns raw API responses without transformation
+ *
+ * @see https://docs.modrinth.com/api-spec
+ */
+
+import type {
+  ModrinthProjectRaw,
+  ModrinthSearchResultRaw,
+  ModrinthVersionRaw,
+  ModrinthTeamMemberRaw,
+} from '../../types.js';
+
+const MODRINTH_API = 'https://api.modrinth.com/v2';
+
+/**
+ * Search options for Modrinth API
+ */
+export interface ModrinthSearchParams {
+  query: string;
+  limit?: number;
+  offset?: number;
+  index?: 'relevance' | 'downloads' | 'follows' | 'newest' | 'updated';
+  facets?: string[][];
+}
+
+/**
+ * Version filter options for Modrinth API
+ */
+export interface ModrinthVersionParams {
+  loaders?: string[];
+  gameVersions?: string[];
+  featured?: boolean;
+}
+
+/**
+ * HTTP client for Modrinth API
+ *
+ * @example
+ * ```typescript
+ * const client = new ModrinthApiClient();
+ * const result = await client.search({ query: 'sodium' });
+ * const project = await client.getProject('sodium');
+ * ```
+ */
+export class ModrinthApiClient {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string = MODRINTH_API) {
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Search for projects
+   */
+  async search(params: ModrinthSearchParams): Promise<ModrinthSearchResultRaw> {
+    const urlParams = new URLSearchParams({
+      query: params.query,
+      limit: String(params.limit ?? 10),
+      offset: String(params.offset ?? 0),
+      index: params.index ?? 'relevance',
+    });
+
+    if (params.facets && params.facets.length > 0) {
+      urlParams.set('facets', JSON.stringify(params.facets));
+    }
+
+    const response = await fetch(`${this.baseUrl}/search?${urlParams}`);
+
+    if (!response.ok) {
+      throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<ModrinthSearchResultRaw>;
+  }
+
+  /**
+   * Get project by slug or ID
+   */
+  async getProject(slugOrId: string): Promise<ModrinthProjectRaw | null> {
+    const response = await fetch(`${this.baseUrl}/project/${slugOrId}`);
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<ModrinthProjectRaw>;
+  }
+
+  /**
+   * Get project versions
+   */
+  async getVersions(slugOrId: string, params?: ModrinthVersionParams): Promise<ModrinthVersionRaw[]> {
+    const urlParams = new URLSearchParams();
+
+    if (params?.loaders?.length) {
+      urlParams.set('loaders', JSON.stringify(params.loaders));
+    }
+    if (params?.gameVersions?.length) {
+      urlParams.set('game_versions', JSON.stringify(params.gameVersions));
+    }
+    if (params?.featured !== undefined) {
+      urlParams.set('featured', String(params.featured));
+    }
+
+    const queryString = urlParams.toString();
+    const url = `${this.baseUrl}/project/${slugOrId}/version${queryString ? '?' + queryString : ''}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<ModrinthVersionRaw[]>;
+  }
+
+  /**
+   * Get team members for a project
+   */
+  async getTeamMembers(teamId: string): Promise<ModrinthTeamMemberRaw[]> {
+    const response = await fetch(`${this.baseUrl}/team/${teamId}/members`);
+
+    if (!response.ok) {
+      return [];
+    }
+
+    return response.json() as Promise<ModrinthTeamMemberRaw[]>;
+  }
+
+  /**
+   * Check if API is available
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/`);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/platform/services/mod-source-modrinth/src/infrastructure/api/index.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/api/index.ts
@@ -1,0 +1,2 @@
+export { ModrinthApiClient } from './ModrinthApiClient.js';
+export type { ModrinthSearchParams, ModrinthVersionParams } from './ModrinthApiClient.js';

--- a/platform/services/mod-source-modrinth/src/infrastructure/index.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Infrastructure Layer
+ *
+ * Contains adapters for external systems:
+ * - api/: HTTP clients for external APIs
+ * - mappers/: Data transformation between external and domain models
+ */
+
+export * from './api/index.js';
+export * from './mappers/index.js';

--- a/platform/services/mod-source-modrinth/src/infrastructure/mappers/ModrinthMapper.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/mappers/ModrinthMapper.ts
@@ -1,0 +1,167 @@
+/**
+ * ModrinthMapper - Maps Modrinth API responses to domain models
+ *
+ * Single responsibility: Transform raw API types to domain models
+ * No HTTP calls, pure data transformation
+ */
+
+import type {
+  ModProject,
+  ModVersion,
+  ModFile,
+  ModDependency,
+  ModProjectType,
+  ModSearchResult,
+} from '@minecraft-docker/shared';
+
+import type {
+  ModrinthProjectRaw,
+  ModrinthSearchResultRaw,
+  ModrinthSearchHitRaw,
+  ModrinthVersionRaw,
+  ModrinthFileRaw,
+  ModrinthDependencyRaw,
+  ModrinthTeamMemberRaw,
+} from '../../types.js';
+
+/**
+ * Source name constant for Modrinth
+ */
+const SOURCE_NAME = 'modrinth';
+
+/**
+ * Mapper for transforming Modrinth API responses to domain models
+ *
+ * @example
+ * ```typescript
+ * const mapper = new ModrinthMapper();
+ * const domainProject = mapper.toProject(rawProject, 'AuthorName');
+ * const domainVersion = mapper.toVersion(rawVersion);
+ * ```
+ */
+export class ModrinthMapper {
+  /**
+   * Map search result to domain model
+   */
+  toSearchResult(raw: ModrinthSearchResultRaw): ModSearchResult {
+    return {
+      hits: raw.hits.map(hit => this.searchHitToProject(hit)),
+      totalHits: raw.total_hits,
+      offset: raw.offset,
+      limit: raw.limit,
+    };
+  }
+
+  /**
+   * Map search hit to ModProject
+   */
+  searchHitToProject(hit: ModrinthSearchHitRaw): ModProject {
+    return {
+      slug: hit.slug,
+      title: hit.title,
+      description: hit.description,
+      downloads: hit.downloads,
+      iconUrl: hit.icon_url,
+      serverSide: hit.server_side,
+      clientSide: hit.client_side,
+      projectType: this.toProjectType(hit.project_type),
+      categories: hit.categories,
+      author: hit.author,
+      license: hit.license,
+      sourceId: hit.project_id,
+      sourceName: SOURCE_NAME,
+    };
+  }
+
+  /**
+   * Map raw project to ModProject
+   */
+  toProject(raw: ModrinthProjectRaw, author: string): ModProject {
+    return {
+      slug: raw.slug,
+      title: raw.title,
+      description: raw.description,
+      downloads: raw.downloads,
+      iconUrl: raw.icon_url,
+      serverSide: raw.server_side,
+      clientSide: raw.client_side,
+      projectType: this.toProjectType(raw.project_type),
+      categories: raw.categories,
+      author,
+      license: raw.license.id,
+      sourceId: raw.id,
+      sourceName: SOURCE_NAME,
+    };
+  }
+
+  /**
+   * Map raw version to ModVersion
+   */
+  toVersion(raw: ModrinthVersionRaw): ModVersion {
+    return {
+      id: raw.id,
+      projectId: raw.project_id,
+      name: raw.name,
+      versionNumber: raw.version_number,
+      versionType: raw.version_type,
+      gameVersions: raw.game_versions,
+      loaders: raw.loaders,
+      files: raw.files.map(f => this.toFile(f)),
+      dependencies: raw.dependencies.map(d => this.toDependency(d)),
+      downloads: raw.downloads,
+      datePublished: raw.date_published,
+      changelog: raw.changelog || undefined,
+    };
+  }
+
+  /**
+   * Map raw file to ModFile
+   */
+  toFile(raw: ModrinthFileRaw): ModFile {
+    return {
+      url: raw.url,
+      filename: raw.filename,
+      size: raw.size,
+      hashes: {
+        sha1: raw.hashes.sha1,
+        sha512: raw.hashes.sha512,
+      },
+      primary: raw.primary,
+    };
+  }
+
+  /**
+   * Map raw dependency to ModDependency
+   */
+  toDependency(raw: ModrinthDependencyRaw): ModDependency {
+    return {
+      projectId: raw.project_id,
+      dependencyType: raw.dependency_type,
+      versionId: raw.version_id ?? undefined,
+    };
+  }
+
+  /**
+   * Extract author from team members
+   */
+  extractAuthor(members: ModrinthTeamMemberRaw[]): string {
+    if (members.length === 0) {
+      return 'Unknown';
+    }
+    const owner = members.find(m => m.role === 'Owner') ?? members[0];
+    return owner?.user?.username ?? 'Unknown';
+  }
+
+  /**
+   * Map Modrinth project type to domain type
+   */
+  private toProjectType(type: string): ModProjectType {
+    const typeMap: Record<string, ModProjectType> = {
+      mod: 'mod',
+      modpack: 'modpack',
+      resourcepack: 'resourcepack',
+      shader: 'shader',
+    };
+    return typeMap[type] ?? 'mod';
+  }
+}

--- a/platform/services/mod-source-modrinth/src/infrastructure/mappers/index.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/mappers/index.ts
@@ -1,0 +1,1 @@
+export { ModrinthMapper } from './ModrinthMapper.js';


### PR DESCRIPTION
## Summary

`mod-source-modrinth` 패키지에 Hexagonal Architecture / DDD 원칙을 적용하여 구조를 개선합니다.

### Before (플랫 구조)
```
src/
├── ModrinthAdapter.ts  # HTTP + 매핑 + 조합 혼재
├── types.ts
└── index.ts
```

### After (레이어드 구조)
```
src/
├── infrastructure/
│   ├── api/
│   │   └── ModrinthApiClient.ts   # 단일 책임: HTTP 요청
│   └── mappers/
│       └── ModrinthMapper.ts      # 단일 책임: Raw → Domain 변환
│
├── ModrinthAdapter.ts             # 조합: 컴포넌트 조합으로 IModSourcePort 구현
├── types.ts                       # Raw API 타입
└── index.ts                       # 자동 등록 & export
```

## 아키텍처 다이어그램

```
┌─────────────────────────────────────────────────────────────┐
│                 ModrinthAdapter (Composition)                │
│  - IModSourcePort 구현                                       │
│  - ApiClient와 Mapper 조합하여 비즈니스 로직 수행             │
└─────────────────────┬───────────────────┬───────────────────┘
                      │                   │
         ┌────────────▼────────┐ ┌────────▼──────────┐
         │  ModrinthApiClient  │ │  ModrinthMapper   │
         │  ────────────────── │ │ ─────────────────  │
         │  - HTTP 요청만 담당  │ │ - 데이터 변환만 담당│
         │  - Raw 타입 반환     │ │ - Raw → Domain    │
         └─────────────────────┘ └───────────────────┘
```

## 장점

| 항목 | 설명 |
|------|------|
| **단일 책임** | 각 클래스가 하나의 이유로만 변경됨 |
| **테스트 용이성** | ApiClient, Mapper를 독립적으로 Mock 가능 |
| **확장성** | 캐싱, 재시도, 인증 등 쉽게 추가 가능 |
| **의존성 주입** | 생성자를 통해 의존성 주입 가능 |

## Test plan

- [x] `pnpm build` 성공 확인
- [ ] `mcctl mod search sodium` 명령어 정상 동작 확인
- [ ] 기존 기능 회귀 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)