### PR TITLE
feat(shared): implement ApiPromptAdapter for non-interactive mode

### DIFF
--- a/platform/services/shared/package.json
+++ b/platform/services/shared/package.json
@@ -46,7 +46,7 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts",
-    "test": "npx tsx --test tests/YamlUserRepository.test.ts"
+    "test": "npx tsx --test tests/*.test.ts"
   },
   "keywords": [
     "minecraft",

--- a/platform/services/shared/src/infrastructure/adapters/ApiPromptAdapter.ts
+++ b/platform/services/shared/src/infrastructure/adapters/ApiPromptAdapter.ts
@@ -1,0 +1,402 @@
+import {
+  ServerName,
+  ServerType,
+  McVersion,
+  Memory,
+  WorldOptions,
+  Server,
+  World,
+} from '../../domain/index.js';
+import type {
+  IPromptPort,
+  TextPromptOptions,
+  SelectPromptOptions,
+  ConfirmPromptOptions,
+  PasswordPromptOptions,
+  Spinner,
+} from '../../application/ports/outbound/IPromptPort.js';
+import type { WorldWithServerStatus } from '../../application/ports/outbound/IWorldRepository.js';
+
+/**
+ * World setup types for API options
+ */
+export type WorldSetupType = 'new' | 'existing' | 'download';
+
+/**
+ * Options for ApiPromptAdapter
+ * Pre-configured values that would normally be collected via interactive prompts
+ */
+export interface ApiPromptOptions {
+  /** Server name (e.g., "myserver") */
+  serverName?: string;
+  /** Server type (e.g., "PAPER", "FORGE") */
+  serverType?: string;
+  /** Minecraft version (e.g., "1.21.1", "LATEST") */
+  mcVersion?: string;
+  /** Memory allocation (e.g., "4G", "2048M") */
+  memory?: string;
+  /** World setup type */
+  worldSetup?: WorldSetupType;
+  /** World name for existing world */
+  worldName?: string;
+  /** World seed for new world */
+  worldSeed?: string;
+  /** World download URL */
+  worldDownloadUrl?: string;
+  /** Password value for password prompts */
+  password?: string;
+  /** Default value for confirm prompts (defaults to true) */
+  confirmValue?: boolean;
+}
+
+/**
+ * Message types for collected output
+ */
+export type MessageType = 'intro' | 'outro' | 'success' | 'error' | 'warn' | 'info' | 'note';
+
+/**
+ * Collected message
+ */
+export interface CollectedMessage {
+  type: MessageType;
+  message: string;
+  title?: string;
+}
+
+/**
+ * Error thrown when API mode operation is not supported
+ */
+export class ApiModeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApiModeError';
+  }
+}
+
+/**
+ * ApiPromptAdapter
+ * Implements IPromptPort for API/non-interactive contexts.
+ * Returns pre-configured values instead of interactive prompts.
+ *
+ * Usage:
+ * ```typescript
+ * const adapter = new ApiPromptAdapter({
+ *   serverName: 'myserver',
+ *   serverType: 'PAPER',
+ *   mcVersion: '1.21.1',
+ *   memory: '4G',
+ *   worldSetup: 'new',
+ * });
+ *
+ * // Use with UseCase
+ * const useCase = new CreateServerUseCase(adapter, shell, serverRepo);
+ * await useCase.execute({ mode: 'cli' }); // Uses pre-configured values
+ * ```
+ */
+export class ApiPromptAdapter implements IPromptPort {
+  private readonly options: ApiPromptOptions;
+  private readonly messages: CollectedMessage[] = [];
+
+  constructor(options: ApiPromptOptions) {
+    this.options = options;
+  }
+
+  // ========================================
+  // Basic Prompts
+  // ========================================
+
+  intro(message: string): void {
+    this.messages.push({ type: 'intro', message });
+  }
+
+  outro(message: string): void {
+    this.messages.push({ type: 'outro', message });
+  }
+
+  async text(options: TextPromptOptions): Promise<string> {
+    // Try to match the prompt message to a known option
+    const value = this.resolveTextValue(options.message);
+    if (value !== undefined) {
+      return value;
+    }
+
+    throw new ApiModeError(
+      `Value for prompt "${options.message}" is required in API mode. ` +
+        'Please provide the appropriate option when creating ApiPromptAdapter.'
+    );
+  }
+
+  async select<T>(options: SelectPromptOptions<T>): Promise<T> {
+    // Try to match based on message context
+    const value = this.resolveSelectValue(options.message);
+    if (value !== undefined) {
+      // Verify the value is in the options list
+      const found = options.options.find((opt) => {
+        if (typeof opt.value === 'string') {
+          return opt.value.toLowerCase() === String(value).toLowerCase();
+        }
+        return opt.value === value;
+      });
+      if (found) {
+        return found.value;
+      }
+    }
+
+    // Return first option as fallback if available
+    if (options.options.length > 0 && options.initialValue !== undefined) {
+      return options.initialValue;
+    }
+
+    throw new ApiModeError(
+      `Selection for prompt "${options.message}" is required in API mode.`
+    );
+  }
+
+  async confirm(_options: ConfirmPromptOptions): Promise<boolean> {
+    // Default to true in API mode unless explicitly configured
+    return this.options.confirmValue ?? true;
+  }
+
+  async password(_options: PasswordPromptOptions): Promise<string> {
+    if (this.options.password !== undefined) {
+      return this.options.password;
+    }
+
+    throw new ApiModeError('Password is required in API mode.');
+  }
+
+  // ========================================
+  // Domain-Specific Prompts
+  // ========================================
+
+  async promptServerName(): Promise<ServerName> {
+    if (!this.options.serverName) {
+      throw new ApiModeError('serverName is required in API mode');
+    }
+    return ServerName.create(this.options.serverName);
+  }
+
+  async promptServerType(): Promise<ServerType> {
+    if (!this.options.serverType) {
+      throw new ApiModeError('serverType is required in API mode');
+    }
+    return ServerType.create(this.options.serverType);
+  }
+
+  async promptMcVersion(_serverType: ServerType): Promise<McVersion> {
+    if (!this.options.mcVersion) {
+      throw new ApiModeError('mcVersion is required in API mode');
+    }
+    return McVersion.create(this.options.mcVersion);
+  }
+
+  async promptMemory(): Promise<Memory> {
+    if (!this.options.memory) {
+      throw new ApiModeError('memory is required in API mode');
+    }
+    return Memory.create(this.options.memory);
+  }
+
+  async promptWorldOptions(): Promise<WorldOptions> {
+    if (!this.options.worldSetup) {
+      throw new ApiModeError('worldSetup is required in API mode');
+    }
+
+    switch (this.options.worldSetup) {
+      case 'new':
+        return WorldOptions.newWorld(this.options.worldSeed);
+
+      case 'existing':
+        if (!this.options.worldName) {
+          throw new ApiModeError(
+            'worldName is required when worldSetup is "existing"'
+          );
+        }
+        return WorldOptions.existingWorld(this.options.worldName);
+
+      case 'download':
+        if (!this.options.worldDownloadUrl) {
+          throw new ApiModeError(
+            'worldDownloadUrl is required when worldSetup is "download"'
+          );
+        }
+        return WorldOptions.downloadWorld(this.options.worldDownloadUrl);
+
+      default:
+        throw new ApiModeError(`Invalid worldSetup: ${this.options.worldSetup}`);
+    }
+  }
+
+  async promptServerSelection(servers: Server[]): Promise<Server> {
+    if (!this.options.serverName) {
+      throw new ApiModeError('serverName is required in API mode for server selection');
+    }
+
+    const server = servers.find(
+      (s) => s.name.value.toLowerCase() === this.options.serverName!.toLowerCase()
+    );
+
+    if (!server) {
+      throw new ApiModeError(`Server '${this.options.serverName}' not found`);
+    }
+
+    return server;
+  }
+
+  async promptWorldSelection(worlds: World[]): Promise<World> {
+    if (!this.options.worldName) {
+      throw new ApiModeError('worldName is required in API mode for world selection');
+    }
+
+    const world = worlds.find(
+      (w) => w.name.toLowerCase() === this.options.worldName!.toLowerCase()
+    );
+
+    if (!world) {
+      throw new ApiModeError(`World '${this.options.worldName}' not found`);
+    }
+
+    return world;
+  }
+
+  async promptExistingWorldSelection(
+    worlds: WorldWithServerStatus[]
+  ): Promise<World | null> {
+    // If no worldName is configured, return null (no selection)
+    if (!this.options.worldName) {
+      return null;
+    }
+
+    const worldEntry = worlds.find(
+      (w) => w.world.name.toLowerCase() === this.options.worldName!.toLowerCase()
+    );
+
+    if (!worldEntry) {
+      throw new ApiModeError(`World '${this.options.worldName}' not found`);
+    }
+
+    // In API mode, we don't warn about stopped servers - caller should check
+    return worldEntry.world;
+  }
+
+  // ========================================
+  // Status Display
+  // ========================================
+
+  spinner(): Spinner {
+    // Return a no-op spinner for API mode
+    return {
+      start: (_message?: string) => {},
+      stop: (_message?: string) => {},
+      message: (_message: string) => {},
+    };
+  }
+
+  success(message: string): void {
+    this.messages.push({ type: 'success', message });
+  }
+
+  error(message: string): void {
+    this.messages.push({ type: 'error', message });
+  }
+
+  warn(message: string): void {
+    this.messages.push({ type: 'warn', message });
+  }
+
+  info(message: string): void {
+    this.messages.push({ type: 'info', message });
+  }
+
+  note(message: string, title?: string): void {
+    this.messages.push({ type: 'note', message, title });
+  }
+
+  // ========================================
+  // Utility
+  // ========================================
+
+  isCancel(_value: unknown): boolean {
+    // In API mode, there's no user interaction to cancel
+    return false;
+  }
+
+  handleCancel(): never {
+    throw new ApiModeError('Cancel not supported in API mode');
+  }
+
+  // ========================================
+  // API-specific methods
+  // ========================================
+
+  /**
+   * Get all collected messages
+   */
+  getMessages(): CollectedMessage[] {
+    return [...this.messages];
+  }
+
+  /**
+   * Clear collected messages
+   */
+  clearMessages(): void {
+    this.messages.length = 0;
+  }
+
+  // ========================================
+  // Private Helpers
+  // ========================================
+
+  /**
+   * Resolve text prompt value from options based on message context
+   */
+  private resolveTextValue(message: string): string | undefined {
+    const lowerMessage = message.toLowerCase();
+
+    if (lowerMessage.includes('server name')) {
+      return this.options.serverName;
+    }
+    if (lowerMessage.includes('version')) {
+      return this.options.mcVersion;
+    }
+    if (lowerMessage.includes('memory')) {
+      return this.options.memory;
+    }
+    if (lowerMessage.includes('world') && lowerMessage.includes('name')) {
+      return this.options.worldName;
+    }
+    if (lowerMessage.includes('seed')) {
+      return this.options.worldSeed;
+    }
+    if (lowerMessage.includes('url')) {
+      return this.options.worldDownloadUrl;
+    }
+    if (lowerMessage.includes('password')) {
+      return this.options.password;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Resolve select prompt value from options based on message context
+   */
+  private resolveSelectValue(message: string): string | undefined {
+    const lowerMessage = message.toLowerCase();
+
+    if (lowerMessage.includes('server type') || lowerMessage.includes('type')) {
+      return this.options.serverType;
+    }
+    if (lowerMessage.includes('version')) {
+      return this.options.mcVersion;
+    }
+    if (lowerMessage.includes('memory')) {
+      return this.options.memory;
+    }
+    if (lowerMessage.includes('world') && lowerMessage.includes('setup')) {
+      return this.options.worldSetup;
+    }
+
+    return undefined;
+  }
+}

--- a/platform/services/shared/src/infrastructure/adapters/index.ts
+++ b/platform/services/shared/src/infrastructure/adapters/index.ts
@@ -8,3 +8,11 @@ export { ServerRepository } from './ServerRepository.js';
 export { WorldRepository } from './WorldRepository.js';
 export { DocsAdapter } from './DocsAdapter.js';
 export { YamlUserRepository } from './YamlUserRepository.js';
+export {
+  ApiPromptAdapter,
+  ApiModeError,
+  type ApiPromptOptions,
+  type WorldSetupType,
+  type MessageType,
+  type CollectedMessage,
+} from './ApiPromptAdapter.js';

--- a/platform/services/shared/tests/ApiPromptAdapter.test.ts
+++ b/platform/services/shared/tests/ApiPromptAdapter.test.ts
@@ -1,0 +1,352 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { ApiPromptAdapter, type ApiPromptOptions } from '../src/infrastructure/adapters/ApiPromptAdapter.js';
+import { ServerName } from '../src/domain/value-objects/ServerName.js';
+import { ServerType, ServerTypeEnum } from '../src/domain/value-objects/ServerType.js';
+import { McVersion } from '../src/domain/value-objects/McVersion.js';
+import { Memory } from '../src/domain/value-objects/Memory.js';
+import { WorldOptions } from '../src/domain/value-objects/WorldOptions.js';
+import { Server, ServerStatus } from '../src/domain/entities/Server.js';
+import { World } from '../src/domain/entities/World.js';
+
+describe('ApiPromptAdapter', () => {
+  describe('constructor and options', () => {
+    test('should create adapter with empty options', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.ok(adapter);
+    });
+
+    test('should create adapter with full options', () => {
+      const options: ApiPromptOptions = {
+        serverName: 'myserver',
+        serverType: 'PAPER',
+        mcVersion: '1.21.1',
+        memory: '4G',
+        worldSetup: 'new',
+      };
+      const adapter = new ApiPromptAdapter(options);
+      assert.ok(adapter);
+    });
+  });
+
+  describe('basic prompts', () => {
+    test('intro should not throw', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.doesNotThrow(() => adapter.intro('Test message'));
+    });
+
+    test('outro should not throw', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.doesNotThrow(() => adapter.outro('Test message'));
+    });
+
+    test('text should return pre-configured value when matching key exists', async () => {
+      const adapter = new ApiPromptAdapter({ serverName: 'myserver' });
+      const result = await adapter.text({ message: 'Server name:' });
+      assert.strictEqual(result, 'myserver');
+    });
+
+    test('text should throw when no matching value', async () => {
+      const adapter = new ApiPromptAdapter({});
+      await assert.rejects(
+        () => adapter.text({ message: 'Unknown prompt:' }),
+        { message: /required in API mode/ }
+      );
+    });
+
+    test('select should return pre-configured value', async () => {
+      const adapter = new ApiPromptAdapter({ serverType: 'FORGE' });
+      const result = await adapter.select({
+        message: 'Server type:',
+        options: [
+          { value: 'PAPER', label: 'Paper' },
+          { value: 'FORGE', label: 'Forge' },
+        ],
+      });
+      assert.strictEqual(result, 'FORGE');
+    });
+
+    test('confirm should return pre-configured value', async () => {
+      const adapter = new ApiPromptAdapter({ confirmValue: true });
+      const result = await adapter.confirm({ message: 'Continue?' });
+      assert.strictEqual(result, true);
+    });
+
+    test('confirm should default to true when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      const result = await adapter.confirm({ message: 'Continue?' });
+      assert.strictEqual(result, true);
+    });
+
+    test('password should return pre-configured value', async () => {
+      const adapter = new ApiPromptAdapter({ password: 'secret123' });
+      const result = await adapter.password({ message: 'Password:' });
+      assert.strictEqual(result, 'secret123');
+    });
+
+    test('password should throw when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      await assert.rejects(
+        () => adapter.password({ message: 'Password:' }),
+        { message: /required in API mode/ }
+      );
+    });
+  });
+
+  describe('domain-specific prompts', () => {
+    test('promptServerName should return ServerName from options', async () => {
+      const adapter = new ApiPromptAdapter({ serverName: 'myserver' });
+      const result = await adapter.promptServerName();
+      assert.ok(result instanceof ServerName);
+      assert.strictEqual(result.value, 'myserver');
+    });
+
+    test('promptServerName should throw when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      await assert.rejects(
+        () => adapter.promptServerName(),
+        { message: /serverName is required in API mode/ }
+      );
+    });
+
+    test('promptServerType should return ServerType from options', async () => {
+      const adapter = new ApiPromptAdapter({ serverType: 'FORGE' });
+      const result = await adapter.promptServerType();
+      assert.ok(result instanceof ServerType);
+      assert.strictEqual(result.value, ServerTypeEnum.FORGE);
+    });
+
+    test('promptServerType should throw when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      await assert.rejects(
+        () => adapter.promptServerType(),
+        { message: /serverType is required in API mode/ }
+      );
+    });
+
+    test('promptMcVersion should return McVersion from options', async () => {
+      const adapter = new ApiPromptAdapter({ mcVersion: '1.21.1' });
+      const result = await adapter.promptMcVersion(ServerType.create('PAPER'));
+      assert.ok(result instanceof McVersion);
+      assert.strictEqual(result.value, '1.21.1');
+    });
+
+    test('promptMcVersion should throw when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      await assert.rejects(
+        () => adapter.promptMcVersion(ServerType.create('PAPER')),
+        { message: /mcVersion is required in API mode/ }
+      );
+    });
+
+    test('promptMemory should return Memory from options', async () => {
+      const adapter = new ApiPromptAdapter({ memory: '8G' });
+      const result = await adapter.promptMemory();
+      assert.ok(result instanceof Memory);
+      assert.strictEqual(result.value, '8G');
+    });
+
+    test('promptMemory should throw when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      await assert.rejects(
+        () => adapter.promptMemory(),
+        { message: /memory is required in API mode/ }
+      );
+    });
+
+    test('promptWorldOptions should return new world options', async () => {
+      const adapter = new ApiPromptAdapter({ worldSetup: 'new' });
+      const result = await adapter.promptWorldOptions();
+      assert.ok(result instanceof WorldOptions);
+      assert.strictEqual(result.isNewWorld, true);
+    });
+
+    test('promptWorldOptions should return new world with seed', async () => {
+      const adapter = new ApiPromptAdapter({ worldSetup: 'new', worldSeed: '12345' });
+      const result = await adapter.promptWorldOptions();
+      assert.strictEqual(result.isNewWorld, true);
+      assert.strictEqual(result.seed, '12345');
+    });
+
+    test('promptWorldOptions should return existing world options', async () => {
+      const adapter = new ApiPromptAdapter({ worldSetup: 'existing', worldName: 'survival' });
+      const result = await adapter.promptWorldOptions();
+      assert.strictEqual(result.isExistingWorld, true);
+      assert.strictEqual(result.worldName, 'survival');
+    });
+
+    test('promptWorldOptions should return download world options', async () => {
+      const adapter = new ApiPromptAdapter({
+        worldSetup: 'download',
+        worldDownloadUrl: 'https://example.com/world.zip',
+      });
+      const result = await adapter.promptWorldOptions();
+      assert.strictEqual(result.isDownloadWorld, true);
+      assert.strictEqual(result.downloadUrl, 'https://example.com/world.zip');
+    });
+
+    test('promptWorldOptions should throw when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      await assert.rejects(
+        () => adapter.promptWorldOptions(),
+        { message: /worldSetup is required in API mode/ }
+      );
+    });
+
+    test('promptServerSelection should return server by name', async () => {
+      const adapter = new ApiPromptAdapter({ serverName: 'myserver' });
+      const servers = [
+        Server.fromStatus('myserver', 'PAPER', '1.21.1', ServerStatus.RUNNING, 0),
+        Server.fromStatus('other', 'FORGE', '1.20.4', ServerStatus.STOPPED, 0),
+      ];
+      const result = await adapter.promptServerSelection(servers);
+      assert.strictEqual(result.name.value, 'myserver');
+    });
+
+    test('promptServerSelection should throw when server not found', async () => {
+      const adapter = new ApiPromptAdapter({ serverName: 'nonexistent' });
+      const servers = [
+        Server.fromStatus('myserver', 'PAPER', '1.21.1', ServerStatus.RUNNING, 0),
+      ];
+      await assert.rejects(
+        () => adapter.promptServerSelection(servers),
+        { message: /Server 'nonexistent' not found/ }
+      );
+    });
+
+    test('promptServerSelection should throw when not configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      const servers = [
+        Server.fromStatus('myserver', 'PAPER', '1.21.1', ServerStatus.RUNNING, 0),
+      ];
+      await assert.rejects(
+        () => adapter.promptServerSelection(servers),
+        { message: /serverName is required in API mode/ }
+      );
+    });
+
+    test('promptWorldSelection should return world by name', async () => {
+      const adapter = new ApiPromptAdapter({ worldName: 'survival' });
+      const worlds = [
+        World.fromDirectory('survival', '/worlds'),
+        World.fromDirectory('creative', '/worlds'),
+      ];
+      const result = await adapter.promptWorldSelection(worlds);
+      assert.strictEqual(result.name, 'survival');
+    });
+
+    test('promptWorldSelection should throw when world not found', async () => {
+      const adapter = new ApiPromptAdapter({ worldName: 'nonexistent' });
+      const worlds = [World.fromDirectory('survival', '/worlds')];
+      await assert.rejects(
+        () => adapter.promptWorldSelection(worlds),
+        { message: /World 'nonexistent' not found/ }
+      );
+    });
+
+    test('promptExistingWorldSelection should return world by name', async () => {
+      const adapter = new ApiPromptAdapter({ worldName: 'survival' });
+      const worlds = [
+        { world: World.fromDirectory('survival', '/worlds'), category: 'available' as const, assignedServer: null },
+        { world: World.fromDirectory('creative', '/worlds'), category: 'stopped' as const, assignedServer: 'mc-other' },
+      ];
+      const result = await adapter.promptExistingWorldSelection(worlds);
+      assert.ok(result);
+      assert.strictEqual(result.name, 'survival');
+    });
+
+    test('promptExistingWorldSelection should return null when no worldName configured', async () => {
+      const adapter = new ApiPromptAdapter({});
+      const worlds = [
+        { world: World.fromDirectory('survival', '/worlds'), category: 'available' as const, assignedServer: null },
+      ];
+      const result = await adapter.promptExistingWorldSelection(worlds);
+      assert.strictEqual(result, null);
+    });
+  });
+
+  describe('status display methods', () => {
+    test('spinner should return no-op implementation', () => {
+      const adapter = new ApiPromptAdapter({});
+      const spinner = adapter.spinner();
+      assert.ok(spinner);
+      assert.doesNotThrow(() => spinner.start('Loading...'));
+      assert.doesNotThrow(() => spinner.message('Processing...'));
+      assert.doesNotThrow(() => spinner.stop('Done'));
+    });
+
+    test('success should not throw', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.doesNotThrow(() => adapter.success('Operation completed'));
+    });
+
+    test('error should not throw', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.doesNotThrow(() => adapter.error('Something went wrong'));
+    });
+
+    test('warn should not throw', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.doesNotThrow(() => adapter.warn('Warning message'));
+    });
+
+    test('info should not throw', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.doesNotThrow(() => adapter.info('Info message'));
+    });
+
+    test('note should not throw', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.doesNotThrow(() => adapter.note('Note message', 'Title'));
+    });
+  });
+
+  describe('utility methods', () => {
+    test('isCancel should always return false in API mode', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.strictEqual(adapter.isCancel(undefined), false);
+      assert.strictEqual(adapter.isCancel(null), false);
+      assert.strictEqual(adapter.isCancel('value'), false);
+      assert.strictEqual(adapter.isCancel(Symbol.for('cancel')), false);
+    });
+
+    test('handleCancel should throw ApiModeError', () => {
+      const adapter = new ApiPromptAdapter({});
+      assert.throws(
+        () => adapter.handleCancel(),
+        { name: 'ApiModeError', message: /Cancel not supported in API mode/ }
+      );
+    });
+  });
+
+  describe('message collector', () => {
+    test('getMessages should return collected messages', () => {
+      const adapter = new ApiPromptAdapter({});
+      adapter.intro('Intro');
+      adapter.success('Success');
+      adapter.error('Error');
+      adapter.warn('Warning');
+      adapter.info('Info');
+      adapter.outro('Outro');
+
+      const messages = adapter.getMessages();
+      assert.strictEqual(messages.length, 6);
+      assert.deepStrictEqual(messages[0], { type: 'intro', message: 'Intro' });
+      assert.deepStrictEqual(messages[1], { type: 'success', message: 'Success' });
+      assert.deepStrictEqual(messages[2], { type: 'error', message: 'Error' });
+      assert.deepStrictEqual(messages[3], { type: 'warn', message: 'Warning' });
+      assert.deepStrictEqual(messages[4], { type: 'info', message: 'Info' });
+      assert.deepStrictEqual(messages[5], { type: 'outro', message: 'Outro' });
+    });
+
+    test('clearMessages should reset collected messages', () => {
+      const adapter = new ApiPromptAdapter({});
+      adapter.success('Message 1');
+      adapter.success('Message 2');
+      assert.strictEqual(adapter.getMessages().length, 2);
+
+      adapter.clearMessages();
+      assert.strictEqual(adapter.getMessages().length, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `ApiPromptAdapter` class that implements `IPromptPort` interface
- Returns pre-configured values instead of interactive prompts
- Designed for API/non-interactive contexts (e.g., REST API, Web Admin)

## Features
- Accept configuration via constructor (`ApiPromptOptions`)
- Throw `ApiModeError` for missing required values with clear error messages
- Collect display messages for API response (`getMessages()`, `clearMessages()`)
- No-op spinner implementation for API mode
- `isCancel()` always returns `false` in API mode

## Test Plan
- [x] Unit tests for all `IPromptPort` methods (41 tests)
- [x] Domain-specific prompt validation tests
- [x] Message collection functionality tests
- [x] Build verification

## Files Changed
- `platform/services/shared/src/infrastructure/adapters/ApiPromptAdapter.ts` (new)
- `platform/services/shared/src/infrastructure/adapters/index.ts` (export added)
- `platform/services/shared/tests/ApiPromptAdapter.test.ts` (new)
- `platform/services/shared/package.json` (test script updated)

Closes #83

---
Generated with [Claude Code](https://claude.com/claude-code)