### PR TITLE
feat(mcctl-api): implement console exec route (#92)

### DIFF
--- a/platform/services/mcctl-api/src/app.ts
+++ b/platform/services/mcctl-api/src/app.ts
@@ -3,6 +3,7 @@ import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import { config } from './config/index.js';
 import authPlugin from './plugins/auth.js';
+import consoleRoutes from './routes/console.js';
 
 export interface BuildAppOptions {
   logger?: boolean;
@@ -38,6 +39,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
       timestamp: new Date().toISOString(),
     };
   });
+
+
+  // Register API routes
+  await app.register(consoleRoutes);
 
   // Graceful shutdown handler
   const gracefulShutdown = async (signal: string) => {

--- a/platform/services/mcctl-api/src/lib/rcon.ts
+++ b/platform/services/mcctl-api/src/lib/rcon.ts
@@ -1,0 +1,87 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Result of an RCON command execution
+ */
+export interface RconResult {
+  exitCode: number;
+  output: string;
+}
+
+/**
+ * Get container name from server name
+ * Ensures the container name has the 'mc-' prefix
+ */
+export function getContainerName(serverName: string): string {
+  return serverName.startsWith('mc-') ? serverName : `mc-${serverName}`;
+}
+
+/**
+ * Execute RCON command and capture output
+ * Uses docker exec to run rcon-cli inside the container
+ */
+export async function execRcon(
+  containerName: string,
+  command: string
+): Promise<RconResult> {
+  // Split command into parts for rcon-cli
+  // Note: rcon-cli accepts the full command as a single argument
+  const normalizedContainer = getContainerName(containerName);
+
+  return new Promise((resolve) => {
+    const child = spawn('docker', ['exec', normalizedContainer, 'rcon-cli', command], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code: number | null) => {
+      resolve({
+        exitCode: code ?? 1,
+        output: stdout || stderr,
+      });
+    });
+
+    child.on('error', (err: Error) => {
+      resolve({
+        exitCode: 1,
+        output: err.message,
+      });
+    });
+  });
+}
+
+/**
+ * Check if a Docker container is running
+ */
+export async function isContainerRunning(containerName: string): Promise<boolean> {
+  const normalizedContainer = getContainerName(containerName);
+
+  return new Promise((resolve) => {
+    const child = spawn('docker', ['inspect', '-f', '{{.State.Running}}', normalizedContainer], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => {
+      output += data.toString();
+    });
+
+    child.on('close', (code: number | null) => {
+      resolve(code === 0 && output.trim() === 'true');
+    });
+
+    child.on('error', () => {
+      resolve(false);
+    });
+  });
+}

--- a/platform/services/mcctl-api/src/routes/console.ts
+++ b/platform/services/mcctl-api/src/routes/console.ts
@@ -1,0 +1,131 @@
+import { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+import { execRcon } from '../lib/rcon.js';
+
+// ============================================================
+// Types
+// ============================================================
+
+interface ExecCommandBody {
+  command: string;
+}
+
+interface ExecCommandParams {
+  id: string;
+}
+
+interface ExecCommandResponse {
+  output: string;
+  exitCode: number;
+}
+
+interface ErrorResponse {
+  error: string;
+  message: string;
+}
+
+// ============================================================
+// JSON Schema for validation
+// ============================================================
+
+const execCommandSchema = {
+  body: {
+    type: 'object',
+    required: ['command'],
+    properties: {
+      command: {
+        type: 'string',
+        minLength: 1,
+        description: 'RCON command to execute',
+      },
+    },
+  },
+  params: {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: {
+        type: 'string',
+        description: 'Server ID (name)',
+      },
+    },
+  },
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        output: { type: 'string' },
+        exitCode: { type: 'number' },
+      },
+    },
+    400: {
+      type: 'object',
+      properties: {
+        error: { type: 'string' },
+        message: { type: 'string' },
+      },
+    },
+  },
+};
+
+// ============================================================
+// Plugin Implementation
+// ============================================================
+
+const consoleRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+  /**
+   * POST /servers/:id/console/exec
+   * Execute an RCON command on the specified server
+   */
+  fastify.post<{
+    Body: ExecCommandBody;
+    Params: ExecCommandParams;
+    Reply: ExecCommandResponse | ErrorResponse;
+  }>(
+    '/servers/:id/console/exec',
+    {
+      schema: execCommandSchema,
+    },
+    async (request, reply) => {
+      const { id: serverId } = request.params;
+      const { command } = request.body;
+
+      // Validation is handled by schema, but double-check for safety
+      if (!command || command.trim().length === 0) {
+        return reply.code(400).send({
+          error: 'ValidationError',
+          message: 'Command is required and cannot be empty',
+        });
+      }
+
+      fastify.log.info({ serverId, command }, 'Executing RCON command');
+
+      try {
+        const result = await execRcon(serverId, command);
+
+        return reply.send({
+          output: result.output.trim(),
+          exitCode: result.exitCode,
+        });
+      } catch (error) {
+        fastify.log.error({ serverId, command, error }, 'RCON execution failed');
+
+        return reply.code(500).send({
+          error: 'RconExecutionError',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    }
+  );
+};
+
+// ============================================================
+// Export
+// ============================================================
+
+export default fp(consoleRoutes, {
+  name: 'console-routes',
+  fastify: '5.x',
+});
+
+export { consoleRoutes };

--- a/platform/services/mcctl-api/tests/console.test.ts
+++ b/platform/services/mcctl-api/tests/console.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+
+// Mock node:child_process module for rcon.ts
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+import { spawn } from 'node:child_process';
+
+describe('Console Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp({ logger: false });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /servers/:id/console/exec', () => {
+    it('should execute RCON command and return output', async () => {
+      // Mock successful RCON execution
+      const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+      mockSpawn.mockImplementation(() => {
+        const mockProcess = {
+          stdout: {
+            on: vi.fn((event, callback) => {
+              if (event === 'data') {
+                callback(Buffer.from('Hello, World!'));
+              }
+            }),
+          },
+          stderr: {
+            on: vi.fn(),
+          },
+          on: vi.fn((event, callback) => {
+            if (event === 'close') {
+              setTimeout(() => callback(0), 10);
+            }
+          }),
+        };
+        return mockProcess;
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/servers/myserver/console/exec',
+        payload: {
+          command: 'say Hello, World!',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty('output');
+      expect(body).toHaveProperty('exitCode');
+      expect(body.exitCode).toBe(0);
+    });
+
+    it('should return 400 if command is missing', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/servers/myserver/console/exec',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('should return 400 if command is empty', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/servers/myserver/console/exec',
+        payload: {
+          command: '',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('should handle RCON execution errors', async () => {
+      const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+      mockSpawn.mockImplementation(() => {
+        const mockProcess = {
+          stdout: {
+            on: vi.fn(),
+          },
+          stderr: {
+            on: vi.fn((event, callback) => {
+              if (event === 'data') {
+                callback(Buffer.from('Connection refused'));
+              }
+            }),
+          },
+          on: vi.fn((event, callback) => {
+            if (event === 'close') {
+              setTimeout(() => callback(1), 10);
+            }
+          }),
+        };
+        return mockProcess;
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/servers/offline-server/console/exec',
+        payload: {
+          command: 'list',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.exitCode).toBe(1);
+    });
+
+    it('should normalize server name with mc- prefix', async () => {
+      const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+      mockSpawn.mockImplementation((cmd: string, args: string[]) => {
+        // Verify container name has mc- prefix
+        expect(args).toContain('mc-testserver');
+
+        const mockProcess = {
+          stdout: {
+            on: vi.fn((event, callback) => {
+              if (event === 'data') {
+                callback(Buffer.from('OK'));
+              }
+            }),
+          },
+          stderr: {
+            on: vi.fn(),
+          },
+          on: vi.fn((event, callback) => {
+            if (event === 'close') {
+              setTimeout(() => callback(0), 10);
+            }
+          }),
+        };
+        return mockProcess;
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/servers/testserver/console/exec',
+        payload: {
+          command: 'list',
+        },
+      });
+    });
+
+    it('should not double-prefix server name that already has mc-', async () => {
+      const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+      mockSpawn.mockImplementation((cmd: string, args: string[]) => {
+        // Verify container name is NOT mc-mc-testserver
+        expect(args).toContain('mc-testserver');
+        expect(args).not.toContain('mc-mc-testserver');
+
+        const mockProcess = {
+          stdout: {
+            on: vi.fn((event, callback) => {
+              if (event === 'data') {
+                callback(Buffer.from('OK'));
+              }
+            }),
+          },
+          stderr: {
+            on: vi.fn(),
+          },
+          on: vi.fn((event, callback) => {
+            if (event === 'close') {
+              setTimeout(() => callback(0), 10);
+            }
+          }),
+        };
+        return mockProcess;
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/servers/mc-testserver/console/exec',
+        payload: {
+          command: 'list',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /servers/:id/console/exec` endpoint for executing RCON commands
- Implement RCON utility using docker exec rcon-cli
- Add comprehensive unit tests with mocked spawn

## Changes
- `src/routes/console.ts`: Console route plugin with JSON schema validation
- `src/lib/rcon.ts`: RCON execution utility (docker exec wrapper)
- `tests/console.test.ts`: Unit tests for all console route scenarios

## API Endpoint
```
POST /servers/:id/console/exec
Request:  { "command": "say Hello" }
Response: { "output": "...", "exitCode": 0 }
```

## Test plan
- [x] Unit tests pass (6/6 tests)
- [x] Build succeeds
- [ ] Manual test with running Minecraft server

Closes #92

---
Generated with [Claude Code](https://claude.com/claude-code)