### PR TITLE
feat(mcctl-api): add Dockerfile for container build (#94)

### DIFF
--- a/platform/services/mcctl-api/.dockerignore
+++ b/platform/services/mcctl-api/.dockerignore
@@ -1,0 +1,57 @@
+# Dependencies
+node_modules
+.pnpm-store
+
+# Build outputs
+dist
+*.tsbuildinfo
+
+# Development files
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# IDE and editor files
+.idea
+.vscode
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test files
+tests
+*.test.ts
+*.spec.ts
+coverage
+.nyc_output
+
+# Documentation
+docs
+*.md
+!README.md
+
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile*
+docker-compose*
+.docker
+
+# Misc
+.eslintrc*
+.prettierrc*
+tsconfig.json
+vitest.config.ts

--- a/platform/services/mcctl-api/Dockerfile
+++ b/platform/services/mcctl-api/Dockerfile
@@ -1,0 +1,89 @@
+# ============================================================
+# mcctl-api Dockerfile
+# Multi-stage build for production-ready container
+# ============================================================
+
+# Build stage
+FROM node:20-alpine AS builder
+
+# Install build dependencies for native modules (bcrypt)
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /app
+
+# Enable corepack for pnpm
+RUN corepack enable pnpm
+
+# Copy workspace configuration files
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY tsconfig.base.json ./
+
+# Copy shared package (dependency)
+COPY platform/services/shared ./platform/services/shared
+
+# Copy mcctl-api package
+COPY platform/services/mcctl-api ./platform/services/mcctl-api
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Build shared package first (dependency)
+RUN pnpm --filter @minecraft-docker/shared build
+
+# Build mcctl-api
+RUN pnpm --filter @minecraft-docker/mcctl-api build
+
+# Prune development dependencies
+RUN pnpm --filter @minecraft-docker/mcctl-api --prod deploy /app/production
+
+# ============================================================
+# Production stage
+# ============================================================
+FROM node:20-alpine AS runner
+
+# Install runtime dependencies for health check
+RUN apk add --no-cache wget
+
+WORKDIR /app
+
+# Set environment
+ENV NODE_ENV=production
+ENV PORT=3001
+ENV HOST=0.0.0.0
+
+# Create non-root user for security
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 --ingroup nodejs mcctl
+
+# Copy built artifacts from builder
+COPY --from=builder --chown=mcctl:nodejs /app/production/dist ./dist
+COPY --from=builder --chown=mcctl:nodejs /app/production/node_modules ./node_modules
+COPY --from=builder --chown=mcctl:nodejs /app/production/package.json ./package.json
+
+# Copy shared package dist (required for workspace dependency)
+COPY --from=builder --chown=mcctl:nodejs /app/platform/services/shared/dist ./node_modules/@minecraft-docker/shared/dist
+COPY --from=builder --chown=mcctl:nodejs /app/platform/services/shared/package.json ./node_modules/@minecraft-docker/shared/package.json
+
+# Create data directory for MCCTL_ROOT
+RUN mkdir -p /data && chown mcctl:nodejs /data
+
+# Health check configuration
+# - interval: Check every 30 seconds
+# - timeout: Fail if no response within 3 seconds
+# - start-period: Allow 5 seconds for startup
+# - retries: Mark unhealthy after 3 consecutive failures
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3001/health || exit 1
+
+# Expose API port
+EXPOSE 3001
+
+# Switch to non-root user
+USER mcctl
+
+# Default environment variables
+ENV MCCTL_ROOT=/data
+ENV LOG_LEVEL=info
+
+# Start the application
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile for mcctl-api container build
- Add .dockerignore to optimize build context
- Image size: 156MB (target < 200MB achieved)

## Changes
- `platform/services/mcctl-api/Dockerfile`: Multi-stage build with builder and runner stages
- `platform/services/mcctl-api/.dockerignore`: Exclude unnecessary files from build context

## Features
- **Multi-stage build**: Separates build and runtime for smaller image
- **Health check**: Configured at `/health` endpoint (30s interval, 3s timeout)
- **Non-root user**: Runs as `mcctl:nodejs` (UID 1001) for security
- **Docker socket support**: Can mount `/var/run/docker.sock` for container management

## Build Command
```bash
docker build -t minecraft-docker/mcctl-api:latest -f platform/services/mcctl-api/Dockerfile .
```

## Run Command
```bash
docker run -d \
  --name mcctl-api \
  -p 3001:3001 \
  -e AUTH_MODE=api-key \
  -e AUTH_API_KEY=your-secret-key \
  -v ~/minecraft-servers:/data \
  -v /var/run/docker.sock:/var/run/docker.sock \
  minecraft-docker/mcctl-api:latest
```

## Environment Variables
| Variable | Default | Description |
|----------|---------|-------------|
| `MCCTL_ROOT` | `/data` | Data directory |
| `PORT` | `3001` | Listen port |
| `HOST` | `0.0.0.0` | Listen address |
| `AUTH_MODE` | `api-key` (prod) | Authentication mode |
| `LOG_LEVEL` | `info` | Logging level |

## Test Results
- [x] Docker build succeeds
- [x] Image size < 200MB (156MB)
- [x] Health check works (`/health` returns `{"status":"ok"}`)
- [x] Non-root user for security (mcctl:nodejs)
- [x] Container starts successfully

## Related Issues
- Closes #94
- Depends on #93 (Swagger documentation)
- Blocks #101 (DevOps Docker Compose integration)

---

## Test Plan
- [x] Build Docker image locally
- [x] Verify image size < 200MB
- [x] Start container and verify health endpoint
- [x] Confirm running as non-root user

---
Generated with [Claude Code](https://claude.com/claude-code)