### PR TITLE
feat(mcctl-api): add world management REST API routes (#91)

### DIFF
--- a/platform/services/mcctl-api/src/app.ts
+++ b/platform/services/mcctl-api/src/app.ts
@@ -7,6 +7,7 @@ import swaggerPlugin from './plugins/swagger.js';
 import serversRoutes from './routes/servers.js';
 import serverActionsRoutes from './routes/servers/actions.js';
 import consoleRoutes from './routes/console.js';
+import worldsRoutes from './routes/worlds.js';
 
 export interface BuildAppOptions {
   logger?: boolean;
@@ -48,6 +49,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // Register server routes
   await app.register(serversRoutes);
   await app.register(serverActionsRoutes);
+
+  // Register world routes
+  await app.register(worldsRoutes);
 
   // Health check endpoint
   app.get('/health', async () => {

--- a/platform/services/mcctl-api/src/routes/worlds.ts
+++ b/platform/services/mcctl-api/src/routes/worlds.ts
@@ -1,0 +1,419 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+import {
+  WorldManagementUseCase,
+  ApiPromptAdapter,
+  ShellAdapter,
+  WorldRepository,
+  ServerRepository,
+  Paths,
+} from '@minecraft-docker/shared';
+import {
+  WorldListResponseSchema,
+  WorldDetailResponseSchema,
+  CreateWorldResponseSchema,
+  AssignWorldResponseSchema,
+  ReleaseWorldResponseSchema,
+  DeleteWorldResponseSchema,
+  WorldErrorResponseSchema,
+  WorldNameParamsSchema,
+  CreateWorldRequestSchema,
+  AssignWorldRequestSchema,
+  DeleteWorldQuerySchema,
+  ReleaseWorldQuerySchema,
+  type WorldNameParams,
+  type CreateWorldRequest,
+  type AssignWorldRequest,
+  type DeleteWorldQuery,
+  type ReleaseWorldQuery,
+} from '../schemas/world.js';
+
+// Route generic interfaces for type-safe request handling
+interface WorldNameRoute {
+  Params: WorldNameParams;
+}
+
+interface CreateWorldRoute {
+  Body: CreateWorldRequest;
+}
+
+interface AssignWorldRoute {
+  Params: WorldNameParams;
+  Body: AssignWorldRequest;
+}
+
+interface ReleaseWorldRoute {
+  Params: WorldNameParams;
+  Querystring: ReleaseWorldQuery;
+}
+
+interface DeleteWorldRoute {
+  Params: WorldNameParams;
+  Querystring: DeleteWorldQuery;
+}
+
+/**
+ * Create WorldManagementUseCase instance with API adapters
+ */
+function createWorldUseCase(options?: {
+  serverName?: string;
+  worldName?: string;
+  worldSeed?: string;
+  confirmValue?: boolean;
+}): WorldManagementUseCase {
+  const paths = new Paths();
+  const prompt = new ApiPromptAdapter({
+    serverName: options?.serverName,
+    worldName: options?.worldName,
+    worldSeed: options?.worldSeed,
+    confirmValue: options?.confirmValue ?? true,
+  });
+  const shell = new ShellAdapter({ paths });
+  const worldRepo = new WorldRepository(paths);
+  const serverRepo = new ServerRepository(paths);
+
+  return new WorldManagementUseCase(prompt, shell, worldRepo, serverRepo);
+}
+
+/**
+ * Worlds routes plugin
+ * Provides REST API for Minecraft world management
+ */
+const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+  /**
+   * GET /api/worlds
+   * List all worlds with lock status
+   */
+  fastify.get('/api/worlds', {
+    schema: {
+      tags: ['worlds'],
+      summary: 'List all worlds',
+      description: 'Returns a list of all available worlds with their lock status',
+      response: {
+        200: WorldListResponseSchema,
+        500: WorldErrorResponseSchema,
+      },
+    },
+  }, async (_request, reply) => {
+    try {
+      const useCase = createWorldUseCase();
+      const worlds = await useCase.listWorlds();
+
+      return reply.send({
+        worlds: worlds.map((world) => ({
+          name: world.name,
+          path: world.path,
+          isLocked: world.isLocked,
+          lockedBy: world.lockedBy,
+          size: world.size,
+          lastModified: world.lastModified?.toISOString(),
+        })),
+        total: worlds.length,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to list worlds');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to list worlds',
+      });
+    }
+  });
+
+  /**
+   * GET /api/worlds/:name
+   * Get world details
+   */
+  fastify.get<WorldNameRoute>('/api/worlds/:name', {
+    schema: {
+      tags: ['worlds'],
+      summary: 'Get world details',
+      description: 'Returns detailed information about a specific world',
+      params: WorldNameParamsSchema,
+      response: {
+        200: WorldDetailResponseSchema,
+        404: WorldErrorResponseSchema,
+        500: WorldErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<WorldNameRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+
+    try {
+      const useCase = createWorldUseCase();
+      const worlds = await useCase.listWorlds();
+      const world = worlds.find((w) => w.name === name);
+
+      if (!world) {
+        return reply.code(404).send({
+          error: 'NotFound',
+          message: `World '${name}' not found`,
+        });
+      }
+
+      return reply.send({
+        world: {
+          name: world.name,
+          path: world.path,
+          isLocked: world.isLocked,
+          lockedBy: world.lockedBy,
+          size: world.size,
+          lastModified: world.lastModified?.toISOString(),
+        },
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get world details');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to get world details',
+      });
+    }
+  });
+
+  /**
+   * POST /api/worlds
+   * Create a new world
+   */
+  fastify.post<CreateWorldRoute>('/api/worlds', {
+    schema: {
+      tags: ['worlds'],
+      summary: 'Create a new world',
+      description: 'Creates a new world with optional seed and server assignment',
+      body: CreateWorldRequestSchema,
+      response: {
+        201: CreateWorldResponseSchema,
+        400: WorldErrorResponseSchema,
+        500: WorldErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<CreateWorldRoute>, reply: FastifyReply) => {
+    const { name, seed, serverName, autoStart } = request.body;
+
+    try {
+      const useCase = createWorldUseCase({
+        serverName,
+        worldName: name,
+        worldSeed: seed,
+      });
+
+      const result = await useCase.createWorld({
+        name,
+        seed,
+        serverName,
+        autoStart: autoStart ?? false,
+      });
+
+      if (!result.success) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: result.error || 'Failed to create world',
+        });
+      }
+
+      return reply.code(201).send({
+        success: true,
+        worldName: result.worldName,
+        seed: result.seed,
+        serverName: result.serverName,
+        started: result.started,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to create world');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to create world',
+      });
+    }
+  });
+
+  /**
+   * POST /api/worlds/:name/assign
+   * Assign world to a server
+   */
+  fastify.post<AssignWorldRoute>('/api/worlds/:name/assign', {
+    schema: {
+      tags: ['worlds'],
+      summary: 'Assign world to server',
+      description: 'Assigns a world to a specific server. The world must not be already locked.',
+      params: WorldNameParamsSchema,
+      body: AssignWorldRequestSchema,
+      response: {
+        200: AssignWorldResponseSchema,
+        400: WorldErrorResponseSchema,
+        404: WorldErrorResponseSchema,
+        409: WorldErrorResponseSchema,
+        500: WorldErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<AssignWorldRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { serverName } = request.body;
+
+    try {
+      const useCase = createWorldUseCase({
+        serverName,
+        worldName: name,
+      });
+
+      const result = await useCase.assignWorldByName(name, serverName);
+
+      if (!result.success) {
+        // Determine appropriate error code
+        if (result.error?.includes('not found')) {
+          return reply.code(404).send({
+            error: 'NotFound',
+            message: result.error,
+          });
+        }
+        if (result.error?.includes('locked')) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            message: result.error,
+          });
+        }
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: result.error || 'Failed to assign world',
+        });
+      }
+
+      return reply.send({
+        success: true,
+        worldName: result.worldName,
+        serverName: result.serverName,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to assign world');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to assign world',
+      });
+    }
+  });
+
+  /**
+   * POST /api/worlds/:name/release
+   * Release world lock
+   */
+  fastify.post<ReleaseWorldRoute>('/api/worlds/:name/release', {
+    schema: {
+      tags: ['worlds'],
+      summary: 'Release world lock',
+      description: 'Releases the lock on a world. The world must be currently locked.',
+      params: WorldNameParamsSchema,
+      querystring: ReleaseWorldQuerySchema,
+      response: {
+        200: ReleaseWorldResponseSchema,
+        400: WorldErrorResponseSchema,
+        404: WorldErrorResponseSchema,
+        500: WorldErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<ReleaseWorldRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { force } = request.query;
+
+    try {
+      const useCase = createWorldUseCase({
+        worldName: name,
+      });
+
+      const result = await useCase.releaseWorldByName(name, force);
+
+      if (!result.success) {
+        if (result.error?.includes('not found')) {
+          return reply.code(404).send({
+            error: 'NotFound',
+            message: result.error,
+          });
+        }
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: result.error || 'Failed to release world',
+        });
+      }
+
+      return reply.send({
+        success: true,
+        worldName: result.worldName,
+        previousServer: result.previousServer,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to release world');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to release world',
+      });
+    }
+  });
+
+  /**
+   * DELETE /api/worlds/:name
+   * Delete a world
+   */
+  fastify.delete<DeleteWorldRoute>('/api/worlds/:name', {
+    schema: {
+      tags: ['worlds'],
+      summary: 'Delete a world',
+      description: 'Deletes a world. Locked worlds cannot be deleted unless force=true.',
+      params: WorldNameParamsSchema,
+      querystring: DeleteWorldQuerySchema,
+      response: {
+        200: DeleteWorldResponseSchema,
+        400: WorldErrorResponseSchema,
+        404: WorldErrorResponseSchema,
+        409: WorldErrorResponseSchema,
+        500: WorldErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<DeleteWorldRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { force } = request.query;
+
+    try {
+      const useCase = createWorldUseCase({
+        worldName: name,
+        confirmValue: true, // Auto-confirm in API mode
+      });
+
+      const result = await useCase.deleteWorldByName(name, force);
+
+      if (!result.success) {
+        if (result.error?.includes('not found')) {
+          return reply.code(404).send({
+            error: 'NotFound',
+            message: result.error,
+          });
+        }
+        if (result.error?.includes('locked')) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            message: result.error,
+          });
+        }
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: result.error || 'Failed to delete world',
+        });
+      }
+
+      return reply.send({
+        success: true,
+        worldName: result.worldName,
+        size: result.size,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to delete world');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to delete world',
+      });
+    }
+  });
+};
+
+export default fp(worldsPlugin, {
+  name: 'worlds-routes',
+  fastify: '5.x',
+});
+
+export { worldsPlugin };

--- a/platform/services/mcctl-api/src/schemas/world.ts
+++ b/platform/services/mcctl-api/src/schemas/world.ts
@@ -1,0 +1,158 @@
+import { Type, Static } from '@sinclair/typebox';
+
+// ========================================
+// World Schemas
+// ========================================
+
+/**
+ * World summary for list responses
+ */
+export const WorldSummarySchema = Type.Object({
+  name: Type.String(),
+  path: Type.String(),
+  isLocked: Type.Boolean(),
+  lockedBy: Type.Optional(Type.String()),
+  size: Type.String(),
+  lastModified: Type.Optional(Type.String({ format: 'date-time' })),
+});
+
+/**
+ * World detail response
+ */
+export const WorldDetailSchema = Type.Object({
+  name: Type.String(),
+  path: Type.String(),
+  isLocked: Type.Boolean(),
+  lockedBy: Type.Optional(Type.String()),
+  size: Type.String(),
+  lastModified: Type.Optional(Type.String({ format: 'date-time' })),
+});
+
+// ========================================
+// Request Schemas
+// ========================================
+
+/**
+ * World name path parameter
+ */
+export const WorldNameParamsSchema = Type.Object({
+  name: Type.String({ minLength: 1 }),
+});
+
+/**
+ * Create world request body
+ */
+export const CreateWorldRequestSchema = Type.Object({
+  name: Type.String({ minLength: 1, pattern: '^[a-zA-Z0-9_-]+$' }),
+  seed: Type.Optional(Type.String()),
+  serverName: Type.Optional(Type.String()),
+  autoStart: Type.Optional(Type.Boolean({ default: false })),
+});
+
+/**
+ * Assign world request body
+ */
+export const AssignWorldRequestSchema = Type.Object({
+  serverName: Type.String({ minLength: 1 }),
+});
+
+/**
+ * Delete world query parameters
+ */
+export const DeleteWorldQuerySchema = Type.Object({
+  force: Type.Optional(Type.Boolean({ default: false })),
+});
+
+/**
+ * Release world query parameters
+ */
+export const ReleaseWorldQuerySchema = Type.Object({
+  force: Type.Optional(Type.Boolean({ default: false })),
+});
+
+// ========================================
+// Response Schemas
+// ========================================
+
+/**
+ * World list response
+ */
+export const WorldListResponseSchema = Type.Object({
+  worlds: Type.Array(WorldSummarySchema),
+  total: Type.Number(),
+});
+
+/**
+ * World detail response
+ */
+export const WorldDetailResponseSchema = Type.Object({
+  world: WorldDetailSchema,
+});
+
+/**
+ * Create world response
+ */
+export const CreateWorldResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  worldName: Type.String(),
+  seed: Type.Optional(Type.String()),
+  serverName: Type.Optional(Type.String()),
+  started: Type.Optional(Type.Boolean()),
+  error: Type.Optional(Type.String()),
+});
+
+/**
+ * Assign world response
+ */
+export const AssignWorldResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  worldName: Type.String(),
+  serverName: Type.String(),
+  error: Type.Optional(Type.String()),
+});
+
+/**
+ * Release world response
+ */
+export const ReleaseWorldResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  worldName: Type.String(),
+  previousServer: Type.Optional(Type.String()),
+  error: Type.Optional(Type.String()),
+});
+
+/**
+ * Delete world response
+ */
+export const DeleteWorldResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  worldName: Type.String(),
+  size: Type.Optional(Type.String()),
+  error: Type.Optional(Type.String()),
+});
+
+/**
+ * Error response
+ */
+export const WorldErrorResponseSchema = Type.Object({
+  error: Type.String(),
+  message: Type.String(),
+});
+
+// ========================================
+// Type Exports
+// ========================================
+
+export type WorldSummary = Static<typeof WorldSummarySchema>;
+export type WorldDetail = Static<typeof WorldDetailSchema>;
+export type WorldNameParams = Static<typeof WorldNameParamsSchema>;
+export type CreateWorldRequest = Static<typeof CreateWorldRequestSchema>;
+export type AssignWorldRequest = Static<typeof AssignWorldRequestSchema>;
+export type DeleteWorldQuery = Static<typeof DeleteWorldQuerySchema>;
+export type ReleaseWorldQuery = Static<typeof ReleaseWorldQuerySchema>;
+export type WorldListResponse = Static<typeof WorldListResponseSchema>;
+export type WorldDetailResponse = Static<typeof WorldDetailResponseSchema>;
+export type CreateWorldResponse = Static<typeof CreateWorldResponseSchema>;
+export type AssignWorldResponse = Static<typeof AssignWorldResponseSchema>;
+export type ReleaseWorldResponse = Static<typeof ReleaseWorldResponseSchema>;
+export type DeleteWorldResponse = Static<typeof DeleteWorldResponseSchema>;


### PR DESCRIPTION
## Summary
- Add World management REST API endpoints to mcctl-api
- Implement TypeBox schemas for request/response validation
- Integrate with WorldManagementUseCase from @minecraft-docker/shared

## Endpoints Added
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/worlds` | List all worlds with lock status |
| GET | `/api/worlds/:name` | Get world details |
| POST | `/api/worlds` | Create new world with optional seed/server |
| DELETE | `/api/worlds/:name` | Delete world (respects lock status) |
| POST | `/api/worlds/:name/assign` | Assign world to server |
| POST | `/api/worlds/:name/release` | Release world lock |

## Test Plan
- [ ] Verify build passes (`pnpm build`)
- [ ] Test GET /api/worlds returns list of worlds
- [ ] Test GET /api/worlds/:name returns 404 for non-existent world
- [ ] Test POST /api/worlds creates world with proper validation
- [ ] Test DELETE /api/worlds/:name returns 409 for locked worlds
- [ ] Test POST /api/worlds/:name/assign works with valid server
- [ ] Test POST /api/worlds/:name/release unlocks world

## Related Issues
Closes #91

---
Generated with [Claude Code](https://claude.com/claude-code)