### PR TITLE
feat(shared): add PM2 service management types

### DIFF
--- a/platform/services/shared/src/application/ports/outbound/IServiceManagerPort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IServiceManagerPort.ts
@@ -1,0 +1,129 @@
+import type { ProcessInfo } from '../../../domain/value-objects/ProcessInfo.js';
+
+/**
+ * Service start options
+ */
+export interface ServiceStartOptions {
+  /** Environment variables to pass to the service */
+  env?: Record<string, string>;
+  /** Working directory for the service */
+  cwd?: string;
+  /** Whether to wait for the service to be ready */
+  wait?: boolean;
+  /** Timeout in milliseconds when waiting */
+  waitTimeout?: number;
+}
+
+/**
+ * Service stop options
+ */
+export interface ServiceStopOptions {
+  /** Force stop (SIGKILL) instead of graceful shutdown */
+  force?: boolean;
+  /** Timeout in milliseconds before force stop */
+  timeout?: number;
+}
+
+/**
+ * Service restart options
+ */
+export interface ServiceRestartOptions extends ServiceStartOptions, ServiceStopOptions {
+  /** Update environment variables before restart */
+  updateEnv?: boolean;
+}
+
+/**
+ * Service logs options
+ */
+export interface ServiceLogsOptions {
+  /** Number of lines to return */
+  lines?: number;
+  /** Return error logs instead of output logs */
+  err?: boolean;
+  /** Filter logs by timestamp (return logs after this date) */
+  since?: Date;
+}
+
+/**
+ * Service Manager Port - Outbound Port
+ * Interface for managing service processes (PM2, systemd, etc.)
+ *
+ * This port abstracts process management operations to allow
+ * different implementations (PM2, systemd, Docker, etc.)
+ */
+export interface IServiceManagerPort {
+  /**
+   * Start a service by name
+   * @param name - The service name as defined in ecosystem config
+   * @param options - Optional start configuration
+   * @throws Error if service not found or start fails
+   */
+  start(name: string, options?: ServiceStartOptions): Promise<void>;
+
+  /**
+   * Stop a service by name
+   * @param name - The service name
+   * @param options - Optional stop configuration
+   * @throws Error if service not found or stop fails
+   */
+  stop(name: string, options?: ServiceStopOptions): Promise<void>;
+
+  /**
+   * Restart a service by name
+   * @param name - The service name
+   * @param options - Optional restart configuration
+   * @throws Error if service not found or restart fails
+   */
+  restart(name: string, options?: ServiceRestartOptions): Promise<void>;
+
+  /**
+   * Get status of one or all services
+   * @param name - Optional service name. If not provided, returns all services
+   * @returns Array of process information
+   */
+  status(name?: string): Promise<ProcessInfo[]>;
+
+  /**
+   * Get logs for a service
+   * @param name - The service name
+   * @param options - Optional log retrieval options
+   * @returns Log content as string
+   */
+  logs(name: string, options?: ServiceLogsOptions): Promise<string>;
+
+  /**
+   * Delete a service from the process manager
+   * @param name - The service name to delete
+   * @throws Error if service not found
+   */
+  delete(name: string): Promise<void>;
+
+  /**
+   * Reload ecosystem configuration
+   * @param configPath - Path to ecosystem config file
+   */
+  reload(configPath: string): Promise<void>;
+
+  /**
+   * Check if a service exists
+   * @param name - The service name
+   * @returns true if service is registered
+   */
+  exists(name: string): Promise<boolean>;
+
+  /**
+   * Flush logs for a service
+   * @param name - The service name
+   */
+  flush(name: string): Promise<void>;
+
+  /**
+   * Save current process list (for restart persistence)
+   */
+  save(): Promise<void>;
+
+  /**
+   * Resurrect saved processes
+   */
+  resurrect(): Promise<void>;
+}

--- a/platform/services/shared/src/application/ports/outbound/index.ts
+++ b/platform/services/shared/src/application/ports/outbound/index.ts
@@ -39,3 +39,11 @@ export type {
 export type { IModSourcePort } from './IModSourcePort.js';
 
 export type { IUserRepository } from './IUserRepository.js';
+
+export type {
+  IServiceManagerPort,
+  ServiceStartOptions,
+  ServiceStopOptions,
+  ServiceRestartOptions,
+  ServiceLogsOptions,
+} from './IServiceManagerPort.js';

--- a/platform/services/shared/src/domain/index.ts
+++ b/platform/services/shared/src/domain/index.ts
@@ -13,6 +13,12 @@ export {
   Username,
   Role,
   RoleEnum,
+  // Service management value objects
+  ServiceStatus,
+  ServiceStatusEnum,
+  ProcessInfo,
+  type ProcessInfoData,
+  type ProcessMetrics,
 } from './value-objects/index.js';
 
 // Entities

--- a/platform/services/shared/src/domain/value-objects/ProcessInfo.ts
+++ b/platform/services/shared/src/domain/value-objects/ProcessInfo.ts
@@ -1,0 +1,237 @@
+import { ServiceStatus, ServiceStatusEnum } from './ServiceStatus.js';
+
+/**
+ * Process monitoring metrics
+ */
+export interface ProcessMetrics {
+  memory: number;  // Memory usage in bytes
+  cpu: number;     // CPU usage percentage
+}
+
+/**
+ * Process information data interface
+ */
+export interface ProcessInfoData {
+  pmId: number;
+  name: string;
+  status: ServiceStatusEnum;
+  pid?: number;
+  cpu?: number;
+  memory?: number;
+  uptime?: number;
+  restarts?: number;
+  createdAt?: Date;
+  interpreter?: string;
+  scriptPath?: string;
+}
+
+/**
+ * ProcessInfo Value Object
+ * Represents information about a managed service process
+ */
+export class ProcessInfo {
+  private constructor(private readonly _data: ProcessInfoData) {
+    Object.freeze(this);
+  }
+
+  get pmId(): number {
+    return this._data.pmId;
+  }
+
+  get name(): string {
+    return this._data.name;
+  }
+
+  get status(): ServiceStatus {
+    return ServiceStatus.create(this._data.status);
+  }
+
+  get statusValue(): ServiceStatusEnum {
+    return this._data.status;
+  }
+
+  get pid(): number | undefined {
+    return this._data.pid;
+  }
+
+  get cpu(): number | undefined {
+    return this._data.cpu;
+  }
+
+  get memory(): number | undefined {
+    return this._data.memory;
+  }
+
+  get uptime(): number | undefined {
+    return this._data.uptime;
+  }
+
+  get restarts(): number | undefined {
+    return this._data.restarts;
+  }
+
+  get createdAt(): Date | undefined {
+    return this._data.createdAt;
+  }
+
+  get interpreter(): string | undefined {
+    return this._data.interpreter;
+  }
+
+  get scriptPath(): string | undefined {
+    return this._data.scriptPath;
+  }
+
+  /**
+   * Check if process is online
+   */
+  get isOnline(): boolean {
+    return this._data.status === ServiceStatusEnum.ONLINE;
+  }
+
+  /**
+   * Check if process is stopped
+   */
+  get isStopped(): boolean {
+    return this._data.status === ServiceStatusEnum.STOPPED;
+  }
+
+  /**
+   * Check if process has errored
+   */
+  get isErrored(): boolean {
+    return this._data.status === ServiceStatusEnum.ERRORED;
+  }
+
+  /**
+   * Get formatted memory usage string
+   */
+  get memoryFormatted(): string {
+    if (this._data.memory === undefined) return 'N/A';
+    return formatBytes(this._data.memory);
+  }
+
+  /**
+   * Get formatted uptime string
+   */
+  get uptimeFormatted(): string {
+    if (this._data.uptime === undefined) return 'N/A';
+    return formatDuration(this._data.uptime);
+  }
+
+  /**
+   * Get metrics object
+   */
+  get metrics(): ProcessMetrics | null {
+    if (this._data.cpu === undefined || this._data.memory === undefined) {
+      return null;
+    }
+    return {
+      cpu: this._data.cpu,
+      memory: this._data.memory,
+    };
+  }
+
+  /**
+   * Create a ProcessInfo from data
+   */
+  static create(data: ProcessInfoData): ProcessInfo {
+    if (data.pmId < 0) {
+      throw new Error('PM2 ID cannot be negative');
+    }
+    if (!data.name || data.name.trim() === '') {
+      throw new Error('Process name is required');
+    }
+    return new ProcessInfo(data);
+  }
+
+  /**
+   * Create from PM2 process description
+   */
+  static fromPm2(pm2Process: {
+    pm_id?: number;
+    name?: string;
+    pm2_env?: {
+      status?: string;
+      pm_uptime?: number;
+      restart_time?: number;
+      created_at?: number;
+      exec_interpreter?: string;
+      pm_exec_path?: string;
+    };
+    pid?: number;
+    monit?: {
+      cpu?: number;
+      memory?: number;
+    };
+  }): ProcessInfo {
+    const env = pm2Process.pm2_env || {};
+    const monit = pm2Process.monit || {};
+
+    return ProcessInfo.create({
+      pmId: pm2Process.pm_id ?? 0,
+      name: pm2Process.name ?? 'unknown',
+      status: (env.status as ServiceStatusEnum) ?? ServiceStatusEnum.STOPPED,
+      pid: pm2Process.pid,
+      cpu: monit.cpu,
+      memory: monit.memory,
+      uptime: env.pm_uptime,
+      restarts: env.restart_time,
+      createdAt: env.created_at ? new Date(env.created_at) : undefined,
+      interpreter: env.exec_interpreter,
+      scriptPath: env.pm_exec_path,
+    });
+  }
+
+  /**
+   * Convert to plain object
+   */
+  toJSON(): ProcessInfoData {
+    return { ...this._data };
+  }
+
+  equals(other: ProcessInfo): boolean {
+    return this._data.pmId === other._data.pmId && this._data.name === other._data.name;
+  }
+
+  toString(): string {
+    return `${this._data.name} (PM2 ID: ${this._data.pmId}, Status: ${this._data.status})`;
+  }
+}
+
+/**
+ * Format bytes to human readable string
+ */
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let unitIndex = 0;
+  let size = bytes;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
+}
+
+/**
+ * Format duration in milliseconds to human readable string
+ */
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days}d ${hours % 24}h`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}

--- a/platform/services/shared/src/domain/value-objects/ServiceStatus.ts
+++ b/platform/services/shared/src/domain/value-objects/ServiceStatus.ts
@@ -1,0 +1,114 @@
+/**
+ * Service Status Enum
+ * Defines possible states for a managed service process
+ */
+export enum ServiceStatusEnum {
+  ONLINE = 'online',
+  STOPPING = 'stopping',
+  STOPPED = 'stopped',
+  ERRORED = 'errored',
+  ONE_LAUNCH_STATUS = 'one-launch-status',
+}
+
+/**
+ * ServiceStatus Value Object
+ * Represents a validated service status
+ */
+export class ServiceStatus {
+  private static readonly VALID_STATUSES = new Set(Object.values(ServiceStatusEnum));
+
+  private constructor(private readonly _value: ServiceStatusEnum) {
+    Object.freeze(this);
+  }
+
+  get value(): ServiceStatusEnum {
+    return this._value;
+  }
+
+  /**
+   * Create a ServiceStatus from a string value
+   */
+  static create(value: string): ServiceStatus {
+    const normalized = value.trim().toLowerCase() as ServiceStatusEnum;
+
+    if (!ServiceStatus.VALID_STATUSES.has(normalized)) {
+      const validStatuses = Array.from(ServiceStatus.VALID_STATUSES).join(', ');
+      throw new Error(
+        `Invalid service status: ${value}. Valid statuses are: ${validStatuses}`
+      );
+    }
+
+    return new ServiceStatus(normalized);
+  }
+
+  /**
+   * Create an online status
+   */
+  static online(): ServiceStatus {
+    return new ServiceStatus(ServiceStatusEnum.ONLINE);
+  }
+
+  /**
+   * Create a stopped status
+   */
+  static stopped(): ServiceStatus {
+    return new ServiceStatus(ServiceStatusEnum.STOPPED);
+  }
+
+  /**
+   * Create a stopping status
+   */
+  static stopping(): ServiceStatus {
+    return new ServiceStatus(ServiceStatusEnum.STOPPING);
+  }
+
+  /**
+   * Create an errored status
+   */
+  static errored(): ServiceStatus {
+    return new ServiceStatus(ServiceStatusEnum.ERRORED);
+  }
+
+  /**
+   * Check if service is online
+   */
+  get isOnline(): boolean {
+    return this._value === ServiceStatusEnum.ONLINE;
+  }
+
+  /**
+   * Check if service is stopped
+   */
+  get isStopped(): boolean {
+    return this._value === ServiceStatusEnum.STOPPED;
+  }
+
+  /**
+   * Check if service is stopping
+   */
+  get isStopping(): boolean {
+    return this._value === ServiceStatusEnum.STOPPING;
+  }
+
+  /**
+   * Check if service has errored
+   */
+  get isErrored(): boolean {
+    return this._value === ServiceStatusEnum.ERRORED;
+  }
+
+  /**
+   * Check if service is running (online or stopping)
+   */
+  get isRunning(): boolean {
+    return this._value === ServiceStatusEnum.ONLINE || this._value === ServiceStatusEnum.STOPPING;
+  }
+
+  equals(other: ServiceStatus): boolean {
+    return this._value === other._value;
+  }
+
+  toString(): string {
+    return this._value;
+  }
+}

--- a/platform/services/shared/src/domain/value-objects/index.ts
+++ b/platform/services/shared/src/domain/value-objects/index.ts
@@ -8,3 +8,7 @@ export { WorldOptions, WorldSetupType, type WorldOptionsData } from './WorldOpti
 export { UserId } from './UserId.js';
 export { Username } from './Username.js';
 export { Role, RoleEnum } from './Role.js';
+
+// Service management value objects
+export { ServiceStatus, ServiceStatusEnum } from './ServiceStatus.js';
+export { ProcessInfo, type ProcessInfoData, type ProcessMetrics } from './ProcessInfo.js';

--- a/platform/services/shared/src/index.ts
+++ b/platform/services/shared/src/index.ts
@@ -72,6 +72,12 @@ export {
   Username,
   Role,
   RoleEnum,
+  // Service management value objects
+  ServiceStatus,
+  ServiceStatusEnum,
+  ProcessInfo,
+  type ProcessInfoData,
+  type ProcessMetrics,
   // Entities
   Server,
   ServerStatus,

--- a/platform/services/shared/src/infrastructure/config/Pm2EcosystemConfig.ts
+++ b/platform/services/shared/src/infrastructure/config/Pm2EcosystemConfig.ts
@@ -1,0 +1,283 @@
+/**
+ * PM2 Ecosystem Configuration Types
+ * Based on PM2 ecosystem.config.js specification
+ * @see https://pm2.keymetrics.io/docs/usage/application-declaration/
+ */
+
+/**
+ * PM2 execution mode
+ */
+export type Pm2ExecMode = 'fork' | 'cluster';
+
+/**
+ * PM2 interpreter type
+ */
+export type Pm2Interpreter = 'node' | 'bash' | 'python' | 'python3' | 'ruby' | 'perl' | string;
+
+/**
+ * PM2 log configuration
+ */
+export interface IPm2LogConfig {
+  /** Output log file path */
+  output?: string;
+  /** Error log file path */
+  error?: string;
+  /** Combined log file path */
+  log?: string;
+  /** Log date format */
+  logDateFormat?: string;
+  /** Merge logs from different instances */
+  mergeLogs?: boolean;
+}
+
+/**
+ * PM2 restart strategy
+ */
+export interface IPm2RestartConfig {
+  /** Delay between restart (ms) */
+  restartDelay?: number;
+  /** Maximum restarts within exponential backoff window */
+  maxRestarts?: number;
+  /** Minimum uptime to be considered started (ms) */
+  minUptime?: number;
+  /** Maximum memory before restart */
+  maxMemoryRestart?: string;
+  /** Enable exponential backoff restart */
+  expBackoffRestartDelay?: number;
+}
+
+/**
+ * PM2 watch configuration
+ */
+export interface IPm2WatchConfig {
+  /** Enable watching */
+  watch?: boolean | string[];
+  /** Paths to ignore for watching */
+  ignoreWatch?: string[];
+  /** Watch options passed to chokidar */
+  watchOptions?: {
+    usePolling?: boolean;
+    interval?: number;
+  };
+}
+
+/**
+ * PM2 application configuration
+ * Defines a single application/service in PM2
+ */
+export interface IPm2AppConfig {
+  /** Application name (required) */
+  name: string;
+
+  /** Script path to run (required) */
+  script: string;
+
+  /** Working directory */
+  cwd?: string;
+
+  /** Script arguments */
+  args?: string | string[];
+
+  /** Interpreter to use */
+  interpreter?: Pm2Interpreter;
+
+  /** Interpreter arguments */
+  interpreterArgs?: string | string[];
+
+  /** Node.js arguments (alias for interpreterArgs when using node) */
+  nodeArgs?: string | string[];
+
+  /** Number of instances (cluster mode) */
+  instances?: number | 'max';
+
+  /** Execution mode: 'fork' or 'cluster' */
+  execMode?: Pm2ExecMode;
+
+  /** Environment variables */
+  env?: Record<string, string>;
+
+  /** Production environment variables */
+  envProduction?: Record<string, string>;
+
+  /** Development environment variables */
+  envDevelopment?: Record<string, string>;
+
+  /** Log configuration */
+  logConfig?: IPm2LogConfig;
+
+  /** Output log file path (shorthand) */
+  output?: string;
+
+  /** Error log file path (shorthand) */
+  error?: string;
+
+  /** Combined log file path (shorthand) */
+  log?: string;
+
+  /** Log date format */
+  logDateFormat?: string;
+
+  /** Merge logs from different instances */
+  mergeLogs?: boolean;
+
+  /** Restart configuration */
+  restartConfig?: IPm2RestartConfig;
+
+  /** Delay between restart (ms, shorthand) */
+  restartDelay?: number;
+
+  /** Maximum restarts within exponential backoff window (shorthand) */
+  maxRestarts?: number;
+
+  /** Minimum uptime to be considered started (ms, shorthand) */
+  minUptime?: number;
+
+  /** Maximum memory before restart (shorthand) */
+  maxMemoryRestart?: string;
+
+  /** Enable exponential backoff restart (shorthand) */
+  expBackoffRestartDelay?: number;
+
+  /** Watch configuration */
+  watchConfig?: IPm2WatchConfig;
+
+  /** Enable watching (shorthand) */
+  watch?: boolean | string[];
+
+  /** Paths to ignore for watching (shorthand) */
+  ignoreWatch?: string[];
+
+  /** Auto restart on crash */
+  autorestart?: boolean;
+
+  /** Cron pattern for scheduled restart */
+  cron?: string;
+
+  /** Enable listening on a port */
+  listenTimeout?: number;
+
+  /** Kill timeout (ms) */
+  killTimeout?: number;
+
+  /** Wait ready signal (process.send('ready')) */
+  waitReady?: boolean;
+
+  /** Source map support */
+  sourceMapSupport?: boolean;
+
+  /** Instance variable name for environment */
+  instanceVar?: string;
+
+  /** Filter environment variables */
+  filterEnv?: string[];
+
+  /** Additional raw PM2 options */
+  [key: string]: unknown;
+}
+
+/**
+ * PM2 Ecosystem Configuration
+ * Defines the complete ecosystem.config.js structure
+ */
+export interface IPm2EcosystemConfig {
+  /** List of applications */
+  apps: IPm2AppConfig[];
+
+  /** Deploy configuration (optional) */
+  deploy?: Record<string, IPm2DeployConfig>;
+}
+
+/**
+ * PM2 Deploy Configuration
+ * For deployment targets
+ */
+export interface IPm2DeployConfig {
+  /** User to use for SSH */
+  user: string;
+
+  /** Host(s) to deploy to */
+  host: string | string[];
+
+  /** SSH port */
+  port?: number;
+
+  /** Git repository URL */
+  repo: string;
+
+  /** Git reference to deploy */
+  ref: string;
+
+  /** Path on remote server */
+  path: string;
+
+  /** SSH key path */
+  key?: string;
+
+  /** Pre-setup commands */
+  preSetup?: string;
+
+  /** Post-setup commands */
+  postSetup?: string;
+
+  /** Pre-deploy commands (local) */
+  preDeploy?: string;
+
+  /** Post-deploy commands (remote) */
+  postDeploy?: string;
+
+  /** Environment variables */
+  env?: Record<string, string>;
+}
+
+/**
+ * Create a minimal PM2 app configuration
+ */
+export function createPm2AppConfig(
+  name: string,
+  script: string,
+  options?: Partial<Omit<IPm2AppConfig, 'name' | 'script'>>
+): IPm2AppConfig {
+  return {
+    name,
+    script,
+    ...options,
+  };
+}
+
+/**
+ * Create a PM2 ecosystem configuration
+ */
+export function createPm2EcosystemConfig(
+  apps: IPm2AppConfig[],
+  deploy?: Record<string, IPm2DeployConfig>
+): IPm2EcosystemConfig {
+  return {
+    apps,
+    ...(deploy && { deploy }),
+  };
+}
+
+/**
+ * Default PM2 app configuration values
+ */
+export const PM2_APP_DEFAULTS: Partial<IPm2AppConfig> = {
+  interpreter: 'node',
+  execMode: 'fork',
+  instances: 1,
+  autorestart: true,
+  maxRestarts: 10,
+  minUptime: 1000,
+  killTimeout: 3000,
+  listenTimeout: 3000,
+  mergeLogs: true,
+} as const;
+
+/**
+ * Merge app config with defaults
+ */
+export function withPm2Defaults(config: IPm2AppConfig): IPm2AppConfig {
+  return {
+    ...PM2_APP_DEFAULTS,
+    ...config,
+  };
+}

--- a/platform/services/shared/src/infrastructure/config/index.ts
+++ b/platform/services/shared/src/infrastructure/config/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Infrastructure Configuration Types
+ * Configuration type definitions for external services
+ */
+
+export {
+  type Pm2ExecMode,
+  type Pm2Interpreter,
+  type IPm2LogConfig,
+  type IPm2RestartConfig,
+  type IPm2WatchConfig,
+  type IPm2AppConfig,
+  type IPm2EcosystemConfig,
+  type IPm2DeployConfig,
+  createPm2AppConfig,
+  createPm2EcosystemConfig,
+  PM2_APP_DEFAULTS,
+  withPm2Defaults,
+} from './Pm2EcosystemConfig.js';

--- a/platform/services/shared/src/infrastructure/index.ts
+++ b/platform/services/shared/src/infrastructure/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './adapters/index.js';
+export * from './config/index.js';


### PR DESCRIPTION
## Summary
- Add TypeScript types and interfaces for PM2 service management to the shared package
- Create value objects for service status and process information
- Define port interface for service manager operations
- Add PM2 ecosystem configuration types with helper functions

## Changes

### New Files
| File | Description |
|------|-------------|
| `ServiceStatus.ts` | Value object for service states (online, stopped, stopping, errored) |
| `ProcessInfo.ts` | Value object for process monitoring data with metrics |
| `IServiceManagerPort.ts` | Interface for service management operations |
| `Pm2EcosystemConfig.ts` | PM2 ecosystem.config.js type definitions |

### Exports
```typescript
// Value Objects
import { ServiceStatus, ServiceStatusEnum, ProcessInfo, ProcessInfoData, ProcessMetrics } from '@minecraft-docker/shared';

// Port Interface
import { IServiceManagerPort, ServiceStartOptions, ServiceStopOptions, ServiceRestartOptions, ServiceLogsOptions } from '@minecraft-docker/shared';

// PM2 Config Types
import { IPm2AppConfig, IPm2EcosystemConfig, createPm2AppConfig, createPm2EcosystemConfig, withPm2Defaults } from '@minecraft-docker/shared';
```

## Test plan
- [x] Build shared package without TypeScript errors
- [x] Run existing tests (75 tests pass)
- [ ] Use types in CLI PM2 adapter implementation

## Related Issues
Closes #135

---
Generated with [Claude Code](https://claude.com/claude-code)