### PR TITLE
refactor(console): optimize for native PM2 execution (#140)

### DIFF
--- a/platform/services/mcctl-console/.env.local.example
+++ b/platform/services/mcctl-console/.env.local.example
@@ -6,12 +6,28 @@
 NEXTAUTH_SECRET=your-secret-key-change-in-production
 
 # Required: Base URL for NextAuth.js callbacks
+# For PM2/native: http://localhost:3000
+# For Docker: http://mcctl-console:3000
 NEXTAUTH_URL=http://localhost:3000
 
 # mcctl-api Configuration
 # URL for the backend API server
+# For PM2/native: http://localhost:3001
+# For Docker: http://mcctl-api:3001
 MCCTL_API_URL=http://localhost:3001
+
+# Internal API Key for console-to-API communication
+# Should match INTERNAL_API_KEY in mcctl-api
+INTERNAL_API_KEY=internal-dev-key
 
 # Development Settings
 # Set to 'development' for verbose logging
+# Set to 'production' for optimized output
 NODE_ENV=development
+
+# Server Port (optional, default: 3000)
+PORT=3000
+
+# Hostname binding (optional, default: 0.0.0.0)
+# Use 127.0.0.1 to restrict to localhost only
+HOSTNAME=0.0.0.0

--- a/platform/services/mcctl-console/README.md
+++ b/platform/services/mcctl-console/README.md
@@ -1,0 +1,186 @@
+# mcctl-console
+
+Web management console for Docker Minecraft servers built with Next.js 14.
+
+## Features
+
+- Server status dashboard
+- Start/stop/restart servers
+- View server logs
+- User authentication via NextAuth.js
+- Dark theme optimized for server management
+
+## Requirements
+
+- Node.js >= 18.0.0
+- mcctl-api running on port 3001
+
+## Installation
+
+```bash
+# Install dependencies
+pnpm install
+
+# Copy environment file
+cp .env.local.example .env.local
+
+# Edit configuration
+vim .env.local
+```
+
+## Development
+
+```bash
+# Start development server
+pnpm dev
+
+# Run linting
+pnpm lint
+
+# Run type checking
+pnpm typecheck
+```
+
+## Production Build
+
+### Option 1: Standard Next.js Start
+
+```bash
+# Build the application
+pnpm build
+
+# Start with Next.js
+pnpm start
+```
+
+### Option 2: Standalone Build (Recommended for PM2)
+
+The standalone build creates a self-contained output that includes only the necessary dependencies.
+
+```bash
+# Build the application
+pnpm build
+
+# Start standalone server
+pnpm start:standalone
+
+# Or directly with node
+node .next/standalone/platform/services/mcctl-console/server.js
+```
+
+### Running with PM2
+
+```bash
+# Build first
+pnpm build
+
+# Start with PM2 (note: monorepo path in standalone)
+pm2 start .next/standalone/platform/services/mcctl-console/server.js --name mcctl-console
+
+# Or with environment variables
+PORT=3000 HOSTNAME=0.0.0.0 pm2 start .next/standalone/platform/services/mcctl-console/server.js --name mcctl-console
+
+# View logs
+pm2 logs mcctl-console
+
+# Monitor
+pm2 monit
+```
+
+### PM2 Ecosystem Configuration
+
+Create `ecosystem.config.js`:
+
+```javascript
+module.exports = {
+  apps: [{
+    name: 'mcctl-console',
+    script: '.next/standalone/platform/services/mcctl-console/server.js',
+    cwd: '/path/to/mcctl-console',
+    instances: 1,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '256M',
+    env: {
+      NODE_ENV: 'production',
+      PORT: 3000,
+      HOSTNAME: '0.0.0.0',
+      NEXTAUTH_SECRET: 'your-secret-key',
+      NEXTAUTH_URL: 'http://localhost:3000',
+      MCCTL_API_URL: 'http://localhost:3001',
+    },
+  }],
+};
+```
+
+Then start with:
+
+```bash
+pm2 start ecosystem.config.js
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NEXTAUTH_SECRET` | Yes | - | JWT encryption secret |
+| `NEXTAUTH_URL` | Yes | `http://localhost:3000` | Base URL for auth callbacks |
+| `MCCTL_API_URL` | No | `http://localhost:3001` | Backend API URL |
+| `INTERNAL_API_KEY` | No | `internal-dev-key` | API key for console-to-API auth |
+| `NODE_ENV` | No | `development` | Environment mode |
+| `PORT` | No | `3000` | Server port |
+| `HOSTNAME` | No | `0.0.0.0` | Hostname binding |
+
+## Health Check
+
+The application provides a health check endpoint for monitoring:
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+Response:
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-01-27T10:00:00.000Z",
+  "service": "mcctl-console",
+  "version": "0.1.0",
+  "uptime": {
+    "seconds": 3600,
+    "formatted": "1h 0m 0s"
+  },
+  "environment": "production",
+  "node": "v20.10.0"
+}
+```
+
+## Project Structure
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── api/
+│   │   ├── auth/           # NextAuth.js routes
+│   │   ├── health/         # Health check endpoint
+│   │   └── proxy/          # BFF proxy to mcctl-api
+│   ├── login/              # Login page
+│   ├── servers/            # Server management pages
+│   ├── layout.tsx          # Root layout
+│   └── page.tsx            # Dashboard
+├── components/             # React components
+│   ├── providers/          # Context providers
+│   ├── server/             # Server-related components
+│   └── ui/                 # UI primitives
+├── hooks/                  # Custom React hooks
+├── lib/                    # Utilities and configs
+│   ├── api-client.ts       # API client wrapper
+│   ├── auth.ts             # NextAuth configuration
+│   └── utils.ts            # Helper functions
+└── types/                  # TypeScript definitions
+```
+
+## License
+
+Apache-2.0

--- a/platform/services/mcctl-console/next.config.js
+++ b/platform/services/mcctl-console/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Enable standalone output for Docker deployment
+  // Enable standalone output for native PM2 deployment
+  // Creates a self-contained build in .next/standalone
   output: 'standalone',
 
   // Enable Server Actions
@@ -15,6 +16,34 @@ const nextConfig = {
 
   // Disable x-powered-by header for security
   poweredByHeader: false,
+
+  // Environment variables exposed to the browser (NEXT_PUBLIC_*)
+  // Server-side variables are read from process.env directly
+  env: {
+    // Build-time version for debugging
+    BUILD_TIME: new Date().toISOString(),
+  },
+
+  // Optimize for production
+  compiler: {
+    // Remove console.log in production
+    removeConsole:
+      process.env.NODE_ENV === 'production'
+        ? { exclude: ['error', 'warn'] }
+        : false,
+  },
+
+  // ESLint configuration
+  eslint: {
+    // Don't fail build on ESLint errors (run separately)
+    ignoreDuringBuilds: false,
+  },
+
+  // TypeScript configuration
+  typescript: {
+    // Don't fail build on TS errors (run separately)
+    ignoreBuildErrors: false,
+  },
 };
 
 module.exports = nextConfig;

--- a/platform/services/mcctl-console/package.json
+++ b/platform/services/mcctl-console/package.json
@@ -6,8 +6,11 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "cp -r public .next/standalone/platform/services/mcctl-console/ 2>/dev/null || true && cp -r .next/static .next/standalone/platform/services/mcctl-console/.next/ 2>/dev/null || true",
     "start": "next start",
+    "start:standalone": "node .next/standalone/platform/services/mcctl-console/server.js",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "clean": "rm -rf .next out"
   },
   "keywords": [

--- a/platform/services/mcctl-console/src/app/api/health/route.ts
+++ b/platform/services/mcctl-console/src/app/api/health/route.ts
@@ -1,18 +1,57 @@
 import { NextResponse } from 'next/server';
 
 /**
- * Health check endpoint for container orchestration.
- * Used by Docker HEALTHCHECK and Kubernetes probes.
+ * Health check endpoint for process monitoring.
+ * Used by PM2, Docker HEALTHCHECK, and Kubernetes probes.
  *
- * @returns JSON response with health status
+ * @returns JSON response with health status and diagnostics
+ *
+ * @example
+ * // PM2 health check
+ * pm2 start ecosystem.config.js --health-check-http http://localhost:3000/api/health
+ *
+ * // curl check
+ * curl -s http://localhost:3000/api/health | jq
  */
 export async function GET() {
+  const uptime = process.uptime();
+
   return NextResponse.json(
     {
       status: 'healthy',
       timestamp: new Date().toISOString(),
       service: 'mcctl-console',
+      version: process.env.npm_package_version || '0.1.0',
+      uptime: {
+        seconds: Math.floor(uptime),
+        formatted: formatUptime(uptime),
+      },
+      environment: process.env.NODE_ENV || 'development',
+      node: process.version,
     },
-    { status: 200 }
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate',
+      },
+    }
   );
+}
+
+/**
+ * Format uptime in human-readable format
+ */
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  parts.push(`${secs}s`);
+
+  return parts.join(' ');
 }

--- a/platform/services/mcctl-console/src/app/api/proxy/[...path]/route.ts
+++ b/platform/services/mcctl-console/src/app/api/proxy/[...path]/route.ts
@@ -19,12 +19,14 @@ import { authOptions } from '@/lib/auth';
  * fetch('/api/proxy/servers')
  *
  * // Forwarded to:
- * fetch('http://mcctl-api:3001/api/servers', {
+ * fetch('http://localhost:3001/api/servers', {
  *   headers: { 'X-User': 'admin', 'X-Role': 'admin', ... }
  * })
  */
 
-const API_URL = process.env.MCCTL_API_URL || 'http://mcctl-api:3001';
+// Default to localhost for native PM2 execution
+// Override with MCCTL_API_URL for Docker or remote API
+const API_URL = process.env.MCCTL_API_URL || 'http://localhost:3001';
 const INTERNAL_API_KEY = process.env.INTERNAL_API_KEY || 'internal-dev-key';
 const isDevelopment = process.env.NODE_ENV === 'development';
 


### PR DESCRIPTION
## Summary

- Update `next.config.js` with PM2-optimized settings (compiler options, build-time tracking)
- Update API proxy default URL to `localhost:3001` for native execution (was `mcctl-api:3001`)
- Enhance health check endpoint with uptime, node version, and diagnostics for PM2 monitoring
- Add `postbuild` and `start:standalone` scripts for PM2 deployment
- Add comprehensive README.md with PM2 deployment documentation

## Test Plan

- [x] Build succeeds: `pnpm --filter @minecraft-docker/mcctl-console build`
- [x] Standalone output created in `.next/standalone/`
- [x] Static files copied by postbuild script
- [x] Lint passes
- [x] TypeScript check passes
- [ ] Manual test: Run with `pnpm start:standalone` and verify health endpoint

## Changes

| File | Description |
|------|-------------|
| `next.config.js` | PM2-optimized settings |
| `package.json` | New scripts: postbuild, start:standalone, typecheck |
| `.env.local.example` | All configuration options documented |
| `src/app/api/health/route.ts` | Enhanced health check with uptime |
| `src/app/api/proxy/[...path]/route.ts` | Default to localhost:3001 |
| `README.md` | PM2 deployment documentation |

Closes #140

---
Generated with [Claude Code](https://claude.com/claude-code)