### PR TITLE
feat(cli): add version update check with 24-hour cache

### DIFF
--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -27,8 +27,21 @@ import {
   consoleRemoveCommand,
 } from './commands/index.js';
 import { ShellExecutor } from './lib/shell.js';
+import { checkForUpdates } from './lib/update-checker.js';
+import { readFileSync } from 'fs';
 
-const VERSION = '0.1.0';
+// Read version from package.json
+function getVersion(): string {
+  try {
+    const packageJsonPath = new URL('../package.json', import.meta.url);
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    return packageJson.version;
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const VERSION = getVersion();
 
 /**
  * Handle console command (shared by both 'console' and deprecated 'admin' commands)
@@ -397,6 +410,9 @@ async function main(): Promise<void> {
     console.log(`mcctl version ${VERSION}`);
     process.exit(0);
   }
+
+  // Check for updates (with 24-hour cache)
+  await checkForUpdates();
 
   const rootDir = flags['root'] as string | undefined;
   const sudoPassword = flags['sudo-password'] as string | undefined;

--- a/platform/services/cli/src/lib/update-checker.ts
+++ b/platform/services/cli/src/lib/update-checker.ts
@@ -1,0 +1,173 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { colors } from '@minecraft-docker/shared';
+
+const PACKAGE_NAME = '@minecraft-docker/mcctl';
+const CACHE_FILE = join(homedir(), '.mcctl-update-check.json');
+const CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FETCH_TIMEOUT_MS = 2000; // 2 seconds
+
+interface CacheData {
+  lastCheck: number;
+  latestVersion: string;
+}
+
+interface PackageJson {
+  version: string;
+}
+
+/**
+ * Get the current installed version from package.json
+ */
+function getCurrentVersion(): string {
+  try {
+    // Read from the package.json in the dist directory's parent
+    const packageJsonPath = new URL('../../package.json', import.meta.url);
+    const packageJson: PackageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    return packageJson.version;
+  } catch {
+    return '0.0.0';
+  }
+}
+
+/**
+ * Read cache file
+ */
+function readCache(): CacheData | null {
+  try {
+    if (!existsSync(CACHE_FILE)) {
+      return null;
+    }
+    const data = readFileSync(CACHE_FILE, 'utf-8');
+    return JSON.parse(data) as CacheData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write cache file
+ */
+function writeCache(data: CacheData): void {
+  try {
+    writeFileSync(CACHE_FILE, JSON.stringify(data, null, 2));
+  } catch {
+    // Ignore write errors
+  }
+}
+
+/**
+ * Fetch latest version from npm registry
+ */
+async function fetchLatestVersion(): Promise<string | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(
+      `https://registry.npmjs.org/${PACKAGE_NAME}/latest`,
+      { signal: controller.signal }
+    );
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json() as { version: string };
+    return data.version;
+  } catch {
+    clearTimeout(timeoutId);
+    return null;
+  }
+}
+
+/**
+ * Compare two semantic versions
+ * Returns true if version2 is newer than version1
+ */
+function isNewerVersion(currentVersion: string, latestVersion: string): boolean {
+  const parseVersion = (v: string): number[] => {
+    return v.replace(/^v/, '').split('.').map(n => parseInt(n, 10) || 0);
+  };
+
+  const current = parseVersion(currentVersion);
+  const latest = parseVersion(latestVersion);
+
+  for (let i = 0; i < Math.max(current.length, latest.length); i++) {
+    const c = current[i] ?? 0;
+    const l = latest[i] ?? 0;
+    if (l > c) return true;
+    if (l < c) return false;
+  }
+  return false;
+}
+
+/**
+ * Print update notification box
+ */
+function printUpdateNotification(currentVersion: string, latestVersion: string): void {
+  const message1 = `Update available: ${currentVersion} → ${latestVersion}`;
+  const message2 = `Run: npm i -g ${PACKAGE_NAME}`;
+  const maxLen = Math.max(message1.length, message2.length);
+  const padding = 2;
+  const boxWidth = maxLen + padding * 2;
+
+  const topBorder = '┌' + '─'.repeat(boxWidth) + '┐';
+  const bottomBorder = '└' + '─'.repeat(boxWidth) + '┘';
+  const emptyLine = '│' + ' '.repeat(boxWidth) + '│';
+
+  const padLine = (text: string): string => {
+    const leftPad = ' '.repeat(padding);
+    const rightPad = ' '.repeat(boxWidth - text.length - padding);
+    return '│' + leftPad + text + rightPad + '│';
+  };
+
+  console.log('');
+  console.log(colors.yellow(topBorder));
+  console.log(colors.yellow(emptyLine));
+  console.log(colors.yellow(padLine(message1)));
+  console.log(colors.yellow(padLine(message2)));
+  console.log(colors.yellow(emptyLine));
+  console.log(colors.yellow(bottomBorder));
+  console.log('');
+}
+
+/**
+ * Check for updates and print notification if available
+ */
+export async function checkForUpdates(): Promise<void> {
+  try {
+    const currentVersion = getCurrentVersion();
+    const cache = readCache();
+    const now = Date.now();
+
+    // Check if cache is valid (within 24 hours)
+    if (cache && (now - cache.lastCheck) < CACHE_DURATION_MS) {
+      // Use cached version
+      if (isNewerVersion(currentVersion, cache.latestVersion)) {
+        printUpdateNotification(currentVersion, cache.latestVersion);
+      }
+      return;
+    }
+
+    // Fetch latest version from npm
+    const latestVersion = await fetchLatestVersion();
+
+    if (latestVersion) {
+      // Update cache
+      writeCache({
+        lastCheck: now,
+        latestVersion,
+      });
+
+      // Check if update is available
+      if (isNewerVersion(currentVersion, latestVersion)) {
+        printUpdateNotification(currentVersion, latestVersion);
+      }
+    }
+  } catch {
+    // Silently ignore any errors - don't disrupt the user
+  }
+}


### PR DESCRIPTION
## Summary
- CLI 실행 시 새 버전이 있는지 체크하고 업데이트 안내 메시지를 표시
- 24시간 캐싱으로 매번 API 호출하지 않음
- 네트워크 오류 시 무시하고 진행

## Changes
- `platform/services/cli/src/lib/update-checker.ts` - 버전 체크 로직
- `platform/services/cli/src/index.ts` - checkForUpdates() 호출 추가

## Screenshot
```
┌─────────────────────────────────────────┐
│                                         │
│  Update available: 1.6.6 → 2.0.0        │
│  Run: npm i -g @minecraft-docker/mcctl  │
│                                         │
└─────────────────────────────────────────┘
```

## Test Plan
- [x] 빌드 성공 확인
- [x] 캐시 파일 생성 확인 (`~/.mcctl-update-check.json`)
- [x] 업데이트 알림 표시 확인
- [x] 24시간 캐싱 동작 확인

Closes #160

🤖 Generated with [Claude Code](https://claude.ai/code)