### PR TITLE
feat(api): add router status API endpoint (#157)

### DIFF
--- a/platform/services/mcctl-api/src/app.ts
+++ b/platform/services/mcctl-api/src/app.ts
@@ -9,6 +9,7 @@ import serverActionsRoutes from './routes/servers/actions.js';
 import consoleRoutes from './routes/console.js';
 import worldsRoutes from './routes/worlds.js';
 import authRoutes from './routes/auth.js';
+import routerRoutes from './routes/router.js';
 
 export interface BuildAppOptions {
   logger?: boolean;
@@ -51,6 +52,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // Register server routes
   await app.register(serversRoutes);
   await app.register(serverActionsRoutes);
+
+  // Register router routes
+  await app.register(routerRoutes);
 
   // Register world routes
   await app.register(worldsRoutes);

--- a/platform/services/mcctl-api/src/routes/router.ts
+++ b/platform/services/mcctl-api/src/routes/router.ts
@@ -1,0 +1,63 @@
+import { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+import { getRouterDetailInfo } from '@minecraft-docker/shared';
+import {
+  RouterStatusResponseSchema,
+  ErrorResponseSchema,
+  type RouterDetail,
+} from '../schemas/router.js';
+
+/**
+ * Router routes plugin
+ * Provides REST API for mc-router status
+ */
+const routerPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+  /**
+   * GET /api/router/status
+   * Get mc-router status and routes
+   */
+  fastify.get('/api/router/status', {
+    schema: {
+      description: 'Get mc-router status including all routes',
+      tags: ['router'],
+      response: {
+        200: RouterStatusResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (_request, reply) => {
+    try {
+      const info = getRouterDetailInfo();
+
+      const router: RouterDetail = {
+        name: info.name,
+        status: info.status,
+        health: info.health,
+        port: info.port,
+        uptime: info.uptime,
+        uptimeSeconds: info.uptimeSeconds,
+        mode: info.mode,
+        routes: info.routes.map((route) => ({
+          hostname: route.hostname,
+          target: route.target,
+          serverStatus: route.serverStatus,
+        })),
+      };
+
+      return reply.send({ router });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get router status');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to get router status',
+      });
+    }
+  });
+};
+
+export default fp(routerPlugin, {
+  name: 'router-routes',
+  fastify: '5.x',
+});
+
+export { routerPlugin };

--- a/platform/services/mcctl-api/src/schemas/router.ts
+++ b/platform/services/mcctl-api/src/schemas/router.ts
@@ -1,0 +1,34 @@
+import { Type, Static } from '@sinclair/typebox';
+import { ContainerStatusSchema, HealthStatusSchema, ErrorResponseSchema } from './server.js';
+
+// Route info schema
+export const RouteInfoSchema = Type.Object({
+  hostname: Type.String(),
+  target: Type.String(),
+  serverStatus: ContainerStatusSchema,
+});
+
+// Router detail schema
+export const RouterDetailSchema = Type.Object({
+  name: Type.String(),
+  status: ContainerStatusSchema,
+  health: HealthStatusSchema,
+  port: Type.Number(),
+  uptime: Type.Optional(Type.String()),
+  uptimeSeconds: Type.Optional(Type.Number()),
+  mode: Type.Optional(Type.String()),
+  routes: Type.Array(RouteInfoSchema),
+});
+
+// Response schema
+export const RouterStatusResponseSchema = Type.Object({
+  router: RouterDetailSchema,
+});
+
+// Re-export error schema
+export { ErrorResponseSchema };
+
+// Type exports
+export type RouteInfo = Static<typeof RouteInfoSchema>;
+export type RouterDetail = Static<typeof RouterDetailSchema>;
+export type RouterStatusResponse = Static<typeof RouterStatusResponseSchema>;


### PR DESCRIPTION
## Summary
- Add `GET /api/router/status` endpoint for mc-router status

## Changes
- New schema: `platform/services/mcctl-api/src/schemas/router.ts`
- New route: `platform/services/mcctl-api/src/routes/router.ts`
- Register route in `app.ts`

## API Response Example
```json
{
  "router": {
    "name": "mc-router",
    "status": "running",
    "health": "healthy",
    "port": 25565,
    "uptime": "2d 5h 30m",
    "uptimeSeconds": 191400,
    "mode": "--in-docker (auto-discovery)",
    "routes": [
      {
        "hostname": "survival.local",
        "target": "mc-survival:25565",
        "serverStatus": "running"
      }
    ]
  }
}
```

## Test Plan
- [ ] Build passes
- [ ] API returns correct router status
- [ ] Routes list includes all hostnames
- [ ] OpenAPI documentation updated

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)