### PR TITLE
feat(api): add server create and delete API endpoints (#154)

### DIFF
--- a/platform/services/mcctl-api/src/schemas/server.ts
+++ b/platform/services/mcctl-api/src/schemas/server.ts
@@ -99,9 +99,52 @@ export const ServerNameParamsSchema = Type.Object({
   name: Type.String(),
 });
 
+// Create Server Request Schema
+export const CreateServerRequestSchema = Type.Object({
+  name: Type.String({ minLength: 1, maxLength: 64, pattern: '^[a-z][a-z0-9-]*$' }),
+  type: Type.Optional(Type.Union([
+    Type.Literal('PAPER'),
+    Type.Literal('VANILLA'),
+    Type.Literal('FORGE'),
+    Type.Literal('FABRIC'),
+    Type.Literal('SPIGOT'),
+    Type.Literal('NEOFORGE'),
+  ])),
+  version: Type.Optional(Type.String()),
+  memory: Type.Optional(Type.String({ pattern: '^\\d+[MG]$' })),
+  seed: Type.Optional(Type.String()),
+  worldUrl: Type.Optional(Type.String({ format: 'uri' })),
+  worldName: Type.Optional(Type.String()),
+  autoStart: Type.Optional(Type.Boolean({ default: true })),
+});
+
+// Create Server Response Schema
+export const CreateServerResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  server: Type.Object({
+    name: Type.String(),
+    container: Type.String(),
+    status: Type.String(),
+  }),
+});
+
+// Delete Server Response Schema
+export const DeleteServerResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  server: Type.String(),
+  message: Type.String(),
+});
+
+// Delete Server Query Schema
+export const DeleteServerQuerySchema = Type.Object({
+  force: Type.Optional(Type.Boolean({ default: false })),
+});
+
 // Type exports
 export type ServerSummary = Static<typeof ServerSummarySchema>;
 export type ServerDetail = Static<typeof ServerDetailSchema>;
 export type ServerNameParams = Static<typeof ServerNameParamsSchema>;
 export type ExecCommandRequest = Static<typeof ExecCommandRequestSchema>;
 export type LogsQuery = Static<typeof LogsQuerySchema>;
+export type CreateServerRequest = Static<typeof CreateServerRequestSchema>;
+export type DeleteServerQuery = Static<typeof DeleteServerQuerySchema>;


### PR DESCRIPTION
## Summary
- Add `POST /api/servers` endpoint for server creation
- Add `DELETE /api/servers/:name` endpoint for server deletion

## API Endpoints

### POST /api/servers
Create a new Minecraft server.

**Request:**
```json
{
  "name": "myserver",
  "type": "PAPER",
  "version": "1.21.1",
  "memory": "4G",
  "autoStart": true
}
```

**Response (201):**
```json
{
  "success": true,
  "server": {
    "name": "myserver",
    "container": "mc-myserver",
    "status": "starting"
  }
}
```

### DELETE /api/servers/:name
Delete a Minecraft server.

**Query Parameters:**
- `force` (boolean): Force delete even if running

**Response (200):**
```json
{
  "success": true,
  "server": "myserver",
  "message": "Server deleted successfully"
}
```

## Changes
- `platform/services/mcctl-api/src/schemas/server.ts`: Add create/delete schemas
- `platform/services/mcctl-api/src/routes/servers.ts`: Add POST and DELETE handlers

## Test Plan
- [ ] Build passes
- [ ] POST /api/servers creates server
- [ ] DELETE /api/servers/:name deletes server
- [ ] Error handling for conflicts and not found

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)