### PR TITLE
feat(api): add player management and backup APIs (#155, #156)

### DIFF
--- a/platform/services/mcctl-api/src/app.ts
+++ b/platform/services/mcctl-api/src/app.ts
@@ -10,6 +10,8 @@ import consoleRoutes from './routes/console.js';
 import worldsRoutes from './routes/worlds.js';
 import authRoutes from './routes/auth.js';
 import routerRoutes from './routes/router.js';
+import playersRoutes from './routes/players.js';
+import backupRoutes from './routes/backup.js';
 
 export interface BuildAppOptions {
   logger?: boolean;
@@ -55,6 +57,12 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
 
   // Register router routes
   await app.register(routerRoutes);
+
+  // Register player routes
+  await app.register(playersRoutes);
+
+  // Register backup routes
+  await app.register(backupRoutes);
 
   // Register world routes
   await app.register(worldsRoutes);

--- a/platform/services/mcctl-api/src/lib/rcon.ts
+++ b/platform/services/mcctl-api/src/lib/rcon.ts
@@ -85,3 +85,35 @@ export async function isContainerRunning(containerName: string): Promise<boolean
     });
   });
 }
+
+/**
+ * Execute RCON command by server name (convenience wrapper)
+ */
+export async function execRconCommand(serverName: string, command: string): Promise<string> {
+  const result = await execRcon(serverName, command);
+  return result.output.trim();
+}
+
+/**
+ * Parse player list from RCON response
+ * Handles: "There are X of a max of Y players online: player1, player2"
+ */
+export function parsePlayerList(response: string): { online: number; max: number; players: string[] } {
+  const match = response.match(/There are (\d+)(?:\s+of a max of\s+|\/)(\d+) players? online/i);
+
+  if (!match || !match[1] || !match[2]) {
+    return { online: 0, max: 20, players: [] };
+  }
+
+  const online = parseInt(match[1], 10);
+  const max = parseInt(match[2], 10);
+
+  // Extract player names after the colon
+  const playersMatch = response.match(/:\s*(.*)$/);
+  let players: string[] = [];
+  if (playersMatch && playersMatch[1]) {
+    players = playersMatch[1].split(',').map(s => s.trim()).filter(Boolean);
+  }
+
+  return { online, max, players };
+}

--- a/platform/services/mcctl-api/src/routes/backup.ts
+++ b/platform/services/mcctl-api/src/routes/backup.ts
@@ -1,0 +1,320 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { config } from '../config/index.js';
+import {
+  BackupStatusResponseSchema,
+  BackupPushRequestSchema,
+  BackupPushResponseSchema,
+  BackupHistoryResponseSchema,
+  BackupRestoreRequestSchema,
+  BackupRestoreResponseSchema,
+  ErrorResponseSchema,
+  type BackupPushRequest,
+  type BackupRestoreRequest,
+  type BackupCommit,
+} from '../schemas/backup.js';
+
+const execPromise = promisify(exec);
+
+// Route interfaces
+interface BackupPushRoute {
+  Body: BackupPushRequest;
+}
+
+interface BackupRestoreRoute {
+  Body: BackupRestoreRequest;
+}
+
+/**
+ * Backup management routes plugin
+ */
+const backupPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+  const platformPath = config.platformPath;
+  const worldsPath = join(platformPath, 'worlds');
+
+  // Helper to check if backup is configured
+  const isBackupConfigured = (): { configured: boolean; repository?: string; branch?: string } => {
+    const repo = process.env['BACKUP_GITHUB_REPO'];
+    const token = process.env['BACKUP_GITHUB_TOKEN'];
+
+    if (!repo || !token) {
+      return { configured: false };
+    }
+
+    return {
+      configured: true,
+      repository: repo,
+      branch: process.env['BACKUP_GITHUB_BRANCH'] || 'main',
+    };
+  };
+
+  /**
+   * GET /api/backup/status
+   * Get backup configuration status
+   */
+  fastify.get('/api/backup/status', {
+    schema: {
+      description: 'Get backup configuration status',
+      tags: ['backup'],
+      response: {
+        200: BackupStatusResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (_request, reply) => {
+    try {
+      const status = isBackupConfigured();
+
+      // Get last backup date if configured
+      let lastBackup: string | undefined;
+      if (status.configured && existsSync(worldsPath)) {
+        try {
+          const { stdout } = await execPromise('git log -1 --format=%cI', {
+            cwd: worldsPath,
+            timeout: 5000,
+          });
+          lastBackup = stdout.trim() || undefined;
+        } catch {
+          // Git not initialized or no commits
+        }
+      }
+
+      return reply.send({
+        configured: status.configured,
+        repository: status.repository,
+        branch: status.branch,
+        lastBackup,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get backup status');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get backup status' });
+    }
+  });
+
+  /**
+   * POST /api/backup/push
+   * Push backup to GitHub
+   */
+  fastify.post<BackupPushRoute>('/api/backup/push', {
+    schema: {
+      description: 'Push worlds backup to GitHub',
+      tags: ['backup'],
+      body: BackupPushRequestSchema,
+      response: {
+        200: BackupPushResponseSchema,
+        400: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<BackupPushRoute>, reply: FastifyReply) => {
+    const { message } = request.body;
+
+    try {
+      const status = isBackupConfigured();
+      if (!status.configured) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: 'Backup not configured. Set BACKUP_GITHUB_REPO and BACKUP_GITHUB_TOKEN environment variables.',
+        });
+      }
+
+      if (!existsSync(worldsPath)) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: 'Worlds directory not found',
+        });
+      }
+
+      // Run backup script or git commands
+      const scriptPath = join(platformPath, 'scripts', 'backup.sh');
+      let command: string;
+
+      if (existsSync(scriptPath)) {
+        command = `bash "${scriptPath}" push ${message ? `--message "${message}"` : ''}`;
+      } else {
+        // Direct git commands
+        const commitMessage = message || `Backup ${new Date().toISOString()}`;
+        command = `cd "${worldsPath}" && git add -A && git commit -m "${commitMessage}" && git push`;
+      }
+
+      const { stdout } = await execPromise(command, {
+        cwd: platformPath,
+        timeout: 120000, // 2 minute timeout
+        env: {
+          ...process.env,
+          MCCTL_ROOT: platformPath,
+        },
+      });
+
+      // Get commit hash
+      let commitHash: string | undefined;
+      try {
+        const { stdout: hashOut } = await execPromise('git rev-parse --short HEAD', { cwd: worldsPath });
+        commitHash = hashOut.trim();
+      } catch {
+        // Ignore
+      }
+
+      return reply.send({
+        success: true,
+        commitHash,
+        message: 'Backup pushed successfully',
+      });
+    } catch (error) {
+      const execError = error as { stderr?: string; message?: string };
+      fastify.log.error(error, 'Failed to push backup');
+
+      // Check for "nothing to commit" which is not an error
+      if (execError.stderr?.includes('nothing to commit') || execError.message?.includes('nothing to commit')) {
+        return reply.send({
+          success: true,
+          message: 'No changes to backup',
+        });
+      }
+
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: execError.stderr || execError.message || 'Failed to push backup',
+      });
+    }
+  });
+
+  /**
+   * GET /api/backup/history
+   * Get backup history (git commits)
+   */
+  fastify.get('/api/backup/history', {
+    schema: {
+      description: 'Get backup history (git commits)',
+      tags: ['backup'],
+      response: {
+        200: BackupHistoryResponseSchema,
+        400: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (_request, reply) => {
+    try {
+      const status = isBackupConfigured();
+      if (!status.configured) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: 'Backup not configured',
+        });
+      }
+
+      if (!existsSync(worldsPath)) {
+        return reply.send({ commits: [], total: 0 });
+      }
+
+      // Get git log
+      const { stdout } = await execPromise(
+        'git log --format="%H|%s|%cI|%an" -n 20',
+        { cwd: worldsPath, timeout: 10000 }
+      );
+
+      const commits: BackupCommit[] = stdout.trim().split('\n')
+        .filter(Boolean)
+        .map(line => {
+          const [hash, message, date, author] = line.split('|');
+          return {
+            hash: hash?.substring(0, 7) || '',
+            message: message || '',
+            date: date || '',
+            author,
+          };
+        });
+
+      return reply.send({ commits, total: commits.length });
+    } catch (error) {
+      const execError = error as { stderr?: string; message?: string };
+
+      // Check for "not a git repository"
+      if (execError.stderr?.includes('not a git repository')) {
+        return reply.send({ commits: [], total: 0 });
+      }
+
+      fastify.log.error(error, 'Failed to get backup history');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get backup history' });
+    }
+  });
+
+  /**
+   * POST /api/backup/restore
+   * Restore from backup
+   */
+  fastify.post<BackupRestoreRoute>('/api/backup/restore', {
+    schema: {
+      description: 'Restore worlds from a backup commit',
+      tags: ['backup'],
+      body: BackupRestoreRequestSchema,
+      response: {
+        200: BackupRestoreResponseSchema,
+        400: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<BackupRestoreRoute>, reply: FastifyReply) => {
+    const { commitHash } = request.body;
+
+    try {
+      const status = isBackupConfigured();
+      if (!status.configured) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: 'Backup not configured',
+        });
+      }
+
+      if (!existsSync(worldsPath)) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: 'Worlds directory not found',
+        });
+      }
+
+      // Run backup restore script or git commands
+      const scriptPath = join(platformPath, 'scripts', 'backup.sh');
+      let command: string;
+
+      if (existsSync(scriptPath)) {
+        command = `bash "${scriptPath}" restore "${commitHash}"`;
+      } else {
+        // Direct git command
+        command = `cd "${worldsPath}" && git checkout ${commitHash} .`;
+      }
+
+      await execPromise(command, {
+        cwd: platformPath,
+        timeout: 120000,
+        env: {
+          ...process.env,
+          MCCTL_ROOT: platformPath,
+        },
+      });
+
+      return reply.send({
+        success: true,
+        message: `Restored to commit ${commitHash}`,
+      });
+    } catch (error) {
+      const execError = error as { stderr?: string; message?: string };
+      fastify.log.error(error, 'Failed to restore backup');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: execError.stderr || execError.message || 'Failed to restore backup',
+      });
+    }
+  });
+};
+
+export default fp(backupPlugin, {
+  name: 'backup-routes',
+  fastify: '5.x',
+});
+
+export { backupPlugin };

--- a/platform/services/mcctl-api/src/routes/players.ts
+++ b/platform/services/mcctl-api/src/routes/players.ts
@@ -1,0 +1,404 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+import { containerExists, getContainerStatus } from '@minecraft-docker/shared';
+import {
+  PlayerInfoSchema,
+  OnlinePlayersResponseSchema,
+  PlayerListResponseSchema,
+  AddPlayerRequestSchema,
+  KickPlayerRequestSchema,
+  PlayerActionResponseSchema,
+  PlayerParamsSchema,
+  UsernameParamsSchema,
+  ErrorResponseSchema,
+  type AddPlayerRequest,
+  type KickPlayerRequest,
+  type PlayerParams,
+  type UsernameParams,
+} from '../schemas/player.js';
+import { ServerNameParamsSchema, type ServerNameParams } from '../schemas/server.js';
+import { execRconCommand, parsePlayerList } from '../lib/rcon.js';
+
+// Route interfaces
+interface ServerRoute {
+  Params: ServerNameParams;
+}
+
+interface PlayerRoute {
+  Params: PlayerParams;
+}
+
+interface UsernameRoute {
+  Params: UsernameParams;
+}
+
+interface AddPlayerRoute {
+  Params: ServerNameParams;
+  Body: AddPlayerRequest;
+}
+
+interface KickPlayerRoute {
+  Params: ServerNameParams;
+  Body: KickPlayerRequest;
+}
+
+/**
+ * Player management routes plugin
+ */
+const playersPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+  // Helper to check server running
+  const checkServerRunning = (name: string, reply: FastifyReply): boolean => {
+    const containerName = `mc-${name}`;
+    if (!containerExists(containerName)) {
+      reply.code(404).send({ error: 'NotFound', message: `Server '${name}' not found` });
+      return false;
+    }
+    const status = getContainerStatus(containerName);
+    if (status !== 'running') {
+      reply.code(400).send({ error: 'BadRequest', message: `Server '${name}' is not running` });
+      return false;
+    }
+    return true;
+  };
+
+  /**
+   * GET /api/servers/:name/players
+   * List online players
+   */
+  fastify.get<ServerRoute>('/api/servers/:name/players', {
+    schema: {
+      description: 'List online players on a server',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      response: {
+        200: OnlinePlayersResponseSchema,
+        400: ErrorResponseSchema,
+        404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<ServerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, 'list');
+      const parsed = parsePlayerList(result);
+      return reply.send(parsed);
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get online players');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get online players' });
+    }
+  });
+
+  /**
+   * GET /api/players/:username
+   * Get player info from Mojang API
+   */
+  fastify.get<UsernameRoute>('/api/players/:username', {
+    schema: {
+      description: 'Get player info (UUID, skin) from Mojang API',
+      tags: ['players'],
+      params: UsernameParamsSchema,
+      response: {
+        200: PlayerInfoSchema,
+        404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<UsernameRoute>, reply: FastifyReply) => {
+    const { username } = request.params;
+
+    try {
+      // Fetch from Mojang API
+      const response = await fetch(`https://api.mojang.com/users/profiles/minecraft/${username}`);
+
+      if (response.status === 404) {
+        return reply.code(404).send({ error: 'NotFound', message: `Player '${username}' not found` });
+      }
+
+      if (!response.ok) {
+        throw new Error(`Mojang API returned ${response.status}`);
+      }
+
+      const data = await response.json() as { id: string; name: string };
+
+      // Format UUID with dashes
+      const uuid = data.id.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+
+      return reply.send({
+        username: data.name,
+        uuid,
+        skinUrl: `https://crafatar.com/avatars/${data.id}?overlay`,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get player info');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get player info' });
+    }
+  });
+
+  // ==================== WHITELIST ====================
+
+  /**
+   * GET /api/servers/:name/whitelist
+   */
+  fastify.get<ServerRoute>('/api/servers/:name/whitelist', {
+    schema: {
+      description: 'Get server whitelist',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      response: { 200: PlayerListResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<ServerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, 'whitelist list');
+      // Parse: "There are N whitelisted players: player1, player2"
+      const match = result.match(/:\s*(.*)$/);
+      const players = match && match[1] ? match[1].split(',').map(p => p.trim()).filter(Boolean) : [];
+      return reply.send({ players, total: players.length });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get whitelist');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get whitelist' });
+    }
+  });
+
+  /**
+   * POST /api/servers/:name/whitelist
+   */
+  fastify.post<AddPlayerRoute>('/api/servers/:name/whitelist', {
+    schema: {
+      description: 'Add player to whitelist',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      body: AddPlayerRequestSchema,
+      response: { 200: PlayerActionResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<AddPlayerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { player } = request.body;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, `whitelist add ${player}`);
+      return reply.send({ success: true, message: result || `Added ${player} to whitelist` });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to add to whitelist');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to add to whitelist' });
+    }
+  });
+
+  /**
+   * DELETE /api/servers/:name/whitelist/:player
+   */
+  fastify.delete<PlayerRoute>('/api/servers/:name/whitelist/:player', {
+    schema: {
+      description: 'Remove player from whitelist',
+      tags: ['players'],
+      params: PlayerParamsSchema,
+      response: { 200: PlayerActionResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<PlayerRoute>, reply: FastifyReply) => {
+    const { name, player } = request.params;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, `whitelist remove ${player}`);
+      return reply.send({ success: true, message: result || `Removed ${player} from whitelist` });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to remove from whitelist');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to remove from whitelist' });
+    }
+  });
+
+  // ==================== BANS ====================
+
+  /**
+   * GET /api/servers/:name/bans
+   */
+  fastify.get<ServerRoute>('/api/servers/:name/bans', {
+    schema: {
+      description: 'Get banned players list',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      response: { 200: PlayerListResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<ServerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, 'banlist players');
+      // Parse: "There are N bans: player1, player2" or "There are no bans"
+      const match = result.match(/:\s*(.*)$/);
+      const players = match && match[1] ? match[1].split(',').map(p => p.trim()).filter(Boolean) : [];
+      return reply.send({ players, total: players.length });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get ban list');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get ban list' });
+    }
+  });
+
+  /**
+   * POST /api/servers/:name/bans
+   */
+  fastify.post<AddPlayerRoute>('/api/servers/:name/bans', {
+    schema: {
+      description: 'Ban a player',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      body: AddPlayerRequestSchema,
+      response: { 200: PlayerActionResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<AddPlayerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { player, reason } = request.body;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const cmd = reason ? `ban ${player} ${reason}` : `ban ${player}`;
+      const result = await execRconCommand(name, cmd);
+      return reply.send({ success: true, message: result || `Banned ${player}` });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to ban player');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to ban player' });
+    }
+  });
+
+  /**
+   * DELETE /api/servers/:name/bans/:player
+   */
+  fastify.delete<PlayerRoute>('/api/servers/:name/bans/:player', {
+    schema: {
+      description: 'Unban a player',
+      tags: ['players'],
+      params: PlayerParamsSchema,
+      response: { 200: PlayerActionResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<PlayerRoute>, reply: FastifyReply) => {
+    const { name, player } = request.params;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, `pardon ${player}`);
+      return reply.send({ success: true, message: result || `Unbanned ${player}` });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to unban player');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to unban player' });
+    }
+  });
+
+  // ==================== KICK ====================
+
+  /**
+   * POST /api/servers/:name/kick
+   */
+  fastify.post<KickPlayerRoute>('/api/servers/:name/kick', {
+    schema: {
+      description: 'Kick a player from the server',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      body: KickPlayerRequestSchema,
+      response: { 200: PlayerActionResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<KickPlayerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { player, reason } = request.body;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const cmd = reason ? `kick ${player} ${reason}` : `kick ${player}`;
+      const result = await execRconCommand(name, cmd);
+      return reply.send({ success: true, message: result || `Kicked ${player}` });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to kick player');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to kick player' });
+    }
+  });
+
+  // ==================== OPERATORS ====================
+
+  /**
+   * GET /api/servers/:name/ops
+   */
+  fastify.get<ServerRoute>('/api/servers/:name/ops', {
+    schema: {
+      description: 'Get server operators list',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      response: { 200: PlayerListResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<ServerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, 'op list');
+      // Parse: "There are N ops: player1, player2"
+      const match = result.match(/:\s*(.*)$/);
+      const players = match && match[1] ? match[1].split(',').map(p => p.trim()).filter(Boolean) : [];
+      return reply.send({ players, total: players.length });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get ops list');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get ops list' });
+    }
+  });
+
+  /**
+   * POST /api/servers/:name/ops
+   */
+  fastify.post<AddPlayerRoute>('/api/servers/:name/ops', {
+    schema: {
+      description: 'Add player as operator',
+      tags: ['players'],
+      params: ServerNameParamsSchema,
+      body: AddPlayerRequestSchema,
+      response: { 200: PlayerActionResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<AddPlayerRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { player } = request.body;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, `op ${player}`);
+      return reply.send({ success: true, message: result || `Made ${player} an operator` });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to add operator');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to add operator' });
+    }
+  });
+
+  /**
+   * DELETE /api/servers/:name/ops/:player
+   */
+  fastify.delete<PlayerRoute>('/api/servers/:name/ops/:player', {
+    schema: {
+      description: 'Remove player operator status',
+      tags: ['players'],
+      params: PlayerParamsSchema,
+      response: { 200: PlayerActionResponseSchema, 400: ErrorResponseSchema, 404: ErrorResponseSchema, 500: ErrorResponseSchema },
+    },
+  }, async (request: FastifyRequest<PlayerRoute>, reply: FastifyReply) => {
+    const { name, player } = request.params;
+    if (!checkServerRunning(name, reply)) return;
+
+    try {
+      const result = await execRconCommand(name, `deop ${player}`);
+      return reply.send({ success: true, message: result || `Removed operator status from ${player}` });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to remove operator');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to remove operator' });
+    }
+  });
+};
+
+export default fp(playersPlugin, {
+  name: 'players-routes',
+  fastify: '5.x',
+});
+
+export { playersPlugin };

--- a/platform/services/mcctl-api/src/schemas/backup.ts
+++ b/platform/services/mcctl-api/src/schemas/backup.ts
@@ -1,0 +1,59 @@
+import { Type, Static } from '@sinclair/typebox';
+import { ErrorResponseSchema } from './server.js';
+
+// Backup status response
+export const BackupStatusResponseSchema = Type.Object({
+  configured: Type.Boolean(),
+  repository: Type.Optional(Type.String()),
+  branch: Type.Optional(Type.String()),
+  lastBackup: Type.Optional(Type.String()),
+});
+
+// Backup push request
+export const BackupPushRequestSchema = Type.Object({
+  message: Type.Optional(Type.String()),
+});
+
+// Backup push response
+export const BackupPushResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  commitHash: Type.Optional(Type.String()),
+  message: Type.String(),
+});
+
+// Backup commit info
+export const BackupCommitSchema = Type.Object({
+  hash: Type.String(),
+  message: Type.String(),
+  date: Type.String(),
+  author: Type.Optional(Type.String()),
+});
+
+// Backup history response
+export const BackupHistoryResponseSchema = Type.Object({
+  commits: Type.Array(BackupCommitSchema),
+  total: Type.Number(),
+});
+
+// Backup restore request
+export const BackupRestoreRequestSchema = Type.Object({
+  commitHash: Type.String({ minLength: 7 }),
+});
+
+// Backup restore response
+export const BackupRestoreResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  message: Type.String(),
+});
+
+// Re-export
+export { ErrorResponseSchema };
+
+// Type exports
+export type BackupStatusResponse = Static<typeof BackupStatusResponseSchema>;
+export type BackupPushRequest = Static<typeof BackupPushRequestSchema>;
+export type BackupPushResponse = Static<typeof BackupPushResponseSchema>;
+export type BackupCommit = Static<typeof BackupCommitSchema>;
+export type BackupHistoryResponse = Static<typeof BackupHistoryResponseSchema>;
+export type BackupRestoreRequest = Static<typeof BackupRestoreRequestSchema>;
+export type BackupRestoreResponse = Static<typeof BackupRestoreResponseSchema>;

--- a/platform/services/mcctl-api/src/schemas/player.ts
+++ b/platform/services/mcctl-api/src/schemas/player.ts
@@ -1,0 +1,64 @@
+import { Type, Static } from '@sinclair/typebox';
+import { ErrorResponseSchema } from './server.js';
+
+// Player info schema
+export const PlayerInfoSchema = Type.Object({
+  username: Type.String(),
+  uuid: Type.String(),
+  offlineUuid: Type.Optional(Type.String()),
+  skinUrl: Type.Optional(Type.String()),
+});
+
+// Online players response
+export const OnlinePlayersResponseSchema = Type.Object({
+  online: Type.Number(),
+  max: Type.Number(),
+  players: Type.Array(Type.String()),
+});
+
+// Player list (whitelist, bans, ops)
+export const PlayerListResponseSchema = Type.Object({
+  players: Type.Array(Type.String()),
+  total: Type.Number(),
+});
+
+// Add player request
+export const AddPlayerRequestSchema = Type.Object({
+  player: Type.String({ minLength: 1, maxLength: 16 }),
+  reason: Type.Optional(Type.String()),
+});
+
+// Kick player request
+export const KickPlayerRequestSchema = Type.Object({
+  player: Type.String({ minLength: 1, maxLength: 16 }),
+  reason: Type.Optional(Type.String()),
+});
+
+// Success response
+export const PlayerActionResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  message: Type.String(),
+});
+
+// Player params
+export const PlayerParamsSchema = Type.Object({
+  name: Type.String(),
+  player: Type.String(),
+});
+
+export const UsernameParamsSchema = Type.Object({
+  username: Type.String(),
+});
+
+// Re-export
+export { ErrorResponseSchema };
+
+// Type exports
+export type PlayerInfo = Static<typeof PlayerInfoSchema>;
+export type OnlinePlayersResponse = Static<typeof OnlinePlayersResponseSchema>;
+export type PlayerListResponse = Static<typeof PlayerListResponseSchema>;
+export type AddPlayerRequest = Static<typeof AddPlayerRequestSchema>;
+export type KickPlayerRequest = Static<typeof KickPlayerRequestSchema>;
+export type PlayerActionResponse = Static<typeof PlayerActionResponseSchema>;
+export type PlayerParams = Static<typeof PlayerParamsSchema>;
+export type UsernameParams = Static<typeof UsernameParamsSchema>;


### PR DESCRIPTION
## Summary
Implements player management and backup APIs in a single PR for efficiency.

## Player Management APIs (#155)

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/servers/:name/players` | List online players |
| GET | `/api/players/:username` | Player info (UUID, skin) from Mojang |
| GET | `/api/servers/:name/whitelist` | Get whitelist |
| POST | `/api/servers/:name/whitelist` | Add to whitelist |
| DELETE | `/api/servers/:name/whitelist/:player` | Remove from whitelist |
| GET | `/api/servers/:name/bans` | Get banned players |
| POST | `/api/servers/:name/bans` | Ban player |
| DELETE | `/api/servers/:name/bans/:player` | Unban player |
| POST | `/api/servers/:name/kick` | Kick player |
| GET | `/api/servers/:name/ops` | Get operators |
| POST | `/api/servers/:name/ops` | Add operator |
| DELETE | `/api/servers/:name/ops/:player` | Remove operator |

## Backup Management APIs (#156)

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/backup/status` | Backup configuration status |
| POST | `/api/backup/push` | Push backup to GitHub |
| GET | `/api/backup/history` | Git commit history |
| POST | `/api/backup/restore` | Restore from commit |

## New Files
- `routes/players.ts` - Player management endpoints
- `routes/backup.ts` - Backup management endpoints
- `schemas/player.ts` - Player schema definitions
- `schemas/backup.ts` - Backup schema definitions

## Test Plan
- [ ] Build passes
- [ ] Player endpoints work with RCON
- [ ] Mojang API lookup works
- [ ] Backup status returns configuration
- [ ] Backup push/restore works

Closes #155
Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)