### PR TITLE
feat(mcctl-console): Create responsive layout with sidebar and header

### DIFF
--- a/platform/services/mcctl-console/src/components/index.ts
+++ b/platform/services/mcctl-console/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './layout';

--- a/platform/services/mcctl-console/src/components/layout/Header.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Header.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { Header } from './Header';
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('Header', () => {
+  it('should render header with title', () => {
+    renderWithTheme(
+      <Header title="Dashboard" onMenuClick={vi.fn()} />
+    );
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('should render menu button for mobile', () => {
+    renderWithTheme(
+      <Header title="Dashboard" onMenuClick={vi.fn()} />
+    );
+
+    expect(screen.getByLabelText('open sidebar')).toBeInTheDocument();
+  });
+
+  it('should call onMenuClick when menu button is clicked', () => {
+    const onMenuClick = vi.fn();
+    renderWithTheme(
+      <Header title="Dashboard" onMenuClick={onMenuClick} />
+    );
+
+    const menuButton = screen.getByLabelText('open sidebar');
+    fireEvent.click(menuButton);
+
+    expect(onMenuClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render user menu button', () => {
+    renderWithTheme(
+      <Header title="Dashboard" onMenuClick={vi.fn()} />
+    );
+
+    expect(screen.getByLabelText('user menu')).toBeInTheDocument();
+  });
+
+  it('should open user menu when clicked', () => {
+    renderWithTheme(
+      <Header title="Dashboard" onMenuClick={vi.fn()} />
+    );
+
+    const userMenuButton = screen.getByLabelText('user menu');
+    fireEvent.click(userMenuButton);
+
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/layout/Header.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Header.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
+import Avatar from '@mui/material/Avatar';
+import MenuIcon from '@mui/icons-material/Menu';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import { SIDEBAR_WIDTH } from './Sidebar';
+
+interface HeaderProps {
+  title?: string;
+  onMenuClick: () => void;
+}
+
+export function Header({ title = 'Dashboard', onMenuClick }: HeaderProps) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleUserMenuClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleUserMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleProfile = () => {
+    handleUserMenuClose();
+    // TODO: Navigate to profile
+  };
+
+  const handleLogout = () => {
+    handleUserMenuClose();
+    // TODO: Implement logout
+  };
+
+  return (
+    <AppBar
+      position="fixed"
+      elevation={0}
+      sx={{
+        width: { lg: `calc(100% - ${SIDEBAR_WIDTH}px)` },
+        ml: { lg: `${SIDEBAR_WIDTH}px` },
+        backgroundColor: 'background.paper',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Toolbar>
+        {/* Menu Button (Mobile Only) */}
+        <IconButton
+          color="inherit"
+          aria-label="open sidebar"
+          edge="start"
+          onClick={onMenuClick}
+          sx={{
+            mr: 2,
+            display: { lg: 'none' },
+          }}
+        >
+          <MenuIcon />
+        </IconButton>
+
+        {/* Page Title */}
+        <Typography
+          variant="h6"
+          component="h1"
+          sx={{
+            flexGrow: 1,
+            fontWeight: 600,
+            color: 'text.primary',
+          }}
+        >
+          {title}
+        </Typography>
+
+        {/* User Menu */}
+        <Box>
+          <IconButton
+            onClick={handleUserMenuClick}
+            aria-label="user menu"
+            aria-controls={open ? 'user-menu' : undefined}
+            aria-haspopup="true"
+            aria-expanded={open ? 'true' : undefined}
+          >
+            <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main' }}>
+              <AccountCircleIcon />
+            </Avatar>
+          </IconButton>
+          <Menu
+            id="user-menu"
+            anchorEl={anchorEl}
+            open={open}
+            onClose={handleUserMenuClose}
+            MenuListProps={{
+              'aria-labelledby': 'user-menu-button',
+            }}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+          >
+            <MenuItem onClick={handleProfile}>Profile</MenuItem>
+            <MenuItem onClick={handleLogout}>Logout</MenuItem>
+          </Menu>
+        </Box>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/platform/services/mcctl-console/src/components/layout/MainLayout.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/MainLayout.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { MainLayout } from './MainLayout';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('MainLayout', () => {
+  it('should render children content', () => {
+    renderWithTheme(
+      <MainLayout>
+        <div>Test Content</div>
+      </MainLayout>
+    );
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('should render sidebar', () => {
+    renderWithTheme(
+      <MainLayout>
+        <div>Content</div>
+      </MainLayout>
+    );
+
+    // Both mobile and desktop drawers render the logo
+    const mcctlElements = screen.getAllByText('MCCTL');
+    expect(mcctlElements.length).toBeGreaterThan(0);
+  });
+
+  it('should render header', () => {
+    renderWithTheme(
+      <MainLayout>
+        <div>Content</div>
+      </MainLayout>
+    );
+
+    expect(screen.getByLabelText('open sidebar')).toBeInTheDocument();
+  });
+
+  it('should apply correct layout structure', () => {
+    renderWithTheme(
+      <MainLayout>
+        <div data-testid="main-content">Content</div>
+      </MainLayout>
+    );
+
+    const mainContent = screen.getByTestId('main-content');
+    expect(mainContent).toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/layout/MainLayout.tsx
+++ b/platform/services/mcctl-console/src/components/layout/MainLayout.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState, ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import { Sidebar, SIDEBAR_WIDTH } from './Sidebar';
+import { Header } from './Header';
+
+interface MainLayoutProps {
+  children: ReactNode;
+  title?: string;
+}
+
+export function MainLayout({ children, title = 'Dashboard' }: MainLayoutProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      {/* Sidebar */}
+      <Box
+        component="nav"
+        sx={{
+          width: { lg: SIDEBAR_WIDTH },
+          flexShrink: { lg: 0 },
+        }}
+      >
+        <Sidebar open={mobileOpen} onClose={handleDrawerToggle} />
+      </Box>
+
+      {/* Main Content Area */}
+      <Box
+        sx={{
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          width: { lg: `calc(100% - ${SIDEBAR_WIDTH}px)` },
+        }}
+      >
+        {/* Header */}
+        <Header title={title} onMenuClick={handleDrawerToggle} />
+
+        {/* Page Content */}
+        <Box
+          component="main"
+          sx={{
+            flexGrow: 1,
+            p: { xs: 2, sm: 3 },
+            mt: '64px', // AppBar height
+            backgroundColor: 'background.default',
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/platform/services/mcctl-console/src/components/layout/Sidebar.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Sidebar.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { Sidebar } from './Sidebar';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('Sidebar', () => {
+  it('should render sidebar with navigation items', () => {
+    renderWithTheme(<Sidebar open={true} onClose={vi.fn()} />);
+
+    // Both mobile and desktop drawers are rendered
+    const dashboardItems = screen.getAllByText('Dashboard');
+    const serversItems = screen.getAllByText('Servers');
+    const playersItems = screen.getAllByText('Players');
+    const settingsItems = screen.getAllByText('Settings');
+
+    expect(dashboardItems.length).toBeGreaterThan(0);
+    expect(serversItems.length).toBeGreaterThan(0);
+    expect(playersItems.length).toBeGreaterThan(0);
+    expect(settingsItems.length).toBeGreaterThan(0);
+  });
+
+  it('should render logo/brand', () => {
+    renderWithTheme(<Sidebar open={true} onClose={vi.fn()} />);
+
+    // Both mobile and desktop drawers render the logo
+    const mcctlElements = screen.getAllByText('MCCTL');
+    expect(mcctlElements.length).toBeGreaterThan(0);
+  });
+
+  it('should call onClose when close button is clicked on mobile', () => {
+    const onClose = vi.fn();
+    renderWithTheme(<Sidebar open={true} onClose={onClose} />);
+
+    // Both mobile and desktop drawers have close buttons
+    const closeButtons = screen.getAllByLabelText('close sidebar');
+    fireEvent.click(closeButtons[0]);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should highlight active navigation item', () => {
+    renderWithTheme(<Sidebar open={true} onClose={vi.fn()} />);
+
+    const dashboardItems = screen.getAllByRole('link', { name: /dashboard/i });
+    // At least one should have aria-current
+    const activeItem = dashboardItems.find(item => item.getAttribute('aria-current') === 'page');
+    expect(activeItem).toBeTruthy();
+  });
+
+  it('should render navigation links with correct hrefs', () => {
+    renderWithTheme(<Sidebar open={true} onClose={vi.fn()} />);
+
+    const dashboardLinks = screen.getAllByRole('link', { name: /dashboard/i });
+    const serversLinks = screen.getAllByRole('link', { name: /servers/i });
+    const playersLinks = screen.getAllByRole('link', { name: /players/i });
+    const settingsLinks = screen.getAllByRole('link', { name: /settings/i });
+
+    expect(dashboardLinks[0]).toHaveAttribute('href', '/');
+    expect(serversLinks[0]).toHaveAttribute('href', '/servers');
+    expect(playersLinks[0]).toHaveAttribute('href', '/players');
+    expect(settingsLinks[0]).toHaveAttribute('href', '/settings');
+  });
+});

--- a/platform/services/mcctl-console/src/components/layout/Sidebar.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Sidebar.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import Divider from '@mui/material/Divider';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import DnsIcon from '@mui/icons-material/Dns';
+import PeopleIcon from '@mui/icons-material/People';
+import SettingsIcon from '@mui/icons-material/Settings';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+
+export const SIDEBAR_WIDTH = 280;
+export const SIDEBAR_WIDTH_COLLAPSED = 72;
+
+interface NavItem {
+  label: string;
+  href: string;
+  icon: React.ReactNode;
+}
+
+const navItems: NavItem[] = [
+  { label: 'Dashboard', href: '/', icon: <DashboardIcon /> },
+  { label: 'Servers', href: '/servers', icon: <DnsIcon /> },
+  { label: 'Players', href: '/players', icon: <PeopleIcon /> },
+  { label: 'Settings', href: '/settings', icon: <SettingsIcon /> },
+];
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function Sidebar({ open, onClose }: SidebarProps) {
+  const pathname = usePathname();
+
+  const drawerContent = (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+      }}
+    >
+      {/* Logo/Brand */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: 2,
+          py: 2,
+          minHeight: 64,
+        }}
+      >
+        <Typography
+          variant="h6"
+          component="span"
+          sx={{
+            fontWeight: 700,
+            color: 'primary.main',
+            letterSpacing: '0.1em',
+          }}
+        >
+          MCCTL
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="close sidebar"
+          sx={{
+            display: { xs: 'flex', lg: 'none' },
+          }}
+        >
+          <ChevronLeftIcon />
+        </IconButton>
+      </Box>
+
+      <Divider />
+
+      {/* Navigation Items */}
+      <List sx={{ flex: 1, px: 1, py: 2 }}>
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <ListItem key={item.href} disablePadding sx={{ mb: 0.5 }}>
+              <ListItemButton
+                component={Link}
+                href={item.href}
+                aria-current={isActive ? 'page' : undefined}
+                sx={{
+                  borderRadius: 2,
+                  backgroundColor: isActive ? 'primary.dark' : 'transparent',
+                  '&:hover': {
+                    backgroundColor: isActive ? 'primary.dark' : 'action.hover',
+                  },
+                }}
+              >
+                <ListItemIcon
+                  sx={{
+                    color: isActive ? 'primary.main' : 'text.secondary',
+                    minWidth: 40,
+                  }}
+                >
+                  {item.icon}
+                </ListItemIcon>
+                <ListItemText
+                  primary={item.label}
+                  primaryTypographyProps={{
+                    fontWeight: isActive ? 600 : 400,
+                    color: isActive ? 'primary.main' : 'text.primary',
+                  }}
+                />
+              </ListItemButton>
+            </ListItem>
+          );
+        })}
+      </List>
+    </Box>
+  );
+
+  return (
+    <>
+      {/* Mobile Drawer */}
+      <Drawer
+        variant="temporary"
+        open={open}
+        onClose={onClose}
+        ModalProps={{
+          keepMounted: true, // Better mobile performance
+        }}
+        sx={{
+          display: { xs: 'block', lg: 'none' },
+          '& .MuiDrawer-paper': {
+            boxSizing: 'border-box',
+            width: SIDEBAR_WIDTH,
+            backgroundColor: 'background.paper',
+          },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+
+      {/* Desktop Drawer */}
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: 'none', lg: 'block' },
+          '& .MuiDrawer-paper': {
+            boxSizing: 'border-box',
+            width: SIDEBAR_WIDTH,
+            backgroundColor: 'background.paper',
+            borderRight: '1px solid',
+            borderColor: 'divider',
+          },
+        }}
+        open
+      >
+        {drawerContent}
+      </Drawer>
+    </>
+  );
+}

--- a/platform/services/mcctl-console/src/components/layout/index.ts
+++ b/platform/services/mcctl-console/src/components/layout/index.ts
@@ -1,0 +1,3 @@
+export { Sidebar, SIDEBAR_WIDTH, SIDEBAR_WIDTH_COLLAPSED } from './Sidebar';
+export { Header } from './Header';
+export { MainLayout } from './MainLayout';


### PR DESCRIPTION
## Summary
- Add Sidebar component with navigation items (Dashboard, Servers, Players, Settings)
- Add Header component with menu toggle and user menu
- Add MainLayout wrapper component for consistent page structure
- Implement responsive breakpoints (Desktop >= 1200px, Tablet 768-1199px, Mobile < 768px)
- Create barrel exports for layout components

## Related Issue
Closes #184

## Files Added
- `src/components/layout/Sidebar.tsx` - Navigation sidebar with responsive drawer
- `src/components/layout/Header.tsx` - Top header with menu toggle and user menu
- `src/components/layout/MainLayout.tsx` - Layout wrapper combining sidebar and header
- `src/components/layout/index.ts` - Barrel exports
- `src/components/index.ts` - Root components export

## Responsive Breakpoints
- Desktop: >= 1200px (permanent sidebar)
- Tablet: 768-1199px (temporary drawer)
- Mobile: < 768px (temporary drawer with hamburger menu)

## Test plan
- [x] All unit tests passing (24 tests)
- [x] TypeScript type-check passing
- [x] ESLint passing
- [ ] Manual testing of responsive layout

Generated with [Claude Code](https://claude.com/claude-code)