### PR TITLE
feat(mcctl-console): implement login/signup forms and route protection (#181)

### DIFF
--- a/platform/services/mcctl-console/src/app/dashboard/page.tsx
+++ b/platform/services/mcctl-console/src/app/dashboard/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Box, Typography, Container } from '@mui/material';
+
+export default function DashboardPage() {
+  return (
+    <Container maxWidth="xl">
+      <Box sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Dashboard
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Welcome to the Minecraft Server Manager dashboard.
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/platform/services/mcctl-console/src/app/login/page.tsx
+++ b/platform/services/mcctl-console/src/app/login/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Box, Card, CardContent, Typography, Link, Container } from '@mui/material';
+import { LoginForm } from '@/components/auth';
+import NextLink from 'next/link';
+
+export default function LoginPage() {
+  const router = useRouter();
+
+  const handleLoginSuccess = () => {
+    // Redirect to dashboard after successful login
+    router.push('/dashboard');
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          py: 4,
+        }}
+      >
+        <Card sx={{ width: '100%', maxWidth: 500 }}>
+          <CardContent sx={{ p: 4 }}>
+            <Typography
+              variant="h4"
+              component="h1"
+              gutterBottom
+              sx={{ fontWeight: 600, textAlign: 'center', mb: 3 }}
+            >
+              Welcome Back
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ textAlign: 'center', mb: 4 }}
+            >
+              Sign in to manage your Minecraft servers
+            </Typography>
+
+            <LoginForm onSuccess={handleLoginSuccess} />
+
+            <Box sx={{ mt: 3, textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                Don&apos;t have an account?{' '}
+                <Link component={NextLink} href="/signup" underline="hover">
+                  Sign up
+                </Link>
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+    </Container>
+  );
+}

--- a/platform/services/mcctl-console/src/app/page.tsx
+++ b/platform/services/mcctl-console/src/app/page.tsx
@@ -1,62 +1,37 @@
 'use client';
 
-import { Box, Container, Typography, Card, CardContent, Button, Stack } from '@mui/material';
-import StorageIcon from '@mui/icons-material/Storage';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Box, CircularProgress } from '@mui/material';
+import { useSession } from '@/lib/auth-client';
 
 export default function Home() {
+  const router = useRouter();
+  const { data: session, isPending } = useSession();
+
+  useEffect(() => {
+    if (!isPending) {
+      if (session?.user) {
+        // User is authenticated, redirect to dashboard
+        router.push('/dashboard');
+      } else {
+        // User is not authenticated, redirect to login
+        router.push('/login');
+      }
+    }
+  }, [session, isPending, router]);
+
+  // Show loading spinner while checking auth status
   return (
     <Box
-      component="main"
       sx={{
-        minHeight: '100vh',
         display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
         justifyContent: 'center',
-        p: 3,
+        alignItems: 'center',
+        minHeight: '100vh',
       }}
     >
-      <Container maxWidth="sm">
-        <Card>
-          <CardContent>
-            <Stack spacing={3} alignItems="center">
-              <StorageIcon sx={{ fontSize: 64, color: 'primary.main' }} />
-
-              <Typography variant="h4" component="h1" align="center" fontWeight="bold">
-                Minecraft Server Manager
-              </Typography>
-
-              <Typography variant="body1" color="text.secondary" align="center">
-                Web-based management console for Minecraft server infrastructure.
-                Real-time monitoring, server lifecycle management, and more.
-              </Typography>
-
-              <Stack direction="row" spacing={2}>
-                <Button
-                  variant="contained"
-                  startIcon={<PlayArrowIcon />}
-                  className="hover:bg-primary-dark"
-                >
-                  Get Started
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="secondary"
-                >
-                  Documentation
-                </Button>
-              </Stack>
-
-              <Box className="mt-4 p-4 rounded-lg bg-background-paper">
-                <Typography variant="caption" color="text.secondary">
-                  MUI + Tailwind CSS Integration Working
-                </Typography>
-              </Box>
-            </Stack>
-          </CardContent>
-        </Card>
-      </Container>
+      <CircularProgress />
     </Box>
   );
 }

--- a/platform/services/mcctl-console/src/app/signup/page.tsx
+++ b/platform/services/mcctl-console/src/app/signup/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Box, Card, CardContent, Typography, Link, Container } from '@mui/material';
+import { SignUpForm } from '@/components/auth';
+import NextLink from 'next/link';
+
+export default function SignUpPage() {
+  const router = useRouter();
+
+  const handleSignUpSuccess = () => {
+    // Redirect to dashboard after successful signup
+    router.push('/dashboard');
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          py: 4,
+        }}
+      >
+        <Card sx={{ width: '100%', maxWidth: 500 }}>
+          <CardContent sx={{ p: 4 }}>
+            <Typography
+              variant="h4"
+              component="h1"
+              gutterBottom
+              sx={{ fontWeight: 600, textAlign: 'center', mb: 3 }}
+            >
+              Create Account
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ textAlign: 'center', mb: 4 }}
+            >
+              Sign up to start managing Minecraft servers
+            </Typography>
+
+            <SignUpForm onSuccess={handleSignUpSuccess} />
+
+            <Box sx={{ mt: 3, textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                Already have an account?{' '}
+                <Link component={NextLink} href="/login" underline="hover">
+                  Sign in
+                </Link>
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+    </Container>
+  );
+}

--- a/platform/services/mcctl-console/src/components/auth/LoginForm.test.tsx
+++ b/platform/services/mcctl-console/src/components/auth/LoginForm.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { LoginForm } from './LoginForm';
+
+// Mock auth client
+vi.mock('@/lib/auth-client', () => ({
+  signIn: {
+    email: vi.fn(),
+  },
+}));
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('LoginForm', () => {
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render email and password fields', () => {
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    expect(screen.getByLabelText(/^email \*$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password \*$/i)).toBeInTheDocument();
+  });
+
+  it('should render login button', () => {
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('should show validation error for empty email', async () => {
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show validation error for invalid email format', async () => {
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email address/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show validation error for empty password', async () => {
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/password is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should call signIn with valid credentials', async () => {
+    const { signIn } = await import('@/lib/auth-client');
+    (signIn.email as any).mockResolvedValue({ data: { user: { id: '1' } }, error: null });
+
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(signIn.email).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123',
+      });
+    });
+  });
+
+  it('should show loading state during submission', async () => {
+    const { signIn } = await import('@/lib/auth-client');
+    (signIn.email as any).mockImplementation(() => new Promise(() => {})); // Never resolves
+
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
+  it('should show error message on authentication failure', async () => {
+    const { signIn } = await import('@/lib/auth-client');
+    (signIn.email as any).mockResolvedValue({
+      data: null,
+      error: { message: 'Invalid credentials' },
+    });
+
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'wrong-password' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should call onSuccess after successful login', async () => {
+    const { signIn } = await import('@/lib/auth-client');
+    (signIn.email as any).mockResolvedValue({ data: { user: { id: '1' } }, error: null });
+
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('should toggle password visibility', () => {
+    renderWithTheme(<LoginForm onSuccess={mockOnSuccess} />);
+
+    const passwordInput = screen.getByLabelText(/^password \*$/i) as HTMLInputElement;
+    expect(passwordInput.type).toBe('password');
+
+    const toggleButton = screen.getByLabelText(/toggle password visibility/i);
+    fireEvent.click(toggleButton);
+
+    expect(passwordInput.type).toBe('text');
+
+    fireEvent.click(toggleButton);
+    expect(passwordInput.type).toBe('password');
+  });
+});

--- a/platform/services/mcctl-console/src/components/auth/LoginForm.tsx
+++ b/platform/services/mcctl-console/src/components/auth/LoginForm.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Alert,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { signIn } from '@/lib/auth-client';
+
+interface LoginFormProps {
+  onSuccess?: () => void;
+}
+
+interface FormErrors {
+  email?: string;
+  password?: string;
+}
+
+export function LoginForm({ onSuccess }: LoginFormProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const validateForm = (): boolean => {
+    const newErrors: FormErrors = {};
+
+    if (!email) {
+      newErrors.email = 'Email is required';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      newErrors.email = 'Invalid email address';
+    }
+
+    if (!password) {
+      newErrors.password = 'Password is required';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setApiError(null);
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const result = await signIn.email({
+        email,
+        password,
+      });
+
+      if (result.error) {
+        setApiError(result.error.message || 'Invalid credentials');
+        setIsLoading(false);
+        return;
+      }
+
+      // Success
+      if (onSuccess) {
+        onSuccess();
+      }
+    } catch (error) {
+      setApiError('An unexpected error occurred. Please try again.');
+      setIsLoading(false);
+    }
+  };
+
+  const handleTogglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+    >
+      {apiError && (
+        <Alert severity="error" onClose={() => setApiError(null)}>
+          {apiError}
+        </Alert>
+      )}
+
+      <TextField
+        label="Email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        error={!!errors.email}
+        helperText={errors.email}
+        disabled={isLoading}
+        fullWidth
+        required
+      />
+
+      <TextField
+        label="Password"
+        type={showPassword ? 'text' : 'password'}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        error={!!errors.password}
+        helperText={errors.password}
+        disabled={isLoading}
+        fullWidth
+        required
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={handleTogglePasswordVisibility}
+                edge="end"
+              >
+                {showPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+      />
+
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        disabled={isLoading}
+        fullWidth
+        size="large"
+      >
+        {isLoading ? 'Signing in...' : 'Sign In'}
+      </Button>
+    </Box>
+  );
+}

--- a/platform/services/mcctl-console/src/components/auth/SignUpForm.test.tsx
+++ b/platform/services/mcctl-console/src/components/auth/SignUpForm.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { SignUpForm } from './SignUpForm';
+
+// Mock auth client
+vi.mock('@/lib/auth-client', () => ({
+  signUp: {
+    email: vi.fn(),
+  },
+}));
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('SignUpForm', () => {
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render name, email and password fields', () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    expect(screen.getByLabelText(/^name \*$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^email \*$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password \*$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^confirm password \*$/i)).toBeInTheDocument();
+  });
+
+  it('should render sign up button', () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    expect(screen.getByRole('button', { name: /sign up/i })).toBeInTheDocument();
+  });
+
+  it('should show validation error for empty name', async () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show validation error for empty email', async () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show validation error for invalid email format', async () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email address/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show validation error for short password', async () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: '12345' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/password must be at least 8 characters/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show validation error for mismatched passwords', async () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+    const confirmPasswordInput = screen.getByLabelText(/^confirm password \*$/i);
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password456' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should call signUp with valid data', async () => {
+    const { signUp } = await import('@/lib/auth-client');
+    (signUp.email as any).mockResolvedValue({ data: { user: { id: '1' } }, error: null });
+
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+    const confirmPasswordInput = screen.getByLabelText(/^confirm password \*$/i);
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(signUp.email).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123',
+        name: 'Test User',
+      });
+    });
+  });
+
+  it('should show loading state during submission', async () => {
+    const { signUp } = await import('@/lib/auth-client');
+    (signUp.email as any).mockImplementation(() => new Promise(() => {})); // Never resolves
+
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+    const confirmPasswordInput = screen.getByLabelText(/^confirm password \*$/i);
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
+  it('should show error message on registration failure', async () => {
+    const { signUp } = await import('@/lib/auth-client');
+    (signUp.email as any).mockResolvedValue({
+      data: null,
+      error: { message: 'Email already exists' },
+    });
+
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+    const confirmPasswordInput = screen.getByLabelText(/^confirm password \*$/i);
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/email already exists/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should call onSuccess after successful signup', async () => {
+    const { signUp } = await import('@/lib/auth-client');
+    (signUp.email as any).mockResolvedValue({ data: { user: { id: '1' } }, error: null });
+
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const nameInput = screen.getByLabelText(/^name \*$/i);
+    const emailInput = screen.getByLabelText(/^email \*$/i);
+    const passwordInput = screen.getByLabelText(/^password \*$/i);
+    const confirmPasswordInput = screen.getByLabelText(/^confirm password \*$/i);
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } });
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('should toggle password visibility', () => {
+    renderWithTheme(<SignUpForm onSuccess={mockOnSuccess} />);
+
+    const passwordInput = screen.getByLabelText(/^password \*$/i) as HTMLInputElement;
+    expect(passwordInput.type).toBe('password');
+
+    const toggleButtons = screen.getAllByLabelText(/toggle password visibility/i);
+    fireEvent.click(toggleButtons[0]);
+
+    expect(passwordInput.type).toBe('text');
+
+    fireEvent.click(toggleButtons[0]);
+    expect(passwordInput.type).toBe('password');
+  });
+});

--- a/platform/services/mcctl-console/src/components/auth/SignUpForm.tsx
+++ b/platform/services/mcctl-console/src/components/auth/SignUpForm.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Alert,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { signUp } from '@/lib/auth-client';
+
+interface SignUpFormProps {
+  onSuccess?: () => void;
+}
+
+interface FormErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+}
+
+export function SignUpForm({ onSuccess }: SignUpFormProps) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const validateForm = (): boolean => {
+    const newErrors: FormErrors = {};
+
+    if (!name) {
+      newErrors.name = 'Name is required';
+    }
+
+    if (!email) {
+      newErrors.email = 'Email is required';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      newErrors.email = 'Invalid email address';
+    }
+
+    if (!password) {
+      newErrors.password = 'Password is required';
+    } else if (password.length < 8) {
+      newErrors.password = 'Password must be at least 8 characters';
+    }
+
+    if (!confirmPassword) {
+      newErrors.confirmPassword = 'Please confirm your password';
+    } else if (password !== confirmPassword) {
+      newErrors.confirmPassword = 'Passwords do not match';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setApiError(null);
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const result = await signUp.email({
+        email,
+        password,
+        name,
+      });
+
+      if (result.error) {
+        setApiError(result.error.message || 'Registration failed');
+        setIsLoading(false);
+        return;
+      }
+
+      // Success
+      if (onSuccess) {
+        onSuccess();
+      }
+    } catch (error) {
+      setApiError('An unexpected error occurred. Please try again.');
+      setIsLoading(false);
+    }
+  };
+
+  const handleTogglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  const handleToggleConfirmPasswordVisibility = () => {
+    setShowConfirmPassword(!showConfirmPassword);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+    >
+      {apiError && (
+        <Alert severity="error" onClose={() => setApiError(null)}>
+          {apiError}
+        </Alert>
+      )}
+
+      <TextField
+        label="Name"
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        error={!!errors.name}
+        helperText={errors.name}
+        disabled={isLoading}
+        fullWidth
+        required
+      />
+
+      <TextField
+        label="Email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        error={!!errors.email}
+        helperText={errors.email}
+        disabled={isLoading}
+        fullWidth
+        required
+      />
+
+      <TextField
+        label="Password"
+        type={showPassword ? 'text' : 'password'}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        error={!!errors.password}
+        helperText={errors.password}
+        disabled={isLoading}
+        fullWidth
+        required
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={handleTogglePasswordVisibility}
+                edge="end"
+              >
+                {showPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+      />
+
+      <TextField
+        label="Confirm Password"
+        type={showConfirmPassword ? 'text' : 'password'}
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        error={!!errors.confirmPassword}
+        helperText={errors.confirmPassword}
+        disabled={isLoading}
+        fullWidth
+        required
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={handleToggleConfirmPasswordVisibility}
+                edge="end"
+              >
+                {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+      />
+
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        disabled={isLoading}
+        fullWidth
+        size="large"
+      >
+        {isLoading ? 'Creating account...' : 'Sign Up'}
+      </Button>
+    </Box>
+  );
+}

--- a/platform/services/mcctl-console/src/components/auth/UserMenu.test.tsx
+++ b/platform/services/mcctl-console/src/components/auth/UserMenu.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { UserMenu } from './UserMenu';
+
+// Mock auth client
+vi.mock('@/lib/auth-client', () => ({
+  useSession: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('UserMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render loading state when session is loading', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({ data: null, isPending: true });
+
+    renderWithTheme(<UserMenu />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('should render login button when not authenticated', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({ data: null, isPending: false });
+
+    renderWithTheme(<UserMenu />);
+
+    expect(screen.getByText(/sign in/i)).toBeInTheDocument();
+  });
+
+  it('should render user avatar when authenticated', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: { user: { id: '1', name: 'Test User', email: 'test@example.com' } },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    expect(screen.getByLabelText(/user menu/i)).toBeInTheDocument();
+  });
+
+  it('should display user initials in avatar', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: { user: { id: '1', name: 'Test User', email: 'test@example.com' } },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    expect(screen.getByText('TU')).toBeInTheDocument();
+  });
+
+  it('should display first letter of email if name is not available', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: { user: { id: '1', email: 'test@example.com' } },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
+
+  it('should open menu when avatar is clicked', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: { user: { id: '1', name: 'Test User', email: 'test@example.com' } },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    const avatarButton = screen.getByLabelText(/user menu/i);
+    fireEvent.click(avatarButton);
+
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('should display logout option in menu', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: { user: { id: '1', name: 'Test User', email: 'test@example.com' } },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    const avatarButton = screen.getByLabelText(/user menu/i);
+    fireEvent.click(avatarButton);
+
+    expect(screen.getByText(/logout/i)).toBeInTheDocument();
+  });
+
+  it('should call signOut when logout is clicked', async () => {
+    const { useSession, signOut } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: { user: { id: '1', name: 'Test User', email: 'test@example.com' } },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    const avatarButton = screen.getByLabelText(/user menu/i);
+    fireEvent.click(avatarButton);
+
+    const logoutButton = screen.getByText(/logout/i);
+    fireEvent.click(logoutButton);
+
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it('should close menu when logout is clicked', () => {
+    const { useSession, signOut } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: { user: { id: '1', name: 'Test User', email: 'test@example.com' } },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    const avatarButton = screen.getByLabelText(/user menu/i);
+    fireEvent.click(avatarButton);
+
+    const logoutButton = screen.getByText(/logout/i);
+    fireEvent.click(logoutButton);
+
+    // Menu should be closed, so user email shouldn't be visible
+    expect(screen.queryByText('test@example.com')).not.toBeInTheDocument();
+  });
+
+  it('should show admin badge for admin users', () => {
+    const { useSession } = require('@/lib/auth-client');
+    useSession.mockReturnValue({
+      data: {
+        user: {
+          id: '1',
+          name: 'Admin User',
+          email: 'admin@example.com',
+          role: 'admin',
+        },
+      },
+      isPending: false,
+    });
+
+    renderWithTheme(<UserMenu />);
+
+    const avatarButton = screen.getByLabelText(/user menu/i);
+    fireEvent.click(avatarButton);
+
+    expect(screen.getByText(/admin/i)).toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/auth/UserMenu.tsx
+++ b/platform/services/mcctl-console/src/components/auth/UserMenu.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Box,
+  IconButton,
+  Avatar,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Divider,
+  Typography,
+  CircularProgress,
+  Button,
+  Chip,
+} from '@mui/material';
+import { Logout, Person } from '@mui/icons-material';
+import { useSession, signOut } from '@/lib/auth-client';
+
+export function UserMenu() {
+  const router = useRouter();
+  const { data: session, isPending } = useSession();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleOpenMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLogout = async () => {
+    handleCloseMenu();
+    await signOut();
+    router.push('/login');
+  };
+
+  const handleLogin = () => {
+    router.push('/login');
+  };
+
+  const getInitials = (name?: string, email?: string): string => {
+    if (name) {
+      const parts = name.split(' ');
+      if (parts.length >= 2) {
+        return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+      }
+      return name.substring(0, 2).toUpperCase();
+    }
+    if (email) {
+      return email[0].toUpperCase();
+    }
+    return '?';
+  };
+
+  // Loading state
+  if (isPending) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  // Not authenticated
+  if (!session?.user) {
+    return (
+      <Button variant="contained" color="primary" onClick={handleLogin}>
+        Sign In
+      </Button>
+    );
+  }
+
+  const { user } = session;
+  const initials = getInitials(user.name, user.email);
+
+  return (
+    <>
+      <IconButton onClick={handleOpenMenu} aria-label="user menu">
+        <Avatar sx={{ bgcolor: 'primary.main' }}>{initials}</Avatar>
+      </IconButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleCloseMenu}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        sx={{ mt: 1 }}
+      >
+        <Box sx={{ px: 2, py: 1.5, minWidth: 200 }}>
+          <Typography variant="subtitle1" fontWeight="600">
+            {user.name || 'User'}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {user.email}
+          </Typography>
+          {user.role === 'admin' && (
+            <Chip
+              label="Admin"
+              size="small"
+              color="primary"
+              sx={{ mt: 1 }}
+            />
+          )}
+        </Box>
+
+        <Divider />
+
+        <MenuItem onClick={handleLogout}>
+          <ListItemIcon>
+            <Logout fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Logout</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/platform/services/mcctl-console/src/components/auth/index.ts
+++ b/platform/services/mcctl-console/src/components/auth/index.ts
@@ -1,0 +1,3 @@
+export { LoginForm } from './LoginForm';
+export { SignUpForm } from './SignUpForm';
+export { UserMenu } from './UserMenu';

--- a/platform/services/mcctl-console/src/components/layout/Header.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Header.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from '@/theme';
 import { Header } from './Header';
 
+// Mock UserMenu component
+vi.mock('@/components/auth', () => ({
+  UserMenu: () => <div data-testid="user-menu">UserMenu</div>,
+}));
+
 const renderWithTheme = (component: React.ReactNode) => {
   return render(<ThemeProvider>{component}</ThemeProvider>);
 };
@@ -36,23 +41,11 @@ describe('Header', () => {
     expect(onMenuClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should render user menu button', () => {
+  it('should render UserMenu component', () => {
     renderWithTheme(
       <Header title="Dashboard" onMenuClick={vi.fn()} />
     );
 
-    expect(screen.getByLabelText('user menu')).toBeInTheDocument();
-  });
-
-  it('should open user menu when clicked', () => {
-    renderWithTheme(
-      <Header title="Dashboard" onMenuClick={vi.fn()} />
-    );
-
-    const userMenuButton = screen.getByLabelText('user menu');
-    fireEvent.click(userMenuButton);
-
-    expect(screen.getByText('Profile')).toBeInTheDocument();
-    expect(screen.getByText('Logout')).toBeInTheDocument();
+    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
   });
 });

--- a/platform/services/mcctl-console/src/components/layout/Header.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Header.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { useState } from 'react';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/material/Box';
-import Avatar from '@mui/material/Avatar';
 import MenuIcon from '@mui/icons-material/Menu';
-import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import { SIDEBAR_WIDTH } from './Sidebar';
+import { UserMenu } from '@/components/auth';
 
 interface HeaderProps {
   title?: string;
@@ -19,27 +15,6 @@ interface HeaderProps {
 }
 
 export function Header({ title = 'Dashboard', onMenuClick }: HeaderProps) {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-
-  const handleUserMenuClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleUserMenuClose = () => {
-    setAnchorEl(null);
-  };
-
-  const handleProfile = () => {
-    handleUserMenuClose();
-    // TODO: Navigate to profile
-  };
-
-  const handleLogout = () => {
-    handleUserMenuClose();
-    // TODO: Implement logout
-  };
-
   return (
     <AppBar
       position="fixed"
@@ -82,37 +57,7 @@ export function Header({ title = 'Dashboard', onMenuClick }: HeaderProps) {
 
         {/* User Menu */}
         <Box>
-          <IconButton
-            onClick={handleUserMenuClick}
-            aria-label="user menu"
-            aria-controls={open ? 'user-menu' : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? 'true' : undefined}
-          >
-            <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main' }}>
-              <AccountCircleIcon />
-            </Avatar>
-          </IconButton>
-          <Menu
-            id="user-menu"
-            anchorEl={anchorEl}
-            open={open}
-            onClose={handleUserMenuClose}
-            MenuListProps={{
-              'aria-labelledby': 'user-menu-button',
-            }}
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'right',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-          >
-            <MenuItem onClick={handleProfile}>Profile</MenuItem>
-            <MenuItem onClick={handleLogout}>Logout</MenuItem>
-          </Menu>
+          <UserMenu />
         </Box>
       </Toolbar>
     </AppBar>

--- a/platform/services/mcctl-console/src/middleware.ts
+++ b/platform/services/mcctl-console/src/middleware.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from './lib/auth';
+
+/**
+ * Routes that require authentication
+ */
+const protectedRoutes = ['/dashboard', '/servers', '/worlds', '/players', '/backups', '/settings'];
+
+/**
+ * Routes that require admin role
+ */
+const adminRoutes = ['/admin'];
+
+/**
+ * Public routes (accessible without authentication)
+ */
+const publicRoutes = ['/login', '/signup'];
+
+/**
+ * Middleware for route protection and authentication
+ */
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Get session
+  const session = await auth.api.getSession({
+    headers: request.headers,
+  });
+
+  // Check if the route is protected
+  const isProtectedRoute = protectedRoutes.some((route) => pathname.startsWith(route));
+  const isAdminRoute = adminRoutes.some((route) => pathname.startsWith(route));
+  const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route));
+
+  // Redirect to login if accessing protected route without authentication
+  if (isProtectedRoute && !session) {
+    const url = new URL('/login', request.url);
+    url.searchParams.set('from', pathname);
+    return NextResponse.redirect(url);
+  }
+
+  // Redirect to login if accessing admin route without authentication
+  if (isAdminRoute && !session) {
+    const url = new URL('/login', request.url);
+    url.searchParams.set('from', pathname);
+    return NextResponse.redirect(url);
+  }
+
+  // Redirect to dashboard if accessing admin route without admin role
+  if (isAdminRoute && session && session.user.role !== 'admin') {
+    const url = new URL('/dashboard', request.url);
+    return NextResponse.redirect(url);
+  }
+
+  // Redirect to dashboard if accessing login/signup while authenticated
+  if (isPublicRoute && session) {
+    const from = request.nextUrl.searchParams.get('from');
+    const url = new URL(from || '/dashboard', request.url);
+    return NextResponse.redirect(url);
+  }
+
+  // Allow access
+  return NextResponse.next();
+}
+
+/**
+ * Matcher configuration
+ * Apply middleware to all routes except static files and API routes
+ */
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+  ],
+};


### PR DESCRIPTION
## Summary
- Add login/signup forms with Better Auth integration
- Implement route protection middleware
- Add UserMenu component for header

## Changes

| File | Description |
|------|-------------|
| `src/components/auth/LoginForm.tsx` | Email/password login form with validation |
| `src/components/auth/SignUpForm.tsx` | Registration form with password confirmation |
| `src/components/auth/UserMenu.tsx` | User dropdown menu with logout |
| `src/app/login/page.tsx` | Centered login page |
| `src/app/signup/page.tsx` | Centered signup page |
| `src/app/dashboard/page.tsx` | Dashboard placeholder |
| `src/middleware.ts` | Route protection + admin check |

## Features
- Login with email/password
- Signup with name, email, password
- Protected routes redirect to /login
- Admin routes (/admin/*) require admin role
- Logout clears session
- Password visibility toggle
- Form validation with error messages
- Loading states during auth

## Test Criteria
- [x] Login with valid credentials redirects to dashboard
- [x] Invalid credentials show error message
- [x] Protected routes redirect to login
- [x] Admin routes redirect non-admin users
- [x] Logout clears session and redirects to login

Closes #181

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)