### PR TITLE
fix(scripts): prevent exit when avahi-daemon not installed (#197)

### DIFF
--- a/platform/scripts/create-server.sh
+++ b/platform/scripts/create-server.sh
@@ -491,7 +491,8 @@ fi
 # =============================================================================
 echo -e "${BLUE}[5/6]${NC} Registering mDNS hostname..."
 HOST_IP=$(get_host_ip)
-register_avahi_hostname "$SERVER_NAME.local" "$HOST_IP"
+# Note: || true prevents set -e from exiting if avahi is not available
+register_avahi_hostname "$SERVER_NAME.local" "$HOST_IP" || true
 
 # =============================================================================
 # Step 6: Start server (optional)

--- a/platform/services/cli/scripts/create-server.sh
+++ b/platform/services/cli/scripts/create-server.sh
@@ -491,7 +491,8 @@ fi
 # =============================================================================
 echo -e "${BLUE}[5/6]${NC} Registering mDNS hostname..."
 HOST_IP=$(get_host_ip)
-register_avahi_hostname "$SERVER_NAME.local" "$HOST_IP"
+# Note: || true prevents set -e from exiting if avahi is not available
+register_avahi_hostname "$SERVER_NAME.local" "$HOST_IP" || true
 
 # =============================================================================
 # Step 6: Start server (optional)


### PR DESCRIPTION
## Summary

Fix "Unknown error occurred" when running `mcctl create` on systems without avahi-daemon.

## Problem

The `create-server.sh` script uses `set -e` which causes the script to exit on any non-zero exit code. When `register_avahi_hostname()` returns 1 (because avahi-daemon is not installed), the entire script fails even though avahi registration is optional.

## Fix

Add `|| true` after the `register_avahi_hostname` call to allow the script to continue even if avahi registration fails.

## Test Plan

- [ ] Run `mcctl create test` on system without avahi-daemon
- [ ] Verify server is created successfully
- [ ] Verify step 6 (start server) executes

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)