### PR TITLE
fix(docker): mark minecraft-net as external network (#199)

### DIFF
--- a/platform/services/cli/templates/docker-compose.yml
+++ b/platform/services/cli/templates/docker-compose.yml
@@ -73,8 +73,5 @@ services:
 # -----------------------------------------------------------------------------
 networks:
   minecraft-net:
+    external: true
     name: ${MINECRAFT_NETWORK:-minecraft-net}
-    driver: bridge
-    ipam:
-      config:
-        - subnet: ${MINECRAFT_SUBNET:-172.28.0.0/16}

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -73,8 +73,5 @@ services:
 # -----------------------------------------------------------------------------
 networks:
   minecraft-net:
+    external: true
     name: ${MINECRAFT_NETWORK:-minecraft-net}
-    driver: bridge
-    ipam:
-      config:
-        - subnet: ${MINECRAFT_SUBNET:-172.28.0.0/16}


### PR DESCRIPTION
## Summary

Fix network warning when running `mcctl up`.

## Problem

```
WARN[0000] a network with name minecraft-net exists but was not created by compose.
Set `external: true` to use an existing network
```

## Fix

Mark `minecraft-net` as `external: true` in docker-compose.yml since it's created by init.sh.

Closes #199

🤖 Generated with [Claude Code](https://claude.ai/code)