### PR TITLE
fix(mcctl-console): resolve Edge runtime error in middleware (#201)

### DIFF
--- a/platform/services/mcctl-console/.env.example
+++ b/platform/services/mcctl-console/.env.example
@@ -4,8 +4,11 @@ MCCTL_API_URL=http://localhost:5001
 # API Key for authentication (generate with: openssl rand -base64 32)
 MCCTL_API_KEY=your-api-key-here
 
-# App base URL (Better Auth)
+# App base URL (for client-side)
 NEXT_PUBLIC_APP_URL=http://localhost:5000
+
+# Better Auth base URL (for server-side callbacks)
+BETTER_AUTH_URL=http://localhost:5000
 
 # Database path (SQLite)
 DATABASE_PATH=./data/mcctl-console.db

--- a/platform/services/mcctl-console/src/middleware.ts
+++ b/platform/services/mcctl-console/src/middleware.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from './lib/auth';
+
+/**
+ * Session cookie name used by Better Auth
+ * This matches the default cookie name from better-auth
+ */
+const SESSION_COOKIE_NAME = 'better-auth.session_token';
 
 /**
  * Routes that require authentication
@@ -8,6 +13,8 @@ const protectedRoutes = ['/dashboard', '/servers', '/worlds', '/players', '/back
 
 /**
  * Routes that require admin role
+ * Note: Admin role check is done in page/API level, not middleware
+ * Middleware only checks for session existence
  */
 const adminRoutes = ['/admin'];
 
@@ -17,43 +24,50 @@ const adminRoutes = ['/admin'];
 const publicRoutes = ['/login', '/signup'];
 
 /**
+ * Check if a session cookie exists
+ * Note: This only checks cookie existence, not validity
+ * Full session validation happens in pages/API routes with Node.js runtime
+ */
+function hasSessionCookie(request: NextRequest): boolean {
+  const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME);
+  return !!sessionCookie?.value;
+}
+
+/**
  * Middleware for route protection and authentication
+ *
+ * This middleware runs in Edge runtime and can only check for cookie existence.
+ * Full session validation (including role checks) must be done in pages/API routes
+ * which run in Node.js runtime and can access the database.
  */
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Get session
-  const session = await auth.api.getSession({
-    headers: request.headers,
-  });
+  // Check for session cookie (lightweight check, no database access)
+  const hasSession = hasSessionCookie(request);
 
   // Check if the route is protected
   const isProtectedRoute = protectedRoutes.some((route) => pathname.startsWith(route));
   const isAdminRoute = adminRoutes.some((route) => pathname.startsWith(route));
   const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route));
 
-  // Redirect to login if accessing protected route without authentication
-  if (isProtectedRoute && !session) {
+  // Redirect to login if accessing protected route without session cookie
+  if (isProtectedRoute && !hasSession) {
     const url = new URL('/login', request.url);
     url.searchParams.set('from', pathname);
     return NextResponse.redirect(url);
   }
 
-  // Redirect to login if accessing admin route without authentication
-  if (isAdminRoute && !session) {
+  // Redirect to login if accessing admin route without session cookie
+  // Note: Admin role validation happens in the admin page itself
+  if (isAdminRoute && !hasSession) {
     const url = new URL('/login', request.url);
     url.searchParams.set('from', pathname);
     return NextResponse.redirect(url);
   }
 
-  // Redirect to dashboard if accessing admin route without admin role
-  if (isAdminRoute && session && session.user.role !== 'admin') {
-    const url = new URL('/dashboard', request.url);
-    return NextResponse.redirect(url);
-  }
-
-  // Redirect to dashboard if accessing login/signup while authenticated
-  if (isPublicRoute && session) {
+  // Redirect to dashboard if accessing login/signup while having session cookie
+  if (isPublicRoute && hasSession) {
     const from = request.nextUrl.searchParams.get('from');
     const url = new URL(from || '/dashboard', request.url);
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary
- Replace database session validation with cookie-based check in middleware
- Middleware now only checks for session cookie existence
- Full session validation happens in pages/API routes (Node.js runtime)

## Problem
The middleware was importing `auth` which cascades to `better-sqlite3` - a native Node.js module incompatible with Edge runtime.

```
Error: The edge runtime does not support Node.js 'fs' module.
```

## Solution
Use lightweight cookie-based session checking instead of direct database access:
- Check for `better-auth.session_token` cookie existence
- Let pages/API routes handle actual session validation with database

## Changes
| File | Change |
|------|--------|
| `src/middleware.ts` | Cookie-based session check (72 modules vs 921) |
| `.env.example` | Added `BETTER_AUTH_URL` variable |

## Test Results
- ✅ `pnpm dev` starts without Edge runtime errors
- ✅ HTTP Status 200 on root path
- ✅ Middleware compiles cleanly

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)