### PR TITLE
chore: update e2e schedule and enforce mandatory dev practices (#208)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,14 +1,11 @@
 name: E2E Tests
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - main
-      - develop
+  # Scheduled: Daily at 3 AM KST (18:00 UTC)
+  schedule:
+    - cron: '0 18 * * *'
+  # Manual trigger (select branch in GitHub Actions UI)
+  workflow_dispatch:
 
 # Cancel in-progress runs on new commits to the same branch
 concurrency:
@@ -120,14 +117,82 @@ jobs:
           path: e2e/test-results/
           retention-days: 7
 
-      - name: Show PM2 logs on failure
+      - name: Collect error logs on failure
+        id: collect-logs
         if: failure()
         run: |
-          echo "=== PM2 Status ==="
-          pm2 status
-          echo ""
-          echo "=== mcctl-api logs ==="
-          pm2 logs mcctl-api --lines 100 --nostream || true
+          mkdir -p /tmp/e2e-error-logs
+
+          echo "=== PM2 Status ===" > /tmp/e2e-error-logs/pm2-status.txt
+          pm2 status >> /tmp/e2e-error-logs/pm2-status.txt 2>&1 || true
+
+          echo "=== mcctl-api logs ===" > /tmp/e2e-error-logs/mcctl-api.log
+          pm2 logs mcctl-api --lines 200 --nostream >> /tmp/e2e-error-logs/mcctl-api.log 2>&1 || true
+
+          # Copy Playwright test results if available
+          if [ -d "e2e/test-results" ]; then
+            cp -r e2e/test-results /tmp/e2e-error-logs/ || true
+          fi
+
+          # Count failed tests
+          FAILED_COUNT=$(find e2e/test-results -name "*.json" -exec cat {} \; 2>/dev/null | grep -c '"status":"failed"' || echo "0")
+          echo "failed_count=$FAILED_COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Create bug issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BRANCH: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          # Check if similar issue already exists (prevent duplicates)
+          EXISTING=$(gh issue list --label "bug,e2e-failure" --state open --limit 1 --json number -q '.[0].number' || echo "")
+
+          if [ -n "$EXISTING" ]; then
+            echo "Similar open issue #$EXISTING already exists, adding comment instead"
+            gh issue comment "$EXISTING" --body "Another E2E test failure occurred.
+
+**Run:** $RUN_URL
+**Branch:** $BRANCH
+**Commit:** $COMMIT_SHA
+**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+See the workflow run for details and artifacts."
+          else
+            gh issue create \
+              --title "bug(e2e): E2E test failure on scheduled run" \
+              --label "bug,e2e-failure" \
+              --body "## E2E Test Failure
+
+An automated E2E test run has failed.
+
+### Details
+
+| Field | Value |
+|-------|-------|
+| **Workflow Run** | $RUN_URL |
+| **Branch** | $BRANCH |
+| **Commit** | \`$COMMIT_SHA\` |
+| **Date** | $(date -u +%Y-%m-%dT%H:%M:%SZ) |
+
+### Artifacts
+
+Download the test artifacts from the workflow run:
+- \`playwright-report\` - Detailed HTML report
+- \`test-results\` - Raw test results
+
+### Next Steps
+
+1. Review the Playwright report artifact
+2. Check PM2 logs in the workflow run
+3. Reproduce locally if needed: \`cd e2e && pnpm test\`
+4. Fix the issue and close this ticket
+
+---
+*This issue was automatically created by the E2E test workflow.*"
+          fi
 
       - name: Stop PM2 services
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,13 +237,65 @@ For full CLI reference, see [docs/cli/commands.md](docs/cli/commands.md).
 
 ## Development Philosophy
 
+### Mandatory Development Practices
+
+> **IMPORTANT**: The following practices are **MANDATORY**, not optional. All code contributions MUST follow these principles.
+
+#### Required Practices (Non-Negotiable)
+
+| Practice | Description | Enforcement |
+|----------|-------------|-------------|
+| **TDD** | Test-Driven Development: Red → Green → Refactor | All new features MUST have tests written BEFORE implementation |
+| **Tidy First** | Never mix structural and behavioral changes | Separate commits for refactoring vs features |
+| **DDD** | Domain-Driven Design | Use domain entities, value objects, aggregates |
+| **Clean Architecture** | Dependency inversion, use cases, ports/adapters | Business logic independent of frameworks |
+| **Hexagonal Architecture** | Ports & Adapters pattern | All external dependencies behind interfaces |
+
+#### TDD is NOT Optional
+
+```
+❌ WRONG: Write code first, add tests later (or skip tests)
+✅ RIGHT: Write failing test → Write minimal code → Refactor
+```
+
+Every new command, feature, or bug fix MUST follow the TDD cycle:
+1. **Red**: Write a failing test that defines the expected behavior
+2. **Green**: Write the minimum code to make the test pass
+3. **Refactor**: Clean up while keeping tests green
+
+#### Architecture Enforcement
+
+All TypeScript code MUST follow this layered architecture:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Presentation Layer                    │
+│              (CLI commands, API routes)                  │
+├─────────────────────────────────────────────────────────┤
+│                    Application Layer                     │
+│           (Use cases, application services)              │
+├─────────────────────────────────────────────────────────┤
+│                      Domain Layer                        │
+│    (Entities, Value Objects, Domain Services, Ports)     │
+├─────────────────────────────────────────────────────────┤
+│                   Infrastructure Layer                   │
+│       (Adapters: DB, External APIs, File System)         │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Key Rules**:
+- Domain layer has NO external dependencies
+- Use cases orchestrate domain logic
+- All I/O operations go through adapters
+- Dependency injection for testability
+
 ### XP (Extreme Programming) Methodology
 
 This project follows **XP (Extreme Programming)** practices as the core development methodology.
 
 **Core Practices**:
-- **TDD (Test-Driven Development)**: Red → Green → Refactor cycle
-- **Tidy First**: Never mix structural and behavioral changes
+- **TDD (Test-Driven Development)**: Red → Green → Refactor cycle **(MANDATORY)**
+- **Tidy First**: Never mix structural and behavioral changes **(MANDATORY)**
 - **Pair Programming**: For complex features and architecture decisions
 - **Continuous Integration**: All PRs must pass lint, type-check, test, build
 - **Small Releases**: Frequent, incremental deployments
@@ -269,7 +321,7 @@ All features are implemented via CLI first, with Web Management UI available.
 
 ### CLI Architecture
 
-The CLI uses **Hexagonal Architecture** (Ports & Adapters) with **Clean Architecture** principles.
+The CLI uses **Hexagonal Architecture** (Ports & Adapters) with **Clean Architecture** principles. This is **MANDATORY** for all CLI code.
 
 See [docs/development/cli-architecture.md](docs/development/cli-architecture.md) for details.
 
@@ -311,14 +363,32 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
 Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 
-#### TDD (Test-Driven Development)
+#### TDD (Test-Driven Development) - MANDATORY
+
+> **This is NOT optional.** Every feature, bug fix, or enhancement MUST follow TDD.
 
 Follow the **Red → Green → Refactor** cycle:
 1. **Red**: Write a failing test first
 2. **Green**: Write minimal code to make the test pass
 3. **Refactor**: Clean up while keeping tests green
 
-#### Tidy First
+**PRs without tests will be rejected** unless:
+- Documentation-only changes
+- Configuration changes with no code logic
+
+```bash
+# Example TDD workflow for a new command
+# 1. RED: Write failing test
+pnpm test -- --watch src/commands/newcmd.test.ts
+
+# 2. GREEN: Implement minimal code
+# 3. REFACTOR: Clean up, then commit
+git commit -m "feat(cli): add newcmd command (#123)"
+```
+
+#### Tidy First - MANDATORY
+
+> **This is NOT optional.** Structural and behavioral changes MUST be in separate commits.
 
 **Never mix structural and behavioral changes in the same commit.**
 
@@ -330,6 +400,11 @@ git commit -m "feat: add world existence check (#7)"
 # Bad: Mixed in one commit - AVOID
 git commit -m "feat: add validation with new helper function"
 ```
+
+**Why this matters**:
+- Easier code review (reviewers can focus on one type of change)
+- Safer rollbacks (can revert behavior without losing refactoring)
+- Cleaner git history
 
 #### Task Checkpoint (task.md)
 


### PR DESCRIPTION
## Summary

Two related improvements to development workflow and standards.

## Changes

### 1. E2E Test Workflow

| Item | Before | After |
|------|--------|-------|
| **Trigger** | push/PR to main/develop | Daily 3 AM KST (`cron: '0 18 * * *'`) |
| **Manual** | Not available | `workflow_dispatch` added |
| **On Failure** | Log only | Auto-create GitHub issue |

**Auto Bug Issue Features:**
- Creates issue with `bug`, `e2e-failure` labels
- Includes workflow run link, branch, commit info
- Prevents duplicates: adds comment to existing open issue instead

### 2. CLAUDE.md - Mandatory Development Practices

**NEW: Mandatory Practices Section**

| Practice | Status |
|----------|--------|
| TDD | **MANDATORY** |
| Tidy First | **MANDATORY** |
| DDD | **MANDATORY** |
| Clean Architecture | **MANDATORY** |
| Hexagonal Architecture | **MANDATORY** |

**Key Additions:**
- Architecture layer diagram
- "PRs without tests will be rejected" statement
- TDD workflow example with `pnpm test -- --watch`
- Explanation of why Tidy First matters

## Test Plan

- [ ] Verify workflow syntax is valid
- [ ] Manual trigger works via GitHub Actions UI
- [ ] CLAUDE.md renders correctly

Closes #208

---
🤖 Generated with [Claude Code](https://claude.ai/code)