### PR TITLE
feat(cli): improve RCON output formatting with colors (#206)

### DIFF
--- a/platform/services/cli/package.json
+++ b/platform/services/cli/package.json
@@ -61,6 +61,7 @@
     "js-yaml": "^4.1.0",
     "picocolors": "^1.1.0",
     "pm2": "^6.0.14",
+    "rcon-client": "^4.2.5",
     "tar": "^7.5.4"
   },
   "devDependencies": {

--- a/platform/services/cli/src/commands/rcon.ts
+++ b/platform/services/cli/src/commands/rcon.ts
@@ -1,10 +1,124 @@
 import { spawn } from 'node:child_process';
+import * as readline from 'node:readline';
+import { Rcon } from 'rcon-client';
 import { Paths, log } from '@minecraft-docker/shared';
 import { getContainerName, isContainerRunning } from '../lib/rcon.js';
 
 export interface RconCommandOptions {
   serverName?: string;
   root?: string;
+}
+
+interface ContainerRconConfig {
+  host: string;
+  port: number;
+  password: string;
+}
+
+/**
+ * Get RCON configuration from Docker container
+ */
+async function getContainerRconConfig(containerName: string): Promise<ContainerRconConfig | null> {
+  return new Promise((resolve) => {
+    // Get container IP
+    const ipProcess = spawn('docker', [
+      'inspect', containerName,
+      '--format', '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
+    ], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    let ip = '';
+    ipProcess.stdout.on('data', (data) => { ip += data.toString(); });
+
+    ipProcess.on('close', (code) => {
+      if (code !== 0 || !ip.trim()) {
+        resolve(null);
+        return;
+      }
+
+      // Get RCON env vars
+      const envProcess = spawn('docker', [
+        'inspect', containerName,
+        '--format', '{{range .Config.Env}}{{println .}}{{end}}'
+      ], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+      let envOutput = '';
+      envProcess.stdout.on('data', (data) => { envOutput += data.toString(); });
+
+      envProcess.on('close', (envCode) => {
+        if (envCode !== 0) {
+          resolve(null);
+          return;
+        }
+
+        const env: Record<string, string> = {};
+        envOutput.split('\n').forEach(line => {
+          const [key, ...valueParts] = line.split('=');
+          if (key) env[key] = valueParts.join('=');
+        });
+
+        resolve({
+          host: ip.trim(),
+          port: parseInt(env['RCON_PORT'] || '25575', 10),
+          password: env['RCON_PASSWORD'] || '',
+        });
+      });
+    });
+  });
+}
+
+// ANSI color codes
+const colors = {
+  cyan: '\x1b[36m',
+  yellow: '\x1b[33m',
+  green: '\x1b[32m',
+  reset: '\x1b[0m',
+};
+
+/**
+ * Format RCON response for better readability
+ * - Adds newline before each `/command` pattern (help output)
+ * - Removes leading `/` from commands (RCON doesn't need it)
+ * - Highlights command names in color
+ * - Formats error messages with proper line breaks
+ */
+function formatRconResponse(response: string): string {
+  let formatted = response;
+
+  // Handle error messages: "See below for error<command>" -> "See below for error\n<command>"
+  if (formatted.includes('See below for error')) {
+    formatted = formatted.replace(/See below for error/g, 'See below for error\n');
+  }
+
+  // Handle help command output: add newline before each `/command`
+  // Example: "/advancement (grant|revoke)/attribute <target>..."
+  if (formatted.match(/\/[a-z]/)) {
+    // Add newline before every `/command` pattern
+    formatted = formatted.replace(/\/([a-z])/g, '\n$1');
+
+    // Remove the first newline if the response starts with it
+    if (formatted.startsWith('\n')) {
+      formatted = formatted.substring(1);
+    }
+
+    // Highlight command names at the start of each line
+    // Pattern: start of line, command name, then space or special chars
+    formatted = formatted.replace(/^([a-z]+)(\s|$|\(|<|\[)/gm,
+      `${colors.cyan}$1${colors.reset}$2`);
+
+    // Highlight alias references like "-> msg" or "-> experience"
+    formatted = formatted.replace(/-> ([a-z]+)/g,
+      `-> ${colors.yellow}$1${colors.reset}`);
+
+    // Highlight keywords inside parentheses (get|base|modifier) -> green
+    formatted = formatted.replace(/\(([^)]+)\)/g, (match, inner) => {
+      // Color each word inside parentheses
+      const coloredInner = inner.replace(/([a-z_]+)/gi,
+        `${colors.green}$1${colors.reset}`);
+      return `(${coloredInner})`;
+    });
+  }
+
+  return formatted;
 }
 
 /**
@@ -42,23 +156,84 @@ export async function rconCommand(options: RconCommandOptions): Promise<number> 
     return 1;
   }
 
+  // Get RCON config from container
+  const rconConfig = await getContainerRconConfig(containerName);
+  if (!rconConfig) {
+    log.error('Failed to get RCON configuration from container');
+    return 1;
+  }
+
+  if (!rconConfig.password) {
+    log.error('RCON_PASSWORD not set in container');
+    return 1;
+  }
+
   log.info(`Connecting to RCON console for '${options.serverName}'...`);
-  log.info('Type "help" for commands, Ctrl+C or "exit" to quit');
-  console.log(''); // Empty line before RCON prompt
+
+  let rcon: Rcon;
+  try {
+    rcon = await Rcon.connect({
+      host: rconConfig.host,
+      port: rconConfig.port,
+      password: rconConfig.password,
+    });
+  } catch (err) {
+    log.error(`Failed to connect to RCON: ${(err as Error).message}`);
+    log.info('Make sure the server is fully started and RCON is enabled.');
+    return 1;
+  }
+
+  log.info('Connected! Type "help" for commands, "exit" or Ctrl+C to quit.');
+  console.log('');
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: '> ',
+  });
+
+  rl.prompt();
 
   return new Promise((resolve) => {
-    const child = spawn('docker', ['exec', '-it', containerName, 'rcon-cli'], {
-      stdio: 'inherit',
+    rl.on('line', async (line) => {
+      const cmd = line.trim();
+
+      if (cmd === 'exit' || cmd === 'quit') {
+        rl.close();
+        return;
+      }
+
+      if (!cmd) {
+        rl.prompt();
+        return;
+      }
+
+      try {
+        const response = await rcon.send(cmd);
+        if (response) {
+          console.log(formatRconResponse(response));
+        }
+      } catch (err) {
+        log.error(`Command failed: ${(err as Error).message}`);
+      }
+
+      rl.prompt();
     });
 
-    child.on('close', (code) => {
-      // Exit code 130 = Ctrl+C, treat as normal exit
-      resolve(code === 130 ? 0 : (code ?? 0));
+    rl.on('close', async () => {
+      console.log('');
+      log.info('Disconnecting from RCON...');
+      try {
+        await rcon.end();
+      } catch {
+        // Ignore disconnect errors
+      }
+      resolve(0);
     });
 
-    child.on('error', (err) => {
-      log.error(`Failed to connect to RCON: ${err.message}`);
-      resolve(1);
+    // Handle Ctrl+C
+    rl.on('SIGINT', () => {
+      rl.close();
     });
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       pm2:
         specifier: ^6.0.14
         version: 6.0.14
+      rcon-client:
+        specifier: ^4.2.5
+        version: 4.2.5
       tar:
         specifier: ^7.5.4
         version: 7.5.4
@@ -3752,6 +3755,9 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  rcon-client@4.2.5:
+    resolution: {integrity: sha512-AnX1GU/ZTlwtYup3H6h0J1hwfP3OYltXVe+8ReBzmNEepX3xGH8nDg7gYqT5Y9rpAS/LmQ48h0BKINt1YGd8bA==}
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -4279,6 +4285,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typed-emitter@0.1.0:
+    resolution: {integrity: sha512-Tfay0l6gJMP5rkil8CzGbLthukn+9BN/VXWcABVFPjOoelJ+koW8BuPZYk+h/L+lEeIp1fSzVRiWRPIjKVjPdg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -7952,6 +7961,10 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  rcon-client@4.2.5:
+    dependencies:
+      typed-emitter: 0.1.0
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -8568,6 +8581,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typed-emitter@0.1.0: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary

- RCON 출력 포맷팅 개선으로 가독성 향상
- `docker exec` 대신 `rcon-client` 라이브러리 사용
- 컬러 하이라이팅 추가

## Changes

### 1. rcon-client 라이브러리 도입
- 직접 RCON 프로토콜 연결로 출력 제어 가능
- `formatRconResponse()` 함수로 응답 포맷팅

### 2. 줄바꿈 처리
- `help` 명령어 출력: 각 명령어를 개별 줄로 분리
- 에러 메시지: `See below for error` 다음 줄바꿈
- `/` 제거: RCON에서는 `/` 없이 입력하므로

### 3. 컬러 하이라이팅

| 색상 | 적용 대상 | 예시 |
|------|----------|------|
| **청록색(Cyan)** | 명령어 이름 | `advancement`, `tell`, `give` |
| **녹색(Green)** | 괄호 안 키워드 | `(grant\|revoke)`, `(get\|base\|modifier)` |
| **노란색(Yellow)** | 별칭 참조 | `-> msg`, `-> experience` |

## Before & After

**Before:**
```
/advancement (grant|revoke)/attribute <target> <attribute> (get|base|modifier)/bossbar...
```

**After:**
```
advancement (grant|revoke)
attribute <target> <attribute> (get|base|modifier)
bossbar (add|remove|list|set|get)
...
tell -> msg
```

## Test plan

- [ ] `mcctl rcon <server>` 연결 테스트
- [ ] `help` 명령어 포맷팅 확인
- [ ] 에러 메시지 포맷팅 확인
- [ ] 컬러 표시 확인

## Related Issue

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)