### PR TITLE
feat(console): improve dashboard layout and spacing (#213)

### DIFF
--- a/platform/services/mcctl-console/src/app/dashboard/page.tsx
+++ b/platform/services/mcctl-console/src/app/dashboard/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Box, Grid, Typography, CircularProgress } from '@mui/material';
+import { Box, Grid, Typography, CircularProgress, Paper, alpha } from '@mui/material';
 import {
   Storage as ServerIcon,
   CheckCircle as OnlineIcon,
   People as PlayersIcon,
   Public as WorldIcon,
+  Dashboard as DashboardIcon,
 } from '@mui/icons-material';
 import { useServers, useWorlds } from '@/hooks/useMcctl';
 import { StatCard, ServerOverview, ActivityFeed } from '@/components/dashboard';
@@ -39,14 +40,42 @@ export default function DashboardPage() {
   return (
     <Box>
       {/* Page Header */}
-      <Box sx={{ mb: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Dashboard
-        </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Overview of your Minecraft server infrastructure
-        </Typography>
-      </Box>
+      <Paper
+        elevation={0}
+        sx={{
+          mb: 4,
+          p: 3,
+          background: (theme) =>
+            `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.secondary.main, 0.1)} 100%)`,
+          borderRadius: 2,
+          border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 56,
+              height: 56,
+              borderRadius: 2,
+              bgcolor: 'primary.main',
+              color: 'primary.contrastText',
+            }}
+          >
+            <DashboardIcon sx={{ fontSize: 32 }} />
+          </Box>
+          <Box>
+            <Typography variant="h4" component="h1" fontWeight="bold">
+              Dashboard
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Overview of your Minecraft server infrastructure
+            </Typography>
+          </Box>
+        </Box>
+      </Paper>
 
       {/* Statistics Cards */}
       <Grid container spacing={3} sx={{ mb: 4 }}>

--- a/platform/services/mcctl-console/src/app/servers/[name]/page.tsx
+++ b/platform/services/mcctl-console/src/app/servers/[name]/page.tsx
@@ -9,10 +9,13 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import { alpha } from '@mui/material/styles';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import DnsIcon from '@mui/icons-material/Dns';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { ServerDetail } from '@/components/servers/ServerDetail';
 import {
@@ -83,22 +86,47 @@ export default function ServerDetailPage() {
         </Typography>
       </Breadcrumbs>
 
-      {/* Header with actions */}
-      <Box
+      {/* Page Header */}
+      <Paper
+        elevation={0}
         sx={{
+          mb: 4,
+          p: 3,
+          background: (theme) =>
+            `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.success.main, 0.1)} 100%)`,
+          borderRadius: 2,
+          border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.2)}`,
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          mb: 3,
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <IconButton onClick={() => router.push('/servers')}>
+          <IconButton onClick={() => router.push('/servers')} sx={{ mr: 1 }}>
             <ArrowBackIcon />
           </IconButton>
-          <Typography variant="h5" component="h1">
-            {serverName}
-          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 56,
+              height: 56,
+              borderRadius: 2,
+              bgcolor: 'primary.main',
+              color: 'primary.contrastText',
+            }}
+          >
+            <DnsIcon sx={{ fontSize: 32 }} />
+          </Box>
+          <Box>
+            <Typography variant="h4" component="h1" fontWeight="bold">
+              {serverName}
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Server configuration and management
+            </Typography>
+          </Box>
         </Box>
 
         <Box sx={{ display: 'flex', gap: 1 }}>
@@ -109,6 +137,7 @@ export default function ServerDetailPage() {
               startIcon={<PlayArrowIcon />}
               onClick={handleStartServer}
               disabled={isActionPending}
+              size="large"
             >
               Start
             </Button>
@@ -120,6 +149,7 @@ export default function ServerDetailPage() {
                 startIcon={<RestartAltIcon />}
                 onClick={handleRestartServer}
                 disabled={isActionPending}
+                size="large"
               >
                 Restart
               </Button>
@@ -129,13 +159,14 @@ export default function ServerDetailPage() {
                 startIcon={<StopIcon />}
                 onClick={handleStopServer}
                 disabled={isActionPending}
+                size="large"
               >
                 Stop
               </Button>
             </>
           )}
         </Box>
-      </Box>
+      </Paper>
 
       {/* Error messages */}
       {error && (

--- a/platform/services/mcctl-console/src/app/servers/page.tsx
+++ b/platform/services/mcctl-console/src/app/servers/page.tsx
@@ -6,7 +6,11 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
+import StorageIcon from '@mui/icons-material/Storage';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { ServerList } from '@/components/servers/ServerList';
 import { CreateServerDialog } from '@/components/servers/CreateServerDialog';
@@ -68,16 +72,54 @@ export default function ServersPage() {
 
   return (
     <MainLayout title="Servers">
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Box />
+      {/* Page Header */}
+      <Paper
+        elevation={0}
+        sx={{
+          mb: 4,
+          p: 3,
+          background: (theme) =>
+            `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.info.main, 0.1)} 100%)`,
+          borderRadius: 2,
+          border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 56,
+              height: 56,
+              borderRadius: 2,
+              bgcolor: 'primary.main',
+              color: 'primary.contrastText',
+            }}
+          >
+            <StorageIcon sx={{ fontSize: 32 }} />
+          </Box>
+          <Box>
+            <Typography variant="h4" component="h1" fontWeight="bold">
+              Servers
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Manage your Minecraft servers
+            </Typography>
+          </Box>
+        </Box>
         <Button
           variant="contained"
           startIcon={<AddIcon />}
           onClick={() => setCreateDialogOpen(true)}
+          size="large"
         >
           Create Server
         </Button>
-      </Box>
+      </Paper>
 
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/platform/services/mcctl-console/src/components/layout/MainLayout.tsx
+++ b/platform/services/mcctl-console/src/components/layout/MainLayout.tsx
@@ -47,9 +47,13 @@ export function MainLayout({ children, title = 'Dashboard' }: MainLayoutProps) {
           component="main"
           sx={{
             flexGrow: 1,
-            p: { xs: 2, sm: 3 },
+            px: { xs: 2, sm: 3, md: 4 },
+            py: { xs: 2, sm: 3, md: 4 },
             mt: '64px', // AppBar height
             backgroundColor: 'background.default',
+            maxWidth: '1600px',
+            mx: 'auto',
+            width: '100%',
           }}
         >
           {children}


### PR DESCRIPTION
## Summary
- Add responsive padding to MainLayout content area (xs: 2, sm: 3, md: 4)
- Set maxWidth: 1600px for content area with auto margins
- Enhance page headers with gradient Paper, icon boxes, and bold typography
- Apply consistent header styling across dashboard, servers list, and server detail pages

## Changes
- `MainLayout.tsx`: Add responsive padding and max-width constraints
- `dashboard/page.tsx`: Enhance header with gradient Paper and icon
- `servers/page.tsx`: Apply consistent header styling with icon
- `servers/[name]/page.tsx`: Apply consistent header styling with icon

Closes #213

## Test plan
- [ ] Verify dashboard page displays with proper margins and header styling
- [ ] Verify servers list page has consistent header design
- [ ] Verify server detail page has consistent header design
- [ ] Verify responsive layout works on mobile/tablet/desktop
- [ ] Verify no lint or type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)