### PR TITLE
feat(console): implement world management UI (#175)

### DIFF
--- a/platform/services/mcctl-console/src/app/(main)/worlds/page.test.tsx
+++ b/platform/services/mcctl-console/src/app/(main)/worlds/page.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import WorldsPage from './page';
+
+// Mock Next.js navigation
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+// Mock the hooks
+vi.mock('@/hooks/useMcctl', () => ({
+  useWorlds: vi.fn(),
+  useServers: vi.fn(),
+  useCreateWorld: vi.fn(),
+  useAssignWorld: vi.fn(),
+  useReleaseWorld: vi.fn(),
+  useDeleteWorld: vi.fn(),
+}));
+
+import {
+  useWorlds,
+  useServers,
+  useCreateWorld,
+  useAssignWorld,
+  useReleaseWorld,
+  useDeleteWorld,
+} from '@/hooks/useMcctl';
+
+const createTestQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+};
+
+const renderWithProviders = (component: React.ReactNode) => {
+  const queryClient = createTestQueryClient();
+  return render(
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        {component}
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+};
+
+const mockMutation = (overrides = {}) => ({
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+  isPending: false,
+  isError: false,
+  error: null,
+  reset: vi.fn(),
+  ...overrides,
+});
+
+const mockWorlds = [
+  {
+    name: 'survival-world',
+    path: '/worlds/survival-world',
+    isLocked: false,
+    size: '256 MB',
+    lastModified: '2025-01-15T10:30:00Z',
+  },
+  {
+    name: 'creative-world',
+    path: '/worlds/creative-world',
+    isLocked: true,
+    lockedBy: 'paper-server',
+    size: '512 MB',
+    lastModified: '2025-01-20T14:00:00Z',
+  },
+];
+
+const setupMocks = (overrides: { worldsLoading?: boolean; worldsError?: Error } = {}) => {
+  vi.mocked(useWorlds).mockReturnValue({
+    data: overrides.worldsLoading
+      ? undefined
+      : { worlds: mockWorlds, total: mockWorlds.length },
+    isLoading: overrides.worldsLoading ?? false,
+    error: overrides.worldsError ?? null,
+  } as any);
+
+  vi.mocked(useServers).mockReturnValue({
+    data: {
+      servers: [
+        { name: 'paper-server', status: 'stopped', health: 'none', container: 'mc-paper', hostname: 'paper.local' },
+      ],
+      total: 1,
+    },
+    isLoading: false,
+    error: null,
+  } as any);
+
+  vi.mocked(useCreateWorld).mockReturnValue(mockMutation() as any);
+  vi.mocked(useAssignWorld).mockReturnValue(mockMutation() as any);
+  vi.mocked(useReleaseWorld).mockReturnValue(mockMutation() as any);
+  vi.mocked(useDeleteWorld).mockReturnValue(mockMutation() as any);
+};
+
+describe('WorldsPage', () => {
+  it('should render page header with title', () => {
+    setupMocks();
+    renderWithProviders(<WorldsPage />);
+
+    expect(screen.getByText('Worlds')).toBeInTheDocument();
+    expect(screen.getByText('Manage your Minecraft worlds')).toBeInTheDocument();
+  });
+
+  it('should render Create World button', () => {
+    setupMocks();
+    renderWithProviders(<WorldsPage />);
+
+    expect(screen.getByRole('button', { name: /create world/i })).toBeInTheDocument();
+  });
+
+  it('should render loading state', () => {
+    setupMocks({ worldsLoading: true });
+    renderWithProviders(<WorldsPage />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('should render error state', () => {
+    setupMocks({ worldsError: new Error('Network error') });
+    renderWithProviders(<WorldsPage />);
+
+    expect(screen.getByText(/failed to load worlds/i)).toBeInTheDocument();
+  });
+
+  it('should render world list when data is loaded', () => {
+    setupMocks();
+    renderWithProviders(<WorldsPage />);
+
+    expect(screen.getByText('survival-world')).toBeInTheDocument();
+    expect(screen.getByText('creative-world')).toBeInTheDocument();
+  });
+
+  it('should open create dialog when Create World button is clicked', () => {
+    setupMocks();
+    renderWithProviders(<WorldsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create world/i }));
+
+    expect(screen.getByText('Create New World')).toBeInTheDocument();
+  });
+
+  it('should open delete confirmation when delete is clicked', () => {
+    setupMocks();
+    renderWithProviders(<WorldsPage />);
+
+    const deleteButtons = screen.getAllByLabelText('Delete world');
+    fireEvent.click(deleteButtons[0]);
+
+    expect(screen.getByText('Delete World')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /world name/i })).toBeInTheDocument();
+  });
+
+  it('should disable delete button until world name is typed correctly', () => {
+    setupMocks();
+    renderWithProviders(<WorldsPage />);
+
+    const deleteButtons = screen.getAllByLabelText('Delete world');
+    fireEvent.click(deleteButtons[0]);
+
+    const deleteConfirmBtn = screen.getByRole('button', { name: /^delete$/i });
+    expect(deleteConfirmBtn).toBeDisabled();
+
+    const input = screen.getByLabelText('World name');
+    fireEvent.change(input, { target: { value: 'survival-world' } });
+
+    expect(deleteConfirmBtn).not.toBeDisabled();
+  });
+});

--- a/platform/services/mcctl-console/src/app/(main)/worlds/page.tsx
+++ b/platform/services/mcctl-console/src/app/(main)/worlds/page.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import { alpha } from '@mui/material/styles';
+import AddIcon from '@mui/icons-material/Add';
+import PublicIcon from '@mui/icons-material/Public';
+import { WorldList } from '@/components/worlds/WorldList';
+import { CreateWorldDialog } from '@/components/worlds/CreateWorldDialog';
+import { AssignWorldDialog } from '@/components/worlds/AssignWorldDialog';
+import {
+  useWorlds,
+  useCreateWorld,
+  useAssignWorld,
+  useReleaseWorld,
+  useDeleteWorld,
+} from '@/hooks/useMcctl';
+import type { CreateWorldRequest } from '@/ports/api/IMcctlApiClient';
+
+export default function WorldsPage() {
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [assignDialogWorld, setAssignDialogWorld] = useState<string | null>(null);
+  const [deleteConfirmWorld, setDeleteConfirmWorld] = useState<string | null>(null);
+  const [deleteConfirmInput, setDeleteConfirmInput] = useState('');
+  const [loadingWorlds, setLoadingWorlds] = useState<string[]>([]);
+
+  // Data fetching
+  const { data, isLoading, error } = useWorlds();
+
+  // Mutations
+  const createWorld = useCreateWorld();
+  const assignWorld = useAssignWorld();
+  const releaseWorld = useReleaseWorld();
+  const deleteWorld = useDeleteWorld();
+
+  const handleCreateWorld = (request: CreateWorldRequest) => {
+    createWorld.mutate(request, {
+      onSuccess: () => {
+        setCreateDialogOpen(false);
+      },
+    });
+  };
+
+  const handleAssignWorld = (worldName: string, serverName: string) => {
+    setLoadingWorlds((prev) => [...prev, worldName]);
+    assignWorld.mutate(
+      { worldName, serverName },
+      {
+        onSuccess: () => {
+          setAssignDialogWorld(null);
+        },
+        onSettled: () => {
+          setLoadingWorlds((prev) => prev.filter((n) => n !== worldName));
+        },
+      }
+    );
+  };
+
+  const handleReleaseWorld = async (worldName: string) => {
+    setLoadingWorlds((prev) => [...prev, worldName]);
+    try {
+      await releaseWorld.mutateAsync({ worldName });
+    } catch (err) {
+      console.error('Failed to release world:', err);
+    } finally {
+      setLoadingWorlds((prev) => prev.filter((n) => n !== worldName));
+    }
+  };
+
+  const handleDeleteWorld = () => {
+    if (!deleteConfirmWorld || deleteConfirmInput !== deleteConfirmWorld) return;
+
+    setLoadingWorlds((prev) => [...prev, deleteConfirmWorld]);
+    deleteWorld.mutate(
+      { name: deleteConfirmWorld, force: true },
+      {
+        onSuccess: () => {
+          setDeleteConfirmWorld(null);
+          setDeleteConfirmInput('');
+        },
+        onSettled: () => {
+          setLoadingWorlds((prev) =>
+            prev.filter((n) => n !== deleteConfirmWorld)
+          );
+        },
+      }
+    );
+  };
+
+  const handleDeleteClick = (worldName: string) => {
+    setDeleteConfirmWorld(worldName);
+    setDeleteConfirmInput('');
+  };
+
+  return (
+    <>
+      {/* Page Header */}
+      <Paper
+        elevation={0}
+        sx={{
+          mb: 4,
+          p: 3,
+          background: (theme) =>
+            `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.info.main, 0.1)} 100%)`,
+          borderRadius: 2,
+          border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 56,
+              height: 56,
+              borderRadius: 2,
+              bgcolor: 'primary.main',
+              color: 'primary.contrastText',
+            }}
+          >
+            <PublicIcon sx={{ fontSize: 32 }} />
+          </Box>
+          <Box>
+            <Typography variant="h4" component="h1" fontWeight="bold">
+              Worlds
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Manage your Minecraft worlds
+            </Typography>
+          </Box>
+        </Box>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setCreateDialogOpen(true)}
+          size="large"
+        >
+          Create World
+        </Button>
+      </Paper>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Failed to load worlds: {error.message}
+        </Alert>
+      )}
+
+      {createWorld.isError && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Failed to create world: {createWorld.error?.message}
+        </Alert>
+      )}
+
+      {assignWorld.isError && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Failed to assign world: {assignWorld.error?.message}
+        </Alert>
+      )}
+
+      {releaseWorld.isError && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Failed to release world: {releaseWorld.error?.message}
+        </Alert>
+      )}
+
+      {deleteWorld.isError && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Failed to delete world: {deleteWorld.error?.message}
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <WorldList
+          worlds={data?.worlds || []}
+          onAssign={(worldName) => setAssignDialogWorld(worldName)}
+          onRelease={handleReleaseWorld}
+          onDelete={handleDeleteClick}
+          onCreate={() => setCreateDialogOpen(true)}
+          loadingWorlds={loadingWorlds}
+        />
+      )}
+
+      <CreateWorldDialog
+        open={createDialogOpen}
+        onClose={() => {
+          setCreateDialogOpen(false);
+          createWorld.reset();
+        }}
+        onSubmit={handleCreateWorld}
+        loading={createWorld.isPending}
+      />
+
+      <AssignWorldDialog
+        open={!!assignDialogWorld}
+        worldName={assignDialogWorld || ''}
+        onClose={() => setAssignDialogWorld(null)}
+        onSubmit={handleAssignWorld}
+        loading={assignWorld.isPending}
+      />
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={!!deleteConfirmWorld}
+        onClose={() => {
+          setDeleteConfirmWorld(null);
+          setDeleteConfirmInput('');
+        }}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Delete World</DialogTitle>
+        <DialogContent>
+          <Typography sx={{ mb: 2 }}>
+            This action cannot be undone. Type <strong>{deleteConfirmWorld}</strong> to confirm deletion.
+          </Typography>
+          <TextField
+            label="World name"
+            value={deleteConfirmInput}
+            onChange={(e) => setDeleteConfirmInput(e.target.value)}
+            fullWidth
+            autoFocus
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            onClick={() => {
+              setDeleteConfirmWorld(null);
+              setDeleteConfirmInput('');
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleDeleteWorld}
+            disabled={
+              deleteConfirmInput !== deleteConfirmWorld ||
+              deleteWorld.isPending
+            }
+            startIcon={
+              deleteWorld.isPending ? <CircularProgress size={16} /> : null
+            }
+          >
+            {deleteWorld.isPending ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/platform/services/mcctl-console/src/components/layout/GNB.tsx
+++ b/platform/services/mcctl-console/src/components/layout/GNB.tsx
@@ -20,6 +20,7 @@ import DnsIcon from '@mui/icons-material/Dns';
 import PeopleIcon from '@mui/icons-material/People';
 import SettingsIcon from '@mui/icons-material/Settings';
 import HistoryIcon from '@mui/icons-material/History';
+import PublicIcon from '@mui/icons-material/Public';
 import { UserMenu } from '@/components/auth';
 import { CreeperIcon } from '@/components/icons/CreeperIcon';
 import { startLoading } from '@/components/providers';
@@ -35,6 +36,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { label: 'Dashboard', href: '/dashboard', icon: <DashboardIcon /> },
   { label: 'Servers', href: '/servers', icon: <DnsIcon /> },
+  { label: 'Worlds', href: '/worlds', icon: <PublicIcon /> },
   { label: 'Players', href: '/players', icon: <PeopleIcon /> },
   { label: 'Audit Log', href: '/audit-logs', icon: <HistoryIcon /> },
   { label: 'Settings', href: '/settings', icon: <SettingsIcon /> },

--- a/platform/services/mcctl-console/src/components/worlds/AssignWorldDialog.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/AssignWorldDialog.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import { useServers } from '@/hooks/useMcctl';
+
+interface AssignWorldDialogProps {
+  open: boolean;
+  worldName: string;
+  onClose: () => void;
+  onSubmit: (worldName: string, serverName: string) => void;
+  loading?: boolean;
+}
+
+export function AssignWorldDialog({
+  open,
+  worldName,
+  onClose,
+  onSubmit,
+  loading = false,
+}: AssignWorldDialogProps) {
+  const [selectedServer, setSelectedServer] = useState('');
+  const { data: serversData, isLoading: serversLoading } = useServers();
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedServer('');
+    }
+  }, [open]);
+
+  const servers = serversData?.servers || [];
+  const stoppedServers = servers.filter(
+    (s) => s.status === 'stopped' || s.status === 'exited'
+  );
+  const runningServers = servers.filter((s) => s.status === 'running');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedServer) return;
+    onSubmit(worldName, selectedServer);
+  };
+
+  return (
+    <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="sm" fullWidth>
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>
+          Assign World: {worldName}
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            {serversLoading ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <CircularProgress />
+              </Box>
+            ) : servers.length === 0 ? (
+              <Typography color="text.secondary">
+                No servers available. Create a server first.
+              </Typography>
+            ) : (
+              <>
+                {stoppedServers.length === 0 && runningServers.length > 0 && (
+                  <Alert severity="warning">
+                    All servers are currently running. It is recommended to assign worlds to stopped servers.
+                  </Alert>
+                )}
+
+                <TextField
+                  label="Select Server"
+                  select
+                  value={selectedServer}
+                  onChange={(e) => setSelectedServer(e.target.value)}
+                  fullWidth
+                  disabled={loading}
+                  helperText="Select a server to assign this world to"
+                >
+                  {stoppedServers.length > 0 && (
+                    <MenuItem disabled>
+                      <Typography variant="caption" color="text.secondary">
+                        Stopped Servers
+                      </Typography>
+                    </MenuItem>
+                  )}
+                  {stoppedServers.map((server) => (
+                    <MenuItem key={server.name} value={server.name}>
+                      {server.name}
+                    </MenuItem>
+                  ))}
+                  {runningServers.length > 0 && (
+                    <MenuItem disabled>
+                      <Typography variant="caption" color="text.secondary">
+                        Running Servers (not recommended)
+                      </Typography>
+                    </MenuItem>
+                  )}
+                  {runningServers.map((server) => (
+                    <MenuItem key={server.name} value={server.name}>
+                      {server.name}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </>
+            )}
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={loading || !selectedServer || serversLoading}
+            startIcon={loading ? <CircularProgress size={16} /> : null}
+          >
+            {loading ? 'Assigning...' : 'Assign'}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import type { CreateWorldRequest } from '@/ports/api/IMcctlApiClient';
+
+interface CreateWorldDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: CreateWorldRequest) => void;
+  loading?: boolean;
+}
+
+const DEFAULT_FORM_VALUES: CreateWorldRequest = {
+  name: '',
+  seed: '',
+};
+
+export function CreateWorldDialog({
+  open,
+  onClose,
+  onSubmit,
+  loading = false,
+}: CreateWorldDialogProps) {
+  const [formData, setFormData] = useState<CreateWorldRequest>(DEFAULT_FORM_VALUES);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!open) {
+      setFormData(DEFAULT_FORM_VALUES);
+      setErrors({});
+    }
+  }, [open]);
+
+  const validateName = (name: string): string | null => {
+    if (!name) {
+      return 'World name is required';
+    }
+    if (!/^[a-z0-9-]+$/.test(name)) {
+      return 'Only lowercase letters, numbers, and hyphens are allowed';
+    }
+    return null;
+  };
+
+  const handleChange = (field: keyof CreateWorldRequest) => (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = e.target.value;
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: '' }));
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    setErrors({});
+
+    const nameError = validateName(formData.name);
+    if (nameError) {
+      setErrors({ name: nameError });
+      return;
+    }
+
+    onSubmit({
+      name: formData.name,
+      ...(formData.seed ? { seed: formData.seed } : {}),
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="sm" fullWidth>
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>Create New World</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            <TextField
+              label="World Name"
+              value={formData.name}
+              onChange={handleChange('name')}
+              error={!!errors.name}
+              helperText={errors.name || 'Only lowercase letters, numbers, and hyphens'}
+              fullWidth
+              autoFocus
+              disabled={loading}
+            />
+
+            <TextField
+              label="Seed (optional)"
+              value={formData.seed || ''}
+              onChange={handleChange('seed')}
+              helperText="Leave empty for a random seed"
+              fullWidth
+              disabled={loading}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={loading}
+            startIcon={loading ? <CircularProgress size={16} /> : null}
+          >
+            {loading ? 'Creating...' : 'Create'}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/platform/services/mcctl-console/src/components/worlds/WorldCard.test.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldCard.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { WorldCard } from './WorldCard';
+import type { World } from '@/ports/api/IMcctlApiClient';
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+const mockAvailableWorld: World = {
+  name: 'survival-world',
+  path: '/worlds/survival-world',
+  isLocked: false,
+  size: '256 MB',
+  lastModified: '2025-01-15T10:30:00Z',
+};
+
+const mockLockedWorld: World = {
+  name: 'creative-world',
+  path: '/worlds/creative-world',
+  isLocked: true,
+  lockedBy: 'paper-server',
+  size: '512 MB',
+  lastModified: '2025-01-20T14:00:00Z',
+};
+
+describe('WorldCard', () => {
+  it('should render world name', () => {
+    renderWithTheme(<WorldCard world={mockAvailableWorld} />);
+    expect(screen.getByText('survival-world')).toBeInTheDocument();
+  });
+
+  it('should render world size', () => {
+    renderWithTheme(<WorldCard world={mockAvailableWorld} />);
+    expect(screen.getByText('256 MB')).toBeInTheDocument();
+  });
+
+  it('should display Available status for unlocked world', () => {
+    renderWithTheme(<WorldCard world={mockAvailableWorld} />);
+    expect(screen.getByText('Available')).toBeInTheDocument();
+  });
+
+  it('should display Locked status for locked world', () => {
+    renderWithTheme(<WorldCard world={mockLockedWorld} />);
+    expect(screen.getByText('Locked')).toBeInTheDocument();
+  });
+
+  it('should display locked by server name', () => {
+    renderWithTheme(<WorldCard world={mockLockedWorld} />);
+    expect(screen.getByText('paper-server')).toBeInTheDocument();
+  });
+
+  it('should show assign button for available world', () => {
+    renderWithTheme(<WorldCard world={mockAvailableWorld} onAssign={vi.fn()} />);
+    expect(screen.getByLabelText('Assign world')).toBeInTheDocument();
+  });
+
+  it('should not show assign button for locked world', () => {
+    renderWithTheme(<WorldCard world={mockLockedWorld} onAssign={vi.fn()} />);
+    expect(screen.queryByLabelText('Assign world')).not.toBeInTheDocument();
+  });
+
+  it('should show release button for locked world', () => {
+    renderWithTheme(<WorldCard world={mockLockedWorld} onRelease={vi.fn()} />);
+    expect(screen.getByLabelText('Release world')).toBeInTheDocument();
+  });
+
+  it('should not show release button for available world', () => {
+    renderWithTheme(<WorldCard world={mockAvailableWorld} onRelease={vi.fn()} />);
+    expect(screen.queryByLabelText('Release world')).not.toBeInTheDocument();
+  });
+
+  it('should show delete button', () => {
+    renderWithTheme(<WorldCard world={mockAvailableWorld} onDelete={vi.fn()} />);
+    expect(screen.getByLabelText('Delete world')).toBeInTheDocument();
+  });
+
+  it('should call onAssign when assign button is clicked', () => {
+    const onAssign = vi.fn();
+    renderWithTheme(<WorldCard world={mockAvailableWorld} onAssign={onAssign} />);
+
+    const assignButton = screen.getByLabelText('Assign world');
+    fireEvent.click(assignButton);
+
+    expect(onAssign).toHaveBeenCalledTimes(1);
+    expect(onAssign).toHaveBeenCalledWith('survival-world');
+  });
+
+  it('should call onRelease when release button is clicked', () => {
+    const onRelease = vi.fn();
+    renderWithTheme(<WorldCard world={mockLockedWorld} onRelease={onRelease} />);
+
+    const releaseButton = screen.getByLabelText('Release world');
+    fireEvent.click(releaseButton);
+
+    expect(onRelease).toHaveBeenCalledTimes(1);
+    expect(onRelease).toHaveBeenCalledWith('creative-world');
+  });
+
+  it('should call onDelete when delete button is clicked', () => {
+    const onDelete = vi.fn();
+    renderWithTheme(<WorldCard world={mockAvailableWorld} onDelete={onDelete} />);
+
+    const deleteButton = screen.getByLabelText('Delete world');
+    fireEvent.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith('survival-world');
+  });
+
+  it('should disable buttons when loading', () => {
+    renderWithTheme(
+      <WorldCard
+        world={mockAvailableWorld}
+        onAssign={vi.fn()}
+        onDelete={vi.fn()}
+        loading={true}
+      />
+    );
+
+    expect(screen.getByLabelText('Assign world')).toBeDisabled();
+    expect(screen.getByLabelText('Delete world')).toBeDisabled();
+  });
+
+  it('should show Unknown size when size is not provided', () => {
+    const worldNoSize: World = { ...mockAvailableWorld, size: undefined };
+    renderWithTheme(<WorldCard world={worldNoSize} />);
+    expect(screen.getByText('Unknown size')).toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardActions from '@mui/material/CardActions';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import LinkIcon from '@mui/icons-material/Link';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
+import DeleteIcon from '@mui/icons-material/Delete';
+import StorageIcon from '@mui/icons-material/Storage';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import type { World } from '@/ports/api/IMcctlApiClient';
+
+interface WorldCardProps {
+  world: World;
+  onAssign?: (worldName: string) => void;
+  onRelease?: (worldName: string) => void;
+  onDelete?: (worldName: string) => void;
+  loading?: boolean;
+}
+
+export function WorldCard({ world, onAssign, onRelease, onDelete, loading = false }: WorldCardProps) {
+  const handleActionClick = (
+    e: React.MouseEvent,
+    action: (worldName: string) => void
+  ) => {
+    e.stopPropagation();
+    action(world.name);
+  };
+
+  const formatDate = (dateStr?: string): string => {
+    if (!dateStr) return '-';
+    try {
+      return new Date(dateStr).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return dateStr;
+    }
+  };
+
+  return (
+    <Card
+      role="article"
+      sx={{
+        transition: 'all 0.2s',
+        height: 200,
+        display: 'flex',
+        flexDirection: 'column',
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          boxShadow: 4,
+        },
+      }}
+    >
+      <CardContent sx={{ flex: 1, pb: 1 }}>
+        {/* Header: Name + Lock Status */}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography
+            variant="h6"
+            component="h3"
+            sx={{
+              fontWeight: 600,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flex: 1,
+              mr: 1,
+            }}
+          >
+            {world.name}
+          </Typography>
+          <Chip
+            label={world.isLocked ? 'Locked' : 'Available'}
+            size="small"
+            color={world.isLocked ? 'warning' : 'success'}
+            sx={{ fontWeight: 500, minWidth: 80 }}
+          />
+        </Box>
+
+        {/* Size */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+          <StorageIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+          <Typography variant="body2" color="text.secondary">
+            {world.size || 'Unknown size'}
+          </Typography>
+        </Box>
+
+        {/* Locked By */}
+        {world.isLocked && world.lockedBy && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+            <LinkIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Tooltip title={`Assigned to ${world.lockedBy}`} arrow>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {world.lockedBy}
+              </Typography>
+            </Tooltip>
+          </Box>
+        )}
+
+        {/* Last Modified */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AccessTimeIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+          <Typography variant="body2" color="text.secondary">
+            {formatDate(world.lastModified)}
+          </Typography>
+        </Box>
+      </CardContent>
+
+      <CardActions sx={{ justifyContent: 'flex-end', px: 2, py: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
+        {!world.isLocked && onAssign && (
+          <Tooltip title="Assign to server" arrow>
+            <IconButton
+              aria-label="Assign world"
+              color="primary"
+              onClick={(e) => handleActionClick(e, onAssign)}
+              disabled={loading}
+              size="small"
+            >
+              <LinkIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+        {world.isLocked && onRelease && (
+          <Tooltip title="Release from server" arrow>
+            <IconButton
+              aria-label="Release world"
+              color="warning"
+              onClick={(e) => handleActionClick(e, onRelease)}
+              disabled={loading}
+              size="small"
+            >
+              <LinkOffIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+        {onDelete && (
+          <Tooltip title="Delete world" arrow>
+            <IconButton
+              aria-label="Delete world"
+              color="error"
+              onClick={(e) => handleActionClick(e, onDelete)}
+              disabled={loading}
+              size="small"
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+      </CardActions>
+    </Card>
+  );
+}

--- a/platform/services/mcctl-console/src/components/worlds/WorldList.test.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldList.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { WorldList } from './WorldList';
+import type { World } from '@/ports/api/IMcctlApiClient';
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+const mockWorlds: World[] = [
+  {
+    name: 'survival-world',
+    path: '/worlds/survival-world',
+    isLocked: false,
+    size: '256 MB',
+    lastModified: '2025-01-15T10:30:00Z',
+  },
+  {
+    name: 'creative-world',
+    path: '/worlds/creative-world',
+    isLocked: true,
+    lockedBy: 'paper-server',
+    size: '512 MB',
+    lastModified: '2025-01-20T14:00:00Z',
+  },
+  {
+    name: 'adventure-world',
+    path: '/worlds/adventure-world',
+    isLocked: false,
+    size: '128 MB',
+    lastModified: '2025-01-10T08:00:00Z',
+  },
+];
+
+describe('WorldList', () => {
+  it('should render all worlds in grid layout', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    expect(screen.getByText('survival-world')).toBeInTheDocument();
+    expect(screen.getByText('creative-world')).toBeInTheDocument();
+    expect(screen.getByText('adventure-world')).toBeInTheDocument();
+  });
+
+  it('should render empty state when no worlds', () => {
+    renderWithTheme(<WorldList worlds={[]} />);
+
+    expect(screen.getByText(/no worlds found/i)).toBeInTheDocument();
+  });
+
+  it('should show create button in empty state', () => {
+    const onCreate = vi.fn();
+    renderWithTheme(<WorldList worlds={[]} onCreate={onCreate} />);
+
+    const createButton = screen.getByRole('button', { name: /create world/i });
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.click(createButton);
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should filter worlds by available status', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    const availableFilter = screen.getByRole('button', { name: /available/i });
+    fireEvent.click(availableFilter);
+
+    expect(screen.getByText('survival-world')).toBeInTheDocument();
+    expect(screen.getByText('adventure-world')).toBeInTheDocument();
+    expect(screen.queryByText('creative-world')).not.toBeInTheDocument();
+  });
+
+  it('should filter worlds by locked status', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    const lockedFilter = screen.getByRole('button', { name: /locked/i });
+    fireEvent.click(lockedFilter);
+
+    expect(screen.getByText('creative-world')).toBeInTheDocument();
+    expect(screen.queryByText('survival-world')).not.toBeInTheDocument();
+    expect(screen.queryByText('adventure-world')).not.toBeInTheDocument();
+  });
+
+  it('should search worlds by name', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    const searchInput = screen.getByPlaceholderText(/search worlds/i);
+    fireEvent.change(searchInput, { target: { value: 'survival' } });
+
+    expect(screen.getByText('survival-world')).toBeInTheDocument();
+    expect(screen.queryByText('creative-world')).not.toBeInTheDocument();
+    expect(screen.queryByText('adventure-world')).not.toBeInTheDocument();
+  });
+
+  it('should search worlds case-insensitively', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    const searchInput = screen.getByPlaceholderText(/search worlds/i);
+    fireEvent.change(searchInput, { target: { value: 'CREATIVE' } });
+
+    expect(screen.getByText('creative-world')).toBeInTheDocument();
+    expect(screen.queryByText('survival-world')).not.toBeInTheDocument();
+  });
+
+  it('should show empty state when search has no results', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    const searchInput = screen.getByPlaceholderText(/search worlds/i);
+    fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
+
+    expect(screen.getByText(/no worlds found/i)).toBeInTheDocument();
+  });
+
+  it('should combine search and filter', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    // Filter by available
+    const availableFilter = screen.getByRole('button', { name: /available/i });
+    fireEvent.click(availableFilter);
+
+    // Then search for "adventure"
+    const searchInput = screen.getByPlaceholderText(/search worlds/i);
+    fireEvent.change(searchInput, { target: { value: 'adventure' } });
+
+    expect(screen.getByText('adventure-world')).toBeInTheDocument();
+    expect(screen.queryByText('survival-world')).not.toBeInTheDocument();
+    expect(screen.queryByText('creative-world')).not.toBeInTheDocument();
+  });
+
+  it('should display world count', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    expect(screen.getByText(/3 worlds/i)).toBeInTheDocument();
+  });
+
+  it('should update count when filtering', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    const availableFilter = screen.getByRole('button', { name: /available/i });
+    fireEvent.click(availableFilter);
+
+    expect(screen.getByText(/2 worlds/i)).toBeInTheDocument();
+  });
+
+  it('should use singular "world" for count of 1', () => {
+    renderWithTheme(<WorldList worlds={mockWorlds} />);
+
+    const lockedFilter = screen.getByRole('button', { name: /locked/i });
+    fireEvent.click(lockedFilter);
+
+    expect(screen.getByText(/1 world$/i)).toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/worlds/WorldList.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldList.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import SearchIcon from '@mui/icons-material/Search';
+import AddIcon from '@mui/icons-material/Add';
+import { WorldCard } from './WorldCard';
+import type { World } from '@/ports/api/IMcctlApiClient';
+
+interface WorldListProps {
+  worlds: World[];
+  onAssign?: (worldName: string) => void;
+  onRelease?: (worldName: string) => void;
+  onDelete?: (worldName: string) => void;
+  onCreate?: () => void;
+  loadingWorlds?: string[];
+}
+
+type LockFilter = 'all' | 'available' | 'locked';
+
+export function WorldList({
+  worlds,
+  onAssign,
+  onRelease,
+  onDelete,
+  onCreate,
+  loadingWorlds = [],
+}: WorldListProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [lockFilter, setLockFilter] = useState<LockFilter>('all');
+
+  const filteredWorlds = useMemo(() => {
+    return worlds.filter((world) => {
+      if (searchQuery && !world.name.toLowerCase().includes(searchQuery.toLowerCase())) {
+        return false;
+      }
+
+      if (lockFilter === 'available' && world.isLocked) {
+        return false;
+      }
+      if (lockFilter === 'locked' && !world.isLocked) {
+        return false;
+      }
+
+      return true;
+    });
+  }, [worlds, searchQuery, lockFilter]);
+
+  const handleLockFilterChange = (_: React.MouseEvent<HTMLElement>, newFilter: LockFilter) => {
+    if (newFilter !== null) {
+      setLockFilter(newFilter);
+    }
+  };
+
+  if (worlds.length === 0) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '400px',
+          gap: 2,
+        }}
+      >
+        <Typography variant="h6" color="text.secondary">
+          No worlds found
+        </Typography>
+        {onCreate && (
+          <Button variant="contained" startIcon={<AddIcon />} onClick={onCreate}>
+            Create World
+          </Button>
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {/* Filters and Search */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: 2,
+          mb: 3,
+          alignItems: { xs: 'stretch', sm: 'center' },
+          justifyContent: 'space-between',
+        }}
+      >
+        <ToggleButtonGroup
+          value={lockFilter}
+          exclusive
+          onChange={handleLockFilterChange}
+          size="small"
+          sx={{ flexShrink: 0 }}
+        >
+          <ToggleButton value="all">All</ToggleButton>
+          <ToggleButton value="available">Available</ToggleButton>
+          <ToggleButton value="locked">Locked</ToggleButton>
+        </ToggleButtonGroup>
+
+        <TextField
+          size="small"
+          placeholder="Search worlds..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            ),
+          }}
+          sx={{ flexGrow: { xs: 1, sm: 0 }, minWidth: { sm: 300 } }}
+        />
+      </Box>
+
+      {/* World Count */}
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {filteredWorlds.length} {filteredWorlds.length === 1 ? 'world' : 'worlds'}
+      </Typography>
+
+      {/* World Grid */}
+      {filteredWorlds.length === 0 ? (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '200px',
+            gap: 2,
+          }}
+        >
+          <Typography variant="h6" color="text.secondary">
+            No worlds found
+          </Typography>
+        </Box>
+      ) : (
+        <Grid container spacing={2}>
+          {filteredWorlds.map((world) => (
+            <Grid item xs={12} sm={6} md={4} key={world.name}>
+              <WorldCard
+                world={world}
+                onAssign={onAssign}
+                onRelease={onRelease}
+                onDelete={onDelete}
+                loading={loadingWorlds.includes(world.name)}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

- Add world management page (`/worlds`) with full CRUD functionality: list, create, assign to server, release, and delete worlds
- Add WorldCard, WorldList, CreateWorldDialog, and AssignWorldDialog components following existing server UI patterns
- Add Worlds navigation item to GNB (between Servers and Players)
- Include 35 tests across 3 test files (WorldCard, WorldList, page)

## New Files

| File | Description |
|------|-------------|
| `src/app/(main)/worlds/page.tsx` | World list page with dialogs and state management |
| `src/components/worlds/WorldCard.tsx` | Card showing name, size, lock status, actions |
| `src/components/worlds/WorldList.tsx` | Search + filter (All/Available/Locked) grid layout |
| `src/components/worlds/CreateWorldDialog.tsx` | Create world form (name + optional seed) |
| `src/components/worlds/AssignWorldDialog.tsx` | Server selection dropdown for world assignment |

## Modified Files

| File | Change |
|------|--------|
| `src/components/layout/GNB.tsx` | Added Worlds nav item with PublicIcon |

## Hooks Used (pre-existing)

`useWorlds()`, `useCreateWorld()`, `useAssignWorld()`, `useReleaseWorld()`, `useDeleteWorld()`, `useServers()`

## Test plan

- [x] WorldCard renders name, size, lock status (Available/Locked)
- [x] WorldCard shows correct action buttons based on lock state
- [x] WorldList search filters by name (case-insensitive)
- [x] WorldList toggle filters (All/Available/Locked)
- [x] WorldList empty state with Create button
- [x] Page renders header, loading, error states
- [x] Create/Delete dialogs open and validate correctly
- [x] Build passes (`pnpm -F @minecraft-docker/mcctl-console build`)
- [x] All 35 tests pass

Closes #175

🤖 Generated with [Claude Code](https://claude.ai/code)