### PR TITLE
feat(shared/scripts): MODRINTH Modpack Infrastructure Support (#243)

### DIFF
--- a/platform/servers/_template/config.env
+++ b/platform/servers/_template/config.env
@@ -17,7 +17,7 @@
 # Server Type
 # -----------------------------------------------------------------------------
 TYPE=PAPER
-# Options: VANILLA, PAPER, SPIGOT, FORGE, FABRIC, NEOFORGE, QUILT
+# Options: VANILLA, PAPER, SPIGOT, FORGE, FABRIC, NEOFORGE, QUILT, MODRINTH, AUTO_CURSEFORGE
 # See: https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/
 
 # Minecraft Version
@@ -87,6 +87,19 @@ MOTD=Welcome! Your adventure begins here.
 # - optional: Download required + optional dependencies
 # - none: Don't download dependencies (manual management)
 MODRINTH_DOWNLOAD_DEPENDENCIES=required
+
+# -----------------------------------------------------------------------------
+# Optional: Modpack Configuration (MODRINTH / AUTO_CURSEFORGE types only)
+# -----------------------------------------------------------------------------
+# For MODRINTH type:
+# MODRINTH_MODPACK=fabric-example
+# MODRINTH_VERSION=1.0.0 (optional - defaults to latest)
+# MODRINTH_LOADER=fabric (optional - auto-detected from modpack)
+
+# For AUTO_CURSEFORGE type:
+# CF_SLUG=forge-example
+# CF_VERSION=2.0.0 (optional - defaults to latest)
+# CF_LOADER=forge (optional - auto-detected from modpack)
 
 # -----------------------------------------------------------------------------
 # Optional: Advanced

--- a/platform/services/shared/src/application/ports/outbound/IPromptPort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IPromptPort.ts
@@ -97,6 +97,21 @@ export interface IPromptPort {
     worlds: WorldWithServerStatus[]
   ): Promise<World | null>;
 
+  /**
+   * Prompt for modpack slug (project identifier)
+   */
+  promptModpackSlug(): Promise<string>;
+
+  /**
+   * Prompt for modpack version (optional)
+   */
+  promptModpackVersion(): Promise<string | undefined>;
+
+  /**
+   * Prompt for modpack loader (optional)
+   */
+  promptModpackLoader(): Promise<string | undefined>;
+
   // ========================================
   // Status Display
   // ========================================

--- a/platform/services/shared/src/application/ports/outbound/IShellPort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IShellPort.ts
@@ -142,6 +142,9 @@ export interface CreateServerOptions {
   worldOptions: WorldOptions;
   memory?: Memory;
   autoStart?: boolean;
+  modpackSlug?: string;
+  modpackVersion?: string;
+  modLoader?: string;
 }
 
 /**

--- a/platform/services/shared/src/infrastructure/adapters/ApiPromptAdapter.ts
+++ b/platform/services/shared/src/infrastructure/adapters/ApiPromptAdapter.ts
@@ -47,6 +47,12 @@ export interface ApiPromptOptions {
   password?: string;
   /** Default value for confirm prompts (defaults to true) */
   confirmValue?: boolean;
+  /** Modpack slug (for MODRINTH/AUTO_CURSEFORGE types) */
+  modpackSlug?: string;
+  /** Modpack version (optional) */
+  modpackVersion?: string;
+  /** Mod loader (optional) */
+  modLoader?: string;
 }
 
 /**
@@ -277,6 +283,21 @@ export class ApiPromptAdapter implements IPromptPort {
 
     // In API mode, we don't warn about stopped servers - caller should check
     return worldEntry.world;
+  }
+
+  async promptModpackSlug(): Promise<string> {
+    if (!this.options.modpackSlug) {
+      throw new ApiModeError('modpackSlug is required in API mode for modpack server types');
+    }
+    return this.options.modpackSlug;
+  }
+
+  async promptModpackVersion(): Promise<string | undefined> {
+    return this.options.modpackVersion;
+  }
+
+  async promptModpackLoader(): Promise<string | undefined> {
+    return this.options.modLoader;
   }
 
   // ========================================

--- a/platform/services/shared/src/infrastructure/adapters/ShellAdapter.ts
+++ b/platform/services/shared/src/infrastructure/adapters/ShellAdapter.ts
@@ -103,6 +103,17 @@ export class ShellAdapter implements IShellPort {
     // Add world options
     args.push(...options.worldOptions.toCliArgs());
 
+    // Add modpack options if provided
+    if (options.modpackSlug) {
+      args.push('--modpack', options.modpackSlug);
+    }
+    if (options.modpackVersion) {
+      args.push('--modpack-version', options.modpackVersion);
+    }
+    if (options.modLoader) {
+      args.push('--mod-loader', options.modLoader);
+    }
+
     if (options.autoStart === false) {
       args.push('--no-start');
     }

--- a/platform/services/shared/tests/ShellAdapter-modpack.test.ts
+++ b/platform/services/shared/tests/ShellAdapter-modpack.test.ts
@@ -1,0 +1,100 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { ServerName, ServerType, ServerTypeEnum, McVersion, WorldOptions } from '../src/domain/index.js';
+import type { CreateServerOptions } from '../src/application/ports/outbound/IShellPort.js';
+
+/**
+ * ShellAdapter Modpack Unit Tests
+ *
+ * These tests verify that CreateServerOptions correctly support modpack fields.
+ * The actual script integration is tested in CLI/E2E tests.
+ */
+describe('ShellAdapter - Modpack Support', () => {
+  describe('CreateServerOptions interface', () => {
+    test('should accept modpack options for MODRINTH type', () => {
+      const options: CreateServerOptions = {
+        type: ServerType.fromEnum(ServerTypeEnum.MODRINTH),
+        version: McVersion.create('1.21.1'),
+        worldOptions: WorldOptions.newWorld(),
+        modpackSlug: 'fabric-example',
+        autoStart: false,
+      };
+
+      assert.strictEqual(options.modpackSlug, 'fabric-example');
+      assert.strictEqual(options.type.value, ServerTypeEnum.MODRINTH);
+    });
+
+    test('should accept modpack version option', () => {
+      const options: CreateServerOptions = {
+        type: ServerType.fromEnum(ServerTypeEnum.MODRINTH),
+        version: McVersion.create('1.21.1'),
+        worldOptions: WorldOptions.newWorld(),
+        modpackSlug: 'fabric-example',
+        modpackVersion: '1.0.0',
+        autoStart: false,
+      };
+
+      assert.strictEqual(options.modpackSlug, 'fabric-example');
+      assert.strictEqual(options.modpackVersion, '1.0.0');
+    });
+
+    test('should accept mod loader option', () => {
+      const options: CreateServerOptions = {
+        type: ServerType.fromEnum(ServerTypeEnum.MODRINTH),
+        version: McVersion.create('1.21.1'),
+        worldOptions: WorldOptions.newWorld(),
+        modpackSlug: 'fabric-example',
+        modLoader: 'fabric',
+        autoStart: false,
+      };
+
+      assert.strictEqual(options.modpackSlug, 'fabric-example');
+      assert.strictEqual(options.modLoader, 'fabric');
+    });
+
+    test('should accept all modpack options together', () => {
+      const options: CreateServerOptions = {
+        type: ServerType.fromEnum(ServerTypeEnum.MODRINTH),
+        version: McVersion.create('1.21.1'),
+        worldOptions: WorldOptions.newWorld(),
+        modpackSlug: 'fabric-example',
+        modpackVersion: '1.0.0',
+        modLoader: 'fabric',
+        autoStart: false,
+      };
+
+      assert.strictEqual(options.modpackSlug, 'fabric-example');
+      assert.strictEqual(options.modpackVersion, '1.0.0');
+      assert.strictEqual(options.modLoader, 'fabric');
+    });
+
+    test('should work for AUTO_CURSEFORGE type', () => {
+      const options: CreateServerOptions = {
+        type: ServerType.fromEnum(ServerTypeEnum.AUTO_CURSEFORGE),
+        version: McVersion.create('1.21.1'),
+        worldOptions: WorldOptions.newWorld(),
+        modpackSlug: 'forge-example',
+        modpackVersion: '2.0.0',
+        autoStart: false,
+      };
+
+      assert.strictEqual(options.type.value, ServerTypeEnum.AUTO_CURSEFORGE);
+      assert.strictEqual(options.modpackSlug, 'forge-example');
+      assert.strictEqual(options.modpackVersion, '2.0.0');
+    });
+
+    test('should work without modpack options for non-modpack server types', () => {
+      const options: CreateServerOptions = {
+        type: ServerType.fromEnum(ServerTypeEnum.PAPER),
+        version: McVersion.create('1.21.1'),
+        worldOptions: WorldOptions.newWorld(),
+        autoStart: false,
+      };
+
+      assert.strictEqual(options.type.value, ServerTypeEnum.PAPER);
+      assert.strictEqual(options.modpackSlug, undefined);
+      assert.strictEqual(options.modpackVersion, undefined);
+      assert.strictEqual(options.modLoader, undefined);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements infrastructure support for MODRINTH and AUTO_CURSEFORGE modpack server types.

Closes #243

## Changes

### 1. IShellPort & IPromptPort Extensions
- Added `modpackSlug`, `modpackVersion`, `modLoader` fields to `CreateServerOptions`
- Added modpack prompt methods: `promptModpackSlug()`, `promptModpackVersion()`, `promptModpackLoader()`

### 2. ShellAdapter Implementation
- Updated `createServer()` to pass modpack options as CLI arguments
- Arguments: `--modpack SLUG`, `--modpack-version VER`, `--mod-loader LOADER`

### 3. ApiPromptAdapter Support
- Extended `ApiPromptOptions` with modpack fields
- Implemented modpack prompt methods for non-interactive mode

### 4. create-server.sh Script Enhancements
- Added new CLI options:
  - `--modpack SLUG` (required for MODRINTH/AUTO_CURSEFORGE)
  - `--modpack-version VER` (optional)
  - `--mod-loader LOADER` (optional)
- Validation: MODRINTH/AUTO_CURSEFORGE types require `--modpack`
- Writes modpack config to `config.env` based on server type:
  - MODRINTH: `MODRINTH_MODPACK`, `MODRINTH_VERSION`, `MODRINTH_LOADER`
  - AUTO_CURSEFORGE: `CF_SLUG`, `CF_VERSION`, `CF_LOADER`

### 5. config.env Template
- Added modpack configuration section with examples for both platforms

## Testing

- All tests passing: 153/153
- Added unit tests for `CreateServerOptions` modpack support
- Integration testing will be done in CLI layer (issue #244)

## Test Plan

```bash
# Build and test shared package
pnpm build --filter @minecraft-docker/shared
pnpm test --filter @minecraft-docker/shared

# Manual test (after CLI integration)
mcctl create test-modpack -t MODRINTH --modpack fabric-example
```

## Dependencies

- Depends on: #242 (merged)
- Blocks: #244 (CLI integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)