### PR TITLE
feat(mcctl-api): add MODRINTH modpack server creation API (#245)

### DIFF
--- a/platform/services/mcctl-api/src/routes/servers.ts
+++ b/platform/services/mcctl-api/src/routes/servers.ts
@@ -581,7 +581,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       },
     },
   }, async (request: FastifyRequest<CreateServerRoute>, reply: FastifyReply) => {
-    const { name, type, version, memory, seed, worldUrl, worldName, autoStart, sudoPassword } = request.body;
+    const { name, type, version, memory, seed, worldUrl, worldName, autoStart, sudoPassword, modpack, modpackVersion, modLoader } = request.body;
     const { follow = false } = request.query;
 
     // Check if server already exists (before SSE mode check)
@@ -589,6 +589,14 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       return reply.code(409).send({
         error: 'Conflict',
         message: `Server '${name}' already exists`,
+      });
+    }
+
+    // Validate modpack requirement for MODRINTH and AUTO_CURSEFORGE types
+    if ((type === 'MODRINTH' || type === 'AUTO_CURSEFORGE') && !modpack) {
+      return reply.code(400).send({
+        error: 'BadRequest',
+        message: `Modpack slug is required for ${type} server type`,
       });
     }
 
@@ -609,6 +617,15 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     }
     if (worldName) {
       args.push('-w', worldName);
+    }
+    if (modpack) {
+      args.push('--modpack', modpack);
+    }
+    if (modpackVersion) {
+      args.push('--modpack-version', modpackVersion);
+    }
+    if (modLoader) {
+      args.push('--mod-loader', modLoader);
     }
     if (autoStart === false) {
       args.push('--no-start');
@@ -719,7 +736,14 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
             targetType: 'server',
             targetName: name,
             status: 'success',
-            details: { type: type ?? null, version: version ?? null, memory: memory ?? null },
+            details: {
+              type: type ?? null,
+              version: version ?? null,
+              memory: memory ?? null,
+              modpack: modpack ?? null,
+              modpackVersion: modpackVersion ?? null,
+              modLoader: modLoader ?? null,
+            },
             errorMessage: null,
           });
 
@@ -795,7 +819,14 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         targetType: 'server',
         targetName: name,
         status: 'success',
-        details: { type: type ?? null, version: version ?? null, memory: memory ?? null },
+        details: {
+          type: type ?? null,
+          version: version ?? null,
+          memory: memory ?? null,
+          modpack: modpack ?? null,
+          modpackVersion: modpackVersion ?? null,
+          modLoader: modLoader ?? null,
+        },
         errorMessage: null,
       });
 

--- a/platform/services/mcctl-api/src/schemas/server.ts
+++ b/platform/services/mcctl-api/src/schemas/server.ts
@@ -144,6 +144,8 @@ export const CreateServerRequestSchema = Type.Object({
     Type.Literal('FABRIC'),
     Type.Literal('SPIGOT'),
     Type.Literal('NEOFORGE'),
+    Type.Literal('MODRINTH'),
+    Type.Literal('AUTO_CURSEFORGE'),
   ])),
   version: Type.Optional(Type.String()),
   memory: Type.Optional(Type.String({ pattern: '^\\d+[MG]$' })),
@@ -152,6 +154,17 @@ export const CreateServerRequestSchema = Type.Object({
   worldName: Type.Optional(Type.String()),
   autoStart: Type.Optional(Type.Boolean({ default: true })),
   sudoPassword: Type.Optional(Type.String({ writeOnly: true })),
+  modpack: Type.Optional(Type.String({
+    description: 'Modrinth modpack slug, ID, or URL (required for MODRINTH/AUTO_CURSEFORGE)',
+  })),
+  modpackVersion: Type.Optional(Type.String({
+    description: 'Specific modpack version ID',
+  })),
+  modLoader: Type.Optional(Type.Union([
+    Type.Literal('forge'),
+    Type.Literal('fabric'),
+    Type.Literal('quilt'),
+  ], { description: 'Mod loader override' })),
 });
 
 // Create Server Query Schema (for SSE streaming support)


### PR DESCRIPTION
## Summary

Implements F-023 (Modrinth Modpack Server Creation API) by extending the POST /api/servers endpoint to support Modrinth and CurseForge modpack server creation.

### Changes

1. **Schema Extension** (`schemas/server.ts`)
   - Added `MODRINTH` and `AUTO_CURSEFORGE` to server type union
   - Added optional fields: `modpack`, `modpackVersion`, `modLoader`

2. **Request Validation** (`routes/servers.ts`)
   - Validates that `modpack` field is required when type is `MODRINTH` or `AUTO_CURSEFORGE`
   - Returns 400 with clear error message if validation fails

3. **Command Argument Passing**
   - Passes `--modpack`, `--modpack-version`, `--mod-loader` to create-server.sh
   - Works in both standard JSON and SSE streaming modes

4. **Audit Logging**
   - Includes modpack information in audit log details field
   - Logs: `modpack`, `modpackVersion`, `modLoader`

5. **Tests**
   - 11 new tests covering:
     - Schema validation (accepts MODRINTH/AUTO_CURSEFORGE types)
     - Required field validation (400 error when modpack missing)
     - Command argument passing verification
     - Existing server type compatibility (PAPER works without modpack)
     - Audit logging with modpack details

### Test Results

```
✓ tests/servers.test.ts (30 tests | 1 skipped)
  ✓ POST /api/servers - Modrinth Modpack Support (11 tests)
    ✓ Schema Validation (6 tests)
    ✓ Command Arguments (2 tests)
    ✓ Audit Logging (1 test)
```

All existing tests remain green (163 passed | 1 skipped).

### Prerequisites

- ✅ #242 (Domain Model) - merged to develop
- ✅ #243 (Infrastructure) - merged to develop
- ✅ `ServerTypeEnum.MODRINTH`, `ModpackOptions` VO exist in shared package
- ✅ `create-server.sh` supports `--modpack`, `--modpack-version`, `--mod-loader` options

### API Examples

**Create Modrinth modpack server:**
```bash
POST /api/servers
{
  "name": "adrenaline-server",
  "type": "MODRINTH",
  "modpack": "adrenaline",
  "modpackVersion": "1.2.3",
  "modLoader": "fabric"
}
```

**Error when modpack missing:**
```bash
POST /api/servers
{
  "name": "modrinth-test",
  "type": "MODRINTH"
}
# Response: 400 - "Modpack slug is required for MODRINTH server type"
```

### OpenAPI Documentation

The new fields are automatically documented in Swagger UI at `/docs` via TypeBox schema reflection.

### Checklist

- ✅ TDD: Tests written first (Red → Green → Refactor)
- ✅ All tests pass (30 tests, 29 passed)
- ✅ Build successful (`pnpm build` passes)
- ✅ No existing tests broken
- ✅ Follows existing API patterns
- ✅ Audit logging implemented
- ✅ Error handling with clear messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)