### PR TITLE
feat(cli): MODRINTH Modpack Server Creation in CLI (#244)

### DIFF
--- a/platform/services/cli/src/commands/create.ts
+++ b/platform/services/cli/src/commands/create.ts
@@ -15,6 +15,9 @@ export interface CreateCommandOptions {
   worldName?: string;
   noStart?: boolean;
   sudoPassword?: string;
+  modpack?: string;
+  modpackVersion?: string;
+  modLoader?: string;
 }
 
 /**
@@ -69,13 +72,29 @@ async function createWithArguments(
       worldUrl: options.worldUrl,
       worldName: options.worldName,
       autoStart: !options.noStart,
+      modpackSlug: options.modpack,
+      modpackVersion: options.modpackVersion,
+      modLoader: options.modLoader,
     });
 
     console.log('');
     console.log(colors.green(`✓ Server '${server.name.value}' created successfully!`));
     console.log(`  Container: ${colors.cyan(server.containerName)}`);
     console.log(`  Type: ${server.type.label}`);
-    console.log(`  Version: ${server.version.value}`);
+
+    // Show modpack info if it's a modpack server
+    if (server.type.isModpack && server.modpackOptions) {
+      console.log(`  Modpack: ${server.modpackOptions.slug}`);
+      if (server.modpackOptions.version) {
+        console.log(`  Modpack Version: ${server.modpackOptions.version}`);
+      }
+      if (server.modpackOptions.loader) {
+        console.log(`  Mod Loader: ${server.modpackOptions.loader}`);
+      }
+    } else {
+      console.log(`  Version: ${server.version.value}`);
+    }
+
     console.log(`  Memory: ${server.memory.value}`);
     console.log('');
     console.log(`  Connect via: ${colors.cyan(server.name.hostname + ':25565')}`);

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -259,12 +259,15 @@ ${colors.cyan('Console Options:')}
   -f, --follow                 Follow log output
 
 ${colors.cyan('Create Options:')}
-  -t, --type TYPE            Server type: PAPER, VANILLA, FORGE, FABRIC
+  -t, --type TYPE            Server type: PAPER, VANILLA, FORGE, FABRIC, MODRINTH
   -v, --version VERSION      Minecraft version (e.g., 1.21.1)
   -s, --seed NUMBER          World seed
   -u, --world-url URL        Download world from ZIP URL
   -w, --world NAME           Use existing world (symlink)
   --no-start                 Create without starting
+  --modpack SLUG             Modrinth modpack slug (required for MODRINTH type)
+  --modpack-version VERSION  Modpack version (optional, default: latest)
+  --mod-loader LOADER        Mod loader (auto/fabric/forge/quilt, default: auto)
 
 ${colors.cyan('Status Options:')}
   --detail, -d               Show detailed info (memory, CPU, players)
@@ -287,6 +290,7 @@ ${colors.cyan('Examples:')}
   mcctl start --all                  # Start all MC servers
   mcctl stop --all                   # Stop all MC servers
   mcctl create myserver -t FORGE -v 1.20.4
+  mcctl create cobblemon -t MODRINTH --modpack cobblemon
   mcctl status --json
   mcctl status --detail              # Show detailed info
   mcctl status --watch               # Real-time monitoring
@@ -491,6 +495,9 @@ async function main(): Promise<void> {
           worldName: flags['world'] as string | undefined,
           noStart: flags['no-start'] === true,
           sudoPassword,
+          modpack: flags['modpack'] as string | undefined,
+          modpackVersion: flags['modpack-version'] as string | undefined,
+          modLoader: flags['mod-loader'] as string | undefined,
         });
         break;
       }

--- a/platform/services/cli/tests/mocks/MockPromptAdapter.ts
+++ b/platform/services/cli/tests/mocks/MockPromptAdapter.ts
@@ -32,6 +32,9 @@ export interface MockPromptValues {
   text?: string;
   password?: string;
   selectIndex?: number;
+  modpackSlug?: string;
+  modpackVersion?: string;
+  modpackLoader?: string;
 }
 
 /**
@@ -170,7 +173,7 @@ export class MockPromptAdapter implements IPromptPort {
     return McVersion.create(this.values.version!);
   }
 
-  async promptMemory(): Promise<Memory> {
+  async promptMemory(_defaultValue?: string): Promise<Memory> {
     if (this._cancelled) {
       throw new MockCancelError();
     }
@@ -210,6 +213,34 @@ export class MockPromptAdapter implements IPromptPort {
     }
     const index = this.values.selectIndex ?? 0;
     return worlds[index] ?? worlds[0]!;
+  }
+
+  async promptExistingWorldSelection(_worlds: any[]): Promise<World | null> {
+    if (this._cancelled) {
+      throw new MockCancelError();
+    }
+    return null;
+  }
+
+  async promptModpackSlug(): Promise<string> {
+    if (this._cancelled) {
+      throw new MockCancelError();
+    }
+    return this.values.modpackSlug ?? 'cobblemon';
+  }
+
+  async promptModpackVersion(): Promise<string | undefined> {
+    if (this._cancelled) {
+      throw new MockCancelError();
+    }
+    return this.values.modpackVersion;
+  }
+
+  async promptModpackLoader(): Promise<string | undefined> {
+    if (this._cancelled) {
+      throw new MockCancelError();
+    }
+    return this.values.modpackLoader;
   }
 
   // ========================================

--- a/platform/services/shared/src/application/ports/inbound/ICreateServerUseCase.ts
+++ b/platform/services/shared/src/application/ports/inbound/ICreateServerUseCase.ts
@@ -31,4 +31,7 @@ export interface CreateServerConfig {
   worldName?: string;
   worldUrl?: string;
   autoStart?: boolean;
+  modpackSlug?: string;
+  modpackVersion?: string;
+  modLoader?: string;
 }

--- a/platform/services/shared/src/application/ports/outbound/IPromptPort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IPromptPort.ts
@@ -70,7 +70,7 @@ export interface IPromptPort {
   /**
    * Prompt for memory allocation
    */
-  promptMemory(): Promise<Memory>;
+  promptMemory(defaultValue?: string): Promise<Memory>;
 
   /**
    * Prompt for world options (new/existing/download)

--- a/platform/services/shared/src/domain/entities/Server.ts
+++ b/platform/services/shared/src/domain/entities/Server.ts
@@ -3,6 +3,7 @@ import { ServerType } from '../value-objects/ServerType.js';
 import { McVersion } from '../value-objects/McVersion.js';
 import { Memory } from '../value-objects/Memory.js';
 import { WorldOptions } from '../value-objects/WorldOptions.js';
+import { ModpackOptions } from '../value-objects/ModpackOptions.js';
 
 /**
  * Server status enumeration
@@ -27,6 +28,7 @@ export interface ServerConfig {
   worldOptions: WorldOptions;
   rconPassword?: string;
   autoStart?: boolean;
+  modpackOptions?: ModpackOptions;
 }
 
 /**
@@ -71,6 +73,10 @@ export class Server {
 
   get autoStart(): boolean {
     return this._config.autoStart ?? true;
+  }
+
+  get modpackOptions(): ModpackOptions | undefined {
+    return this._config.modpackOptions;
   }
 
   // Status management


### PR DESCRIPTION
## Summary
CLI에서 MODRINTH 모드팩 서버 생성 기능 구현

### 주요 변경사항
- CLI 인자 모드: `--modpack`, `--modpack-version`, `--mod-loader` 옵션 추가
- 인터랙티브 모드: MODRINTH 타입 선택 시 모드팩 관련 추가 프롬프트
- 서버 타입 그룹핑: Standard Servers / Modpack Platforms 분리 표시
- MODRINTH 선택 시 Minecraft Version 프롬프트 스킵
- MODRINTH 선택 시 기본 메모리 6G

### CLI 인자 모드 예시
```bash
mcctl create cobblemon -t MODRINTH --modpack cobblemon
mcctl create modpack -t MODRINTH --modpack test-pack --modpack-version 1.0.0 --mod-loader fabric
```

### 인터랙티브 모드 흐름
```
◆ Server type?
│ ── Standard Servers ──
│ ○ Paper (Recommended)
│ ○ Vanilla / Forge / Fabric / NeoForge
│ ── Modpack Platforms ──
│ ● Modrinth Modpack
│
◆ Modrinth modpack slug or URL?
│ cobblemon
│
◆ Mod loader? (Auto-detect / Fabric / Forge / Quilt)
│ Auto-detect
│
◆ Memory? (6G recommended for modpacks)
│ 6G
```

### 구현 내용
1. **ClackPromptAdapter**
   - `promptModpackSlug()`: 필수 텍스트 입력
   - `promptModpackVersion()`: 선택적 텍스트 입력
   - `promptModpackLoader()`: Auto-detect/Fabric/Forge/Quilt 선택
   - `promptMemory(defaultValue)`: 기본값 파라미터 추가

2. **CreateServerUseCase**
   - `execute()`: MODRINTH 타입일 때 모드팩 프롬프트 추가
   - `executeWithConfig()`: 모드팩 슬러그 필수 검증, 6G 기본 메모리

3. **Domain 모델**
   - `Server.modpackOptions`: ModpackOptions getter 추가
   - `CreateServerConfig`: modpackSlug/modpackVersion/modLoader 필드 추가

### 테스트
- CreateServerUseCase integration 테스트 추가
- MODRINTH 타입 서버 생성, 기본값, 검증 테스트

## Checklist
- [x] CLI 인자 모드 구현
- [x] 인터랙티브 모드 구현
- [x] 서버 타입 그룹핑
- [x] MODRINTH 선택 시 Version 프롬프트 스킵
- [x] 모드팩용 6G 기본 메모리
- [x] Domain 모델 업데이트
- [x] 테스트 작성
- [x] TypeScript 빌드 성공

## Related Issues
- Implements #244
- Depends on #242 (Domain Model)
- Depends on #243 (Infrastructure)

🤖 Generated with Claude Code