### PR TITLE
refactor(cli): isolate service node_modules into .services/ directory (#262)

### DIFF
--- a/platform/services/shared/src/utils/index.ts
+++ b/platform/services/shared/src/utils/index.ts
@@ -177,6 +177,11 @@ export class Paths {
     return join(this.dataDir, 'backups');
   }
 
+  /** Services installation directory (.services/) - isolates node_modules from user data */
+  get services(): string {
+    return join(this.dataDir, '.services');
+  }
+
   /** .env file path */
   get envFile(): string {
     return join(this.dataDir, '.env');


### PR DESCRIPTION
## Summary
- Service npm packages (mcctl-api, mcctl-console, shared) are now installed into `MCCTL_ROOT/.services/` instead of directly in `MCCTL_ROOT/`
- Prevents `node_modules/`, `package.json`, `package-lock.json` from polluting the user data directory
- All path resolution checks `.services/` first, then falls back to legacy `rootDir/node_modules/` for backward compatibility
- **No migration required** for existing installations - they continue to work via legacy fallback

## Changes
- `shared/src/utils/index.ts`: Added `services` getter to `Paths` class
- `cli/src/lib/pm2-utils.ts`: Updated `resolveServiceScriptPaths` to check `.services/` first
- `cli/src/commands/console/init.ts`: Install functions now target `.services/` directory
- `cli/src/commands/update.ts`: Version check and updates now use `.services/` directory

## Test plan
- [x] TypeScript compilation passes
- [x] Existing unit tests pass (no regressions)
- [ ] Manual test: `mcctl console init` installs packages into `.services/`
- [ ] Manual test: `mcctl update --all` updates packages in `.services/`
- [ ] Manual test: Legacy installations still detected and work correctly

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)