### PR TITLE
fix: CLI test timeout and e2e workflow issues (#269)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -161,8 +161,8 @@ jobs:
           fi
 
           # Count failed tests
-          FAILED_COUNT=$(find e2e/test-results -name "*.json" -exec cat {} \; 2>/dev/null | grep -c '"status":"failed"' || echo "0")
-          echo "failed_count=$FAILED_COUNT" >> "$GITHUB_OUTPUT"
+          FAILED_COUNT=$(find e2e/test-results -name "*.json" -exec cat {} \; 2>/dev/null | { grep -c '"status":"failed"' || true; })
+          echo "failed_count=${FAILED_COUNT:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Create bug issue on failure
         if: failure()

--- a/platform/services/cli/tests/unit/commands/console/service-force.test.ts
+++ b/platform/services/cli/tests/unit/commands/console/service-force.test.ts
@@ -50,6 +50,12 @@ vi.mock('@minecraft-docker/shared', async () => {
   };
 });
 
+// Mock @clack/prompts (prevent interactive prompts from blocking tests)
+vi.mock('@clack/prompts', () => ({
+  select: vi.fn().mockResolvedValue('all'),
+  isCancel: vi.fn().mockReturnValue(false),
+}));
+
 // Mock pm2-utils
 vi.mock('../../../../src/lib/pm2-utils.js', () => ({
   checkPm2Installation: vi.fn().mockReturnValue({ installed: true, version: '5.0.0' }),


### PR DESCRIPTION
## Summary
- **CLI test timeout**: `service-force.test.ts`의 6개 테스트가 `@clack/prompts.select()` mock 누락으로 30초 타임아웃 발생. mock 추가하여 해결
- **E2E GITHUB_OUTPUT 포맷 에러**: `grep -c || echo "0"` 패턴이 multi-line 값을 생성하여 `Invalid format '0'` 에러 발생. subshell 패턴으로 수정
- **e2e-failure 라벨**: E2E 워크플로우의 자동 이슈 생성에 필요한 `e2e-failure` 라벨 생성

## Test plan
- [x] `service-force.test.ts` 6개 테스트 모두 통과 (30s 타임아웃 → ~7s)
- [x] 기존 테스트 회귀 없음

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)