### PR TITLE
feat(cli): MODRINTH Modpack Server Creation Support (#244)

### DIFF
--- a/platform/services/cli/tests/unit/commands/create.test.ts
+++ b/platform/services/cli/tests/unit/commands/create.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createCommand, type CreateCommandOptions } from '../../../src/commands/create.js';
+import { Paths } from '@minecraft-docker/shared';
+import * as container from '../../../src/infrastructure/di/container.js';
+
+/**
+ * Unit tests for create command with MODRINTH modpack support
+ * Tests follow TDD approach: Red → Green → Refactor
+ */
+describe('create command - MODRINTH modpack support', () => {
+  let mockContainer: ReturnType<typeof container.getContainer>;
+  let mockCreateServerUseCase: {
+    execute: ReturnType<typeof vi.fn>;
+    executeWithConfig: ReturnType<typeof vi.fn>;
+  };
+  let mockPromptPort: {
+    isCancel: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    // Mock container
+    mockCreateServerUseCase = {
+      execute: vi.fn(),
+      executeWithConfig: vi.fn(),
+    };
+    mockPromptPort = {
+      isCancel: vi.fn().mockReturnValue(false),
+    };
+
+    mockContainer = {
+      createServerUseCase: mockCreateServerUseCase,
+      promptPort: mockPromptPort,
+    } as unknown as ReturnType<typeof container.getContainer>;
+
+    vi.spyOn(container, 'getContainer').mockReturnValue(mockContainer);
+
+    // Mock Paths
+    vi.spyOn(Paths.prototype, 'isInitialized').mockReturnValue(true);
+
+    // Mock sudo password prompt
+    vi.mock('../../../src/lib/sudo-utils.js', () => ({
+      promptSudoPasswordIfNeeded: vi.fn().mockResolvedValue(undefined),
+    }));
+  });
+
+  describe('CLI argument mode with MODRINTH type', () => {
+    it('should pass modpack options to executeWithConfig when --modpack is provided', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'MODRINTH',
+        modpack: 'cobblemon',
+        modpackVersion: '1.3.2',
+        modLoader: 'fabric',
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver' },
+        containerName: 'mc-myserver',
+        type: { label: 'Modrinth Modpack', isModpack: true },
+        version: { value: 'LATEST' },
+        memory: { value: '6G' },
+        modpackOptions: {
+          slug: 'cobblemon',
+          version: '1.3.2',
+          loader: 'fabric',
+        },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      expect(mockCreateServerUseCase.executeWithConfig).toHaveBeenCalledWith({
+        name: 'myserver',
+        type: 'MODRINTH',
+        version: undefined,
+        seed: undefined,
+        worldUrl: undefined,
+        worldName: undefined,
+        autoStart: true,
+        modpackSlug: 'cobblemon',
+        modpackVersion: '1.3.2',
+        modLoader: 'fabric',
+      });
+    });
+
+    it('should pass only slug if version and loader are not provided', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'MODRINTH',
+        modpack: 'cobblemon',
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver' },
+        containerName: 'mc-myserver',
+        type: { label: 'Modrinth Modpack', isModpack: true },
+        version: { value: 'LATEST' },
+        memory: { value: '6G' },
+        modpackOptions: {
+          slug: 'cobblemon',
+        },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      expect(mockCreateServerUseCase.executeWithConfig).toHaveBeenCalledWith({
+        name: 'myserver',
+        type: 'MODRINTH',
+        version: undefined,
+        seed: undefined,
+        worldUrl: undefined,
+        worldName: undefined,
+        autoStart: true,
+        modpackSlug: 'cobblemon',
+        modpackVersion: undefined,
+        modLoader: undefined,
+      });
+    });
+
+    it('should fail early when MODRINTH type is used without --modpack (validation)', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'MODRINTH',
+        // modpack is missing
+        noStart: false,
+      };
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(1);
+      // Should fail before calling use case (early validation)
+      expect(mockCreateServerUseCase.executeWithConfig).not.toHaveBeenCalled();
+    });
+
+    it('should warn when --modpack is used with non-modpack type', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'PAPER',
+        modpack: 'cobblemon', // Should be ignored for PAPER
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver' },
+        containerName: 'mc-myserver',
+        type: { label: 'Paper', isModpack: false },
+        version: { value: '1.21.1' },
+        memory: { value: '4G' },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      // modpackSlug should still be passed, but use case should handle validation
+      expect(mockCreateServerUseCase.executeWithConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'PAPER',
+          modpackSlug: 'cobblemon', // Passed but should be validated by use case
+        })
+      );
+    });
+  });
+
+  describe('Output formatting for modpack servers', () => {
+    it('should display modpack information in success output', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'MODRINTH',
+        modpack: 'cobblemon',
+        modpackVersion: '1.3.2',
+        modLoader: 'fabric',
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver' },
+        containerName: 'mc-myserver',
+        type: { label: 'Modrinth Modpack', isModpack: true },
+        version: { value: 'LATEST' },
+        memory: { value: '6G' },
+        modpackOptions: {
+          slug: 'cobblemon',
+          version: '1.3.2',
+          loader: 'fabric',
+        },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // Mock console.log to capture output
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+
+      // Verify modpack info is logged
+      const loggedOutput = consoleLogSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+      expect(loggedOutput).toContain('Modpack: cobblemon');
+      expect(loggedOutput).toContain('Modpack Version: 1.3.2');
+      expect(loggedOutput).toContain('Mod Loader: fabric');
+
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should display standard version for non-modpack servers', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'PAPER',
+        version: '1.21.1',
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver' },
+        containerName: 'mc-myserver',
+        type: { label: 'Paper', isModpack: false },
+        version: { value: '1.21.1' },
+        memory: { value: '4G' },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // Mock console.log to capture output
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+
+      // Verify standard version is logged
+      const loggedOutput = consoleLogSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+      expect(loggedOutput).toContain('Version: 1.21.1');
+      expect(loggedOutput).not.toContain('Modpack:');
+
+      consoleLogSpy.mockRestore();
+    });
+  });
+
+  describe('Interactive mode with MODRINTH', () => {
+    it('should use execute() for interactive mode when no name is provided', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        // name is not provided → interactive mode
+      };
+
+      mockCreateServerUseCase.execute.mockResolvedValue({
+        name: { value: 'myserver' },
+        containerName: 'mc-myserver',
+        type: { label: 'Modrinth Modpack', isModpack: true },
+        version: { value: 'LATEST' },
+        memory: { value: '6G' },
+        modpackOptions: {
+          slug: 'cobblemon',
+        },
+      });
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      expect(mockCreateServerUseCase.execute).toHaveBeenCalled();
+      expect(mockCreateServerUseCase.executeWithConfig).not.toHaveBeenCalled();
+    });
+
+    it('should handle user cancellation gracefully', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {};
+
+      mockPromptPort.isCancel.mockReturnValue(true);
+      mockCreateServerUseCase.execute.mockRejectedValue(new Error('CANCELLED'));
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0); // User cancellation should return 0
+      expect(mockCreateServerUseCase.execute).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #244

CLI에서 MODRINTH 모드팩 서버 생성 기능에 대한 검증 로직 추가 및 테스트 작성.

## Changes

### CLI Validation (create.ts)
- MODRINTH 타입에 `--modpack` 필수 검증 추가
- 일반 서버 타입에 `--modpack` 사용 시 경고 추가
- `validateModpackOptions()` 헬퍼 함수 추출

### Testing (create.test.ts)
- 8개 unit tests 추가 (모두 통과)
- CLI 인자 모드 테스트
- 검증 로직 테스트
- 출력 포맷 테스트
- 인터랙티브 모드 테스트

## Implementation Details

### Validation Rules
```typescript
// MODRINTH without --modpack → Error
mcctl create myserver -t MODRINTH
// Error: --modpack <slug> is required when using -t MODRINTH

// Valid usage
mcctl create myserver -t MODRINTH --modpack cobblemon

// Non-modpack with --modpack → Warning (ignored)
mcctl create myserver -t PAPER --modpack cobblemon
// Warning: --modpack option is only used for modpack server types
```

### Test Coverage
- ✅ Pass modpack options to executeWithConfig
- ✅ Pass only slug if version/loader not provided
- ✅ Fail early when MODRINTH without --modpack
- ✅ Warn when --modpack with non-modpack type
- ✅ Display modpack info in success output
- ✅ Display standard version for non-modpack
- ✅ Interactive mode uses execute()
- ✅ Handle user cancellation gracefully

## Development Process (TDD)

1. **RED**: Write failing test for validation
2. **GREEN**: Implement validation logic
3. **REFACTOR**: Extract helper function
4. **VERIFY**: All tests passing (8/8)

## Pre-existing Features (Already Implemented)

Most features were already implemented in:
- `CreateCommandOptions` (modpack fields) ✅
- Commander options (--modpack, --modpack-version, --mod-loader) ✅
- `ClackPromptAdapter` (modpack prompts) ✅
- `CreateServerUseCase` (modpack logic) ✅
- Output formatting (modpack info display) ✅

**This PR adds:**
- CLI-level validation for better UX
- Comprehensive test coverage (was missing)

## Testing

```bash
cd platform/services/cli
npm run build        # ✅ Pass
npm run test         # ✅ 8/8 tests passing
```

## Related Issues

- Depends on #242 (F-020: MODRINTH Domain Model) ✅ Complete
- Depends on #243 (F-021: Infrastructure Support) ✅ Complete

## Usage Examples

### CLI Argument Mode
```bash
# Full options
mcctl create myserver -t MODRINTH --modpack cobblemon --mod-loader fabric --modpack-version 1.3.2

# Minimal (auto-detect loader and version)
mcctl create myserver -t MODRINTH --modpack cobblemon
```

### Interactive Mode
```
$ mcctl create

┌  Create Minecraft Server
│
◆  Server name?
│  myserver
│
◆  Server type?
│  ── Modpack Platforms ──
│  ● Modrinth Modpack
│
◆  Modrinth modpack slug or URL?
│  cobblemon
│
◆  Mod loader:
│  ● Auto-detect
│
└  ✓ Server 'myserver' created successfully!
   Modpack: cobblemon
```

## Checklist

- [x] TDD approach (Red → Green → Refactor)
- [x] All tests passing (8/8)
- [x] Build successful
- [x] Follows Clean Architecture
- [x] Commit message follows convention
- [x] Co-Authored-By added