### PR TITLE
fix(api,console): return UUID in whitelist/ban API responses (#303)

### DIFF
--- a/platform/services/mcctl-api/src/schemas/player.ts
+++ b/platform/services/mcctl-api/src/schemas/player.ts
@@ -16,6 +16,22 @@ export const OnlinePlayersResponseSchema = Type.Object({
   players: Type.Array(Type.String()),
 });
 
+// Whitelist entry
+export const WhitelistEntrySchema = Type.Object({
+  name: Type.String(),
+  uuid: Type.String(),
+});
+
+// Banned player entry
+export const BannedPlayerEntrySchema = Type.Object({
+  name: Type.String(),
+  uuid: Type.String(),
+  reason: Type.String(),
+  created: Type.String(),
+  source: Type.String(),
+  expires: Type.String(),
+});
+
 // Player list (whitelist, bans, ops)
 export const PlayerListResponseSchema = Type.Object({
   players: Type.Array(Type.String()),
@@ -25,6 +41,24 @@ export const PlayerListResponseSchema = Type.Object({
     Type.Literal('file'),
     Type.Literal('config'),
   ])),
+});
+
+// Whitelist response
+export const WhitelistResponseSchema = Type.Object({
+  players: Type.Array(WhitelistEntrySchema),
+  total: Type.Number(),
+  source: Type.Optional(Type.Union([
+    Type.Literal('rcon'),
+    Type.Literal('file'),
+    Type.Literal('config'),
+  ])),
+});
+
+// Banned players response
+export const BannedPlayersResponseSchema = Type.Object({
+  players: Type.Array(BannedPlayerEntrySchema),
+  total: Type.Number(),
+  source: Type.Literal('file'),
 });
 
 // Add player request
@@ -67,6 +101,10 @@ export { ErrorResponseSchema };
 export type PlayerInfo = Static<typeof PlayerInfoSchema>;
 export type OnlinePlayersResponse = Static<typeof OnlinePlayersResponseSchema>;
 export type PlayerListResponse = Static<typeof PlayerListResponseSchema>;
+export type WhitelistEntry = Static<typeof WhitelistEntrySchema>;
+export type BannedPlayerEntry = Static<typeof BannedPlayerEntrySchema>;
+export type WhitelistResponse = Static<typeof WhitelistResponseSchema>;
+export type BannedPlayersResponse = Static<typeof BannedPlayersResponseSchema>;
 export type AddPlayerRequest = Static<typeof AddPlayerRequestSchema>;
 export type KickPlayerRequest = Static<typeof KickPlayerRequestSchema>;
 export type PlayerActionResponse = Static<typeof PlayerActionResponseSchema>;

--- a/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
+++ b/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
@@ -25,6 +25,8 @@ import {
   BackupHistoryResponse,
   BackupRestoreResponse,
   PlayerListResponse,
+  WhitelistResponse,
+  BannedPlayersResponse,
   PlayerActionResponse,
   OperatorsListResponse,
   OperatorActionResponse,
@@ -306,8 +308,8 @@ export class McctlApiAdapter implements IMcctlApiClient {
   // Player Management Operations
   // ============================================================
 
-  async getWhitelist(serverName: string): Promise<PlayerListResponse> {
-    return this.fetch<PlayerListResponse>(
+  async getWhitelist(serverName: string): Promise<WhitelistResponse> {
+    return this.fetch<WhitelistResponse>(
       `/api/servers/${encodeURIComponent(serverName)}/whitelist`
     );
   }
@@ -326,8 +328,8 @@ export class McctlApiAdapter implements IMcctlApiClient {
     );
   }
 
-  async getBans(serverName: string): Promise<PlayerListResponse> {
-    return this.fetch<PlayerListResponse>(
+  async getBans(serverName: string): Promise<BannedPlayersResponse> {
+    return this.fetch<BannedPlayersResponse>(
       `/api/servers/${encodeURIComponent(serverName)}/bans`
     );
   }

--- a/platform/services/mcctl-console/src/app/api/players/ban/route.ts
+++ b/platform/services/mcctl-console/src/app/api/players/ban/route.ts
@@ -38,15 +38,8 @@ export async function GET(request: NextRequest) {
 
     const result = await client.getBans(server);
 
-    const players = result.players.map((name) => ({
-      name,
-      uuid: '',
-      reason: '',
-      created: '',
-      source: '',
-    }));
-
-    return NextResponse.json({ players, source: result.source });
+    // API now returns players with full ban details, pass through directly
+    return NextResponse.json({ players: result.players, source: result.source });
   } catch (error) {
     if (error instanceof AuthError) {
       return NextResponse.json(

--- a/platform/services/mcctl-console/src/app/api/players/whitelist/route.ts
+++ b/platform/services/mcctl-console/src/app/api/players/whitelist/route.ts
@@ -38,9 +38,8 @@ export async function GET(request: NextRequest) {
 
     const result = await client.getWhitelist(server);
 
-    const players = result.players.map((name) => ({ name, uuid: '' }));
-
-    return NextResponse.json({ players, source: result.source });
+    // API now returns players with UUID, pass through directly
+    return NextResponse.json({ players: result.players, source: result.source });
   } catch (error) {
     if (error instanceof AuthError) {
       return NextResponse.json(

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -298,10 +298,36 @@ export interface BackupRestoreResponse {
 
 export type PlayerDataSource = 'rcon' | 'file' | 'config';
 
+export interface WhitelistEntry {
+  name: string;
+  uuid: string;
+}
+
+export interface BannedPlayerEntry {
+  name: string;
+  uuid: string;
+  reason: string;
+  created: string;
+  source: string;
+  expires: string;
+}
+
 export interface PlayerListResponse {
   players: string[];
   total: number;
   source?: PlayerDataSource;
+}
+
+export interface WhitelistResponse {
+  players: WhitelistEntry[];
+  total: number;
+  source?: PlayerDataSource;
+}
+
+export interface BannedPlayersResponse {
+  players: BannedPlayerEntry[];
+  total: number;
+  source: 'file';
 }
 
 export interface PlayerActionResponse {
@@ -379,10 +405,10 @@ export interface IMcctlApiClient {
   restoreBackup(commitHash: string): Promise<BackupRestoreResponse>;
 
   // Player management operations
-  getWhitelist(serverName: string): Promise<PlayerListResponse>;
+  getWhitelist(serverName: string): Promise<WhitelistResponse>;
   addToWhitelist(serverName: string, player: string): Promise<PlayerActionResponse>;
   removeFromWhitelist(serverName: string, player: string): Promise<PlayerActionResponse>;
-  getBans(serverName: string): Promise<PlayerListResponse>;
+  getBans(serverName: string): Promise<BannedPlayersResponse>;
   banPlayer(serverName: string, player: string, reason?: string): Promise<PlayerActionResponse>;
   unbanPlayer(serverName: string, player: string): Promise<PlayerActionResponse>;
 


### PR DESCRIPTION
## Summary
화이트리스트와 밴 목록 API에서 플레이어 UUID가 "UUID not available"로 표시되는 버그 수정

## Root Cause
데이터가 3개 계층에서 UUID를 누락시킴:
1. **PlayerFileService**: 파일에서 `{uuid, name}` 읽지만 이름만 반환
2. **mcctl-api routes**: API 응답에서 이름 배열만 반환
3. **mcctl-console BFF routes**: 빈 UUID로 덮어씀

## Changes

### mcctl-api
- `PlayerFileService.readWhitelist()`: `{name, uuid}[]` 반환
- `PlayerFileService.readBannedPlayers()`: `{name, uuid, reason, created, source, expires}[]` 반환
- WhitelistResponse, BannedPlayersResponse 스키마 추가
- GET `/api/servers/:name/whitelist`: WhitelistResponse 사용
- GET `/api/servers/:name/bans`: BannedPlayersResponse 사용

### mcctl-console
- IMcctlApiClient에 WhitelistResponse, BannedPlayersResponse 타입 추가
- McctlApiAdapter: getWhitelist(), getBans() 반환 타입 변경
- BFF whitelist/ban routes: API 응답의 UUID 그대로 전달
- 테스트 모킹 업데이트 (mockGetWhitelist, mockGetBans 등)

## Test Plan
- [x] mcctl-api 테스트 통과 (PlayerFileService)
- [x] mcctl-console BFF 테스트 통과 (players routes)
- [x] UUID가 화이트리스트/밴 목록에 올바르게 표시되는지 수동 확인 필요

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)