### PR TITLE
feat(console): apply responsive grid layout to settings page

### DIFF
--- a/platform/services/mcctl-console/src/app/(main)/settings/page.tsx
+++ b/platform/services/mcctl-console/src/app/(main)/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
@@ -40,11 +41,17 @@ export default function SettingsPage() {
         </Typography>
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, maxWidth: 700 }}>
-        <ProfileSection onSuccess={handleSuccess} onError={handleError} />
-        <PasswordSection onSuccess={handleSuccess} onError={handleError} />
-        <AccountInfoSection />
-      </Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <ProfileSection onSuccess={handleSuccess} onError={handleError} />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <AccountInfoSection />
+        </Grid>
+        <Grid item xs={12}>
+          <PasswordSection onSuccess={handleSuccess} onError={handleError} />
+        </Grid>
+      </Grid>
 
       <Snackbar
         open={snackbar.open}

--- a/platform/services/mcctl-console/src/components/settings/AccountInfoSection.tsx
+++ b/platform/services/mcctl-console/src/components/settings/AccountInfoSection.tsx
@@ -33,7 +33,7 @@ export function AccountInfoSection() {
   if (!user) return null;
 
   return (
-    <Card>
+    <Card sx={{ height: '100%' }}>
       <CardContent>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
           <InfoIcon color="primary" />

--- a/platform/services/mcctl-console/src/components/settings/ProfileSection.tsx
+++ b/platform/services/mcctl-console/src/components/settings/ProfileSection.tsx
@@ -56,7 +56,7 @@ export function ProfileSection({ onSuccess, onError }: ProfileSectionProps) {
   if (!user) return null;
 
   return (
-    <Card>
+    <Card sx={{ height: '100%' }}>
       <CardContent>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
           <PersonIcon color="primary" />


### PR DESCRIPTION
## Summary
Closes #310

Settings 페이지에 반응형 그리드 레이아웃을 적용했습니다.

## Changes
- `settings/page.tsx`: MUI Grid를 사용하여 반응형 레이아웃 구현
- `ProfileSection.tsx`: Card에 `height: 100%` 추가하여 동일 높이 유지
- `AccountInfoSection.tsx`: Card에 `height: 100%` 추가하여 동일 높이 유지

## Layout
**Desktop (md+)**:
```
┌──────────────┐ ┌──────────────┐
│   Profile    │ │ Account Info │
└──────────────┘ └──────────────┘
┌─────────────────────────────────┐
│       Change Password           │
└─────────────────────────────────┘
```

**Mobile (xs-sm)**: 모든 섹션이 세로로 나열됩니다.

## Test Plan
- [x] 빌드 성공 확인
- [x] 기존 테스트 통과 (Settings 관련 테스트 포함)
- [ ] 브라우저에서 데스크톱/모바일 반응형 동작 확인

## Screenshots
(사용자가 배포 후 확인)

🤖 Generated with Claude Code