### PR TITLE
feat: add hostname/domain management to server Options tab

### DIFF
--- a/platform/services/mcctl-api/src/app.ts
+++ b/platform/services/mcctl-api/src/app.ts
@@ -7,6 +7,7 @@ import swaggerPlugin from './plugins/swagger.js';
 import serversRoutes from './routes/servers.js';
 import serverActionsRoutes from './routes/servers/actions.js';
 import serverConfigRoutes from './routes/servers/config.js';
+import serverHostnameRoutes from './routes/servers/hostnames.js';
 import consoleRoutes from './routes/console.js';
 import worldsRoutes from './routes/worlds.js';
 import authRoutes from './routes/auth.js';
@@ -57,6 +58,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await app.register(serversRoutes);
   await app.register(serverActionsRoutes);
   await app.register(serverConfigRoutes);
+  await app.register(serverHostnameRoutes);
 
   // Register router routes
   await app.register(routerRoutes);

--- a/platform/services/mcctl-api/src/routes/servers/hostnames.ts
+++ b/platform/services/mcctl-api/src/routes/servers/hostnames.ts
@@ -1,0 +1,170 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+import { serverExists } from '@minecraft-docker/shared';
+import {
+  HostnameResponseSchema,
+  UpdateCustomHostnamesRequestSchema,
+  UpdateHostnamesResponseSchema,
+  type UpdateCustomHostnamesRequest,
+} from '../../schemas/hostname.js';
+import { ErrorResponseSchema, ServerNameParamsSchema, type ServerNameParams } from '../../schemas/server.js';
+import { config } from '../../config/index.js';
+import { createHostnameService } from '../../services/HostnameService.js';
+
+// ============================================================
+// Types
+// ============================================================
+
+interface GetHostnamesRoute {
+  Params: ServerNameParams;
+}
+
+interface UpdateHostnamesRoute {
+  Params: ServerNameParams;
+  Body: UpdateCustomHostnamesRequest;
+}
+
+// ============================================================
+// Plugin Definition
+// ============================================================
+
+/**
+ * Server hostname routes plugin
+ * Provides REST API for hostname/domain management
+ */
+const hostnamesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+  const hostnameService = createHostnameService(config.platformPath);
+
+  /**
+   * GET /api/servers/:name/hostnames
+   * Get server hostnames with system/custom classification
+   */
+  fastify.get<GetHostnamesRoute>('/api/servers/:name/hostnames', {
+    schema: {
+      description: 'Get server hostnames with system/custom classification',
+      tags: ['servers', 'hostnames'],
+      params: ServerNameParamsSchema,
+      response: {
+        200: HostnameResponseSchema,
+        404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<GetHostnamesRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+
+    try {
+      if (!serverExists(name)) {
+        return reply.code(404).send({
+          error: 'NotFound',
+          message: `Server '${name}' not found`,
+        });
+      }
+
+      if (!hostnameService.composeExists(name)) {
+        return reply.code(404).send({
+          error: 'NotFound',
+          message: `Docker compose file for server '${name}' not found`,
+        });
+      }
+
+      const data = hostnameService.getHostnames(name);
+
+      return reply.send({
+        serverName: data.serverName,
+        hostnames: data.hostnames,
+        systemHostnames: data.systemHostnames,
+        customHostnames: data.customHostnames,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get server hostnames');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to get server hostnames',
+      });
+    }
+  });
+
+  /**
+   * PUT /api/servers/:name/hostnames
+   * Update custom hostnames (replaces all custom hostnames)
+   */
+  fastify.put<UpdateHostnamesRoute>('/api/servers/:name/hostnames', {
+    schema: {
+      description: 'Update custom hostnames for a server (replaces all custom hostnames)',
+      tags: ['servers', 'hostnames'],
+      params: ServerNameParamsSchema,
+      body: UpdateCustomHostnamesRequestSchema,
+      response: {
+        200: UpdateHostnamesResponseSchema,
+        400: ErrorResponseSchema,
+        404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<UpdateHostnamesRoute>, reply: FastifyReply) => {
+    const { name } = request.params;
+    const { customHostnames } = request.body;
+
+    try {
+      if (!serverExists(name)) {
+        return reply.code(404).send({
+          error: 'NotFound',
+          message: `Server '${name}' not found`,
+        });
+      }
+
+      if (!hostnameService.composeExists(name)) {
+        return reply.code(404).send({
+          error: 'NotFound',
+          message: `Docker compose file for server '${name}' not found`,
+        });
+      }
+
+      const data = hostnameService.updateCustomHostnames(name, customHostnames);
+
+      fastify.log.info({
+        server: name,
+        customHostnames: data.customHostnames,
+      }, 'Server hostnames updated');
+
+      return reply.send({
+        success: true,
+        serverName: data.serverName,
+        hostnames: data.hostnames,
+        systemHostnames: data.systemHostnames,
+        customHostnames: data.customHostnames,
+        recreateRequired: true,
+      });
+    } catch (error) {
+      if (error instanceof Error && (
+        error.message.includes('Duplicate') ||
+        error.message.includes('Invalid') ||
+        error.message.includes('Cannot use') ||
+        error.message.includes('must be between')
+      )) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: error.message,
+        });
+      }
+
+      fastify.log.error(error, 'Failed to update server hostnames');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to update server hostnames',
+      });
+    }
+  });
+};
+
+// ============================================================
+// Export
+// ============================================================
+
+export default fp(hostnamesPlugin, {
+  name: 'server-hostname-routes',
+  fastify: '5.x',
+});
+
+export { hostnamesPlugin };

--- a/platform/services/mcctl-api/src/schemas/hostname.ts
+++ b/platform/services/mcctl-api/src/schemas/hostname.ts
@@ -1,0 +1,79 @@
+import { Type, Static } from '@sinclair/typebox';
+
+// ============================================================
+// Hostname Management Schemas
+// ============================================================
+
+/**
+ * Hostname type classification
+ */
+export const HostnameTypeSchema = Type.Union([
+  Type.Literal('system'),
+  Type.Literal('custom'),
+]);
+
+/**
+ * Single hostname info with classification
+ */
+export const HostnameInfoSchema = Type.Object({
+  hostname: Type.String(),
+  type: HostnameTypeSchema,
+  description: Type.Optional(Type.String()),
+});
+
+/**
+ * Full hostname data for a server
+ */
+export const HostnameDataSchema = Type.Object({
+  serverName: Type.String(),
+  hostnames: Type.Array(Type.String(), { description: 'All hostnames (raw from docker-compose)' }),
+  systemHostnames: Type.Array(HostnameInfoSchema, { description: 'System-managed hostnames (read-only)' }),
+  customHostnames: Type.Array(Type.String(), { description: 'User-managed custom domains' }),
+});
+
+/**
+ * Request schema for updating custom hostnames
+ */
+export const UpdateCustomHostnamesRequestSchema = Type.Object({
+  customHostnames: Type.Array(
+    Type.String({
+      minLength: 1,
+      maxLength: 253,
+      pattern: '^[a-zA-Z0-9]([a-zA-Z0-9\\-\\.]*[a-zA-Z0-9])?$',
+    }),
+    { description: 'Custom domain hostnames to set (replaces all existing custom hostnames)' }
+  ),
+});
+
+/**
+ * Response schema for GET hostname
+ */
+export const HostnameResponseSchema = Type.Object({
+  serverName: Type.String(),
+  hostnames: Type.Array(Type.String()),
+  systemHostnames: Type.Array(HostnameInfoSchema),
+  customHostnames: Type.Array(Type.String()),
+});
+
+/**
+ * Response schema for PUT hostname update
+ */
+export const UpdateHostnamesResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  serverName: Type.String(),
+  hostnames: Type.Array(Type.String()),
+  systemHostnames: Type.Array(HostnameInfoSchema),
+  customHostnames: Type.Array(Type.String()),
+  recreateRequired: Type.Boolean({ description: 'Whether container recreation is needed' }),
+});
+
+// ============================================================
+// Type Exports
+// ============================================================
+
+export type HostnameType = Static<typeof HostnameTypeSchema>;
+export type HostnameInfo = Static<typeof HostnameInfoSchema>;
+export type HostnameData = Static<typeof HostnameDataSchema>;
+export type UpdateCustomHostnamesRequest = Static<typeof UpdateCustomHostnamesRequestSchema>;
+export type HostnameResponse = Static<typeof HostnameResponseSchema>;
+export type UpdateHostnamesResponse = Static<typeof UpdateHostnamesResponseSchema>;

--- a/platform/services/mcctl-api/src/services/HostnameService.ts
+++ b/platform/services/mcctl-api/src/services/HostnameService.ts
@@ -1,0 +1,221 @@
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import type { HostnameInfo, HostnameData } from '../schemas/hostname.js';
+
+/**
+ * Regex for matching mc-router.host label in docker-compose.yml
+ * Matches: mc-router.host: "hostname1,hostname2" (single or double quotes)
+ */
+const HOST_LABEL_REGEX = /(mc-router\.host:\s*["'])([^"']+)(["'])/;
+
+/**
+ * System hostname patterns
+ * - .local: mDNS hostname
+ * - .<IP>.nip.io: nip.io wildcard DNS
+ */
+const SYSTEM_LOCAL_PATTERN = /^[a-z0-9-]+\.local$/;
+const SYSTEM_NIPIO_PATTERN = /^[a-z0-9-]+\.\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\.nip\.io$/;
+
+/**
+ * HostnameService - Manages server hostname/domain configuration
+ * Reads and writes mc-router.host labels in server docker-compose.yml files
+ */
+export class HostnameService {
+  private readonly platformPath: string;
+
+  constructor(platformPath: string) {
+    this.platformPath = platformPath;
+  }
+
+  /**
+   * Get the path to a server's docker-compose.yml file
+   */
+  private getComposePath(serverName: string): string {
+    return join(this.platformPath, 'servers', serverName, 'docker-compose.yml');
+  }
+
+  /**
+   * Check if a server's docker-compose.yml exists
+   */
+  composeExists(serverName: string): boolean {
+    return existsSync(this.getComposePath(serverName));
+  }
+
+  /**
+   * Classify a hostname as system or custom
+   */
+  private classifyHostname(hostname: string, serverName: string): HostnameInfo {
+    const trimmed = hostname.trim().toLowerCase();
+
+    // Check for .local pattern (mDNS)
+    if (SYSTEM_LOCAL_PATTERN.test(trimmed) && trimmed === `${serverName}.local`) {
+      return {
+        hostname: trimmed,
+        type: 'system',
+        description: 'mDNS (Local Network)',
+      };
+    }
+
+    // Check for .nip.io pattern
+    if (SYSTEM_NIPIO_PATTERN.test(trimmed) && trimmed.startsWith(`${serverName}.`)) {
+      const ipMatch = trimmed.match(/^[a-z0-9-]+\.(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\.nip\.io$/);
+      const ip = ipMatch ? ipMatch[1] : '';
+      return {
+        hostname: trimmed,
+        type: 'system',
+        description: `nip.io (${ip})`,
+      };
+    }
+
+    return {
+      hostname: trimmed,
+      type: 'custom',
+    };
+  }
+
+  /**
+   * Parse hostnames from docker-compose.yml mc-router.host label
+   */
+  private parseHostnames(content: string): string[] {
+    const match = content.match(HOST_LABEL_REGEX);
+    if (!match) {
+      return [];
+    }
+    const hostValue = match[2];
+    if (!hostValue) return [];
+    return hostValue.split(',').map((h) => h.trim()).filter((h) => h);
+  }
+
+  /**
+   * Get hostname data for a server
+   */
+  getHostnames(serverName: string): HostnameData {
+    const composePath = this.getComposePath(serverName);
+
+    if (!existsSync(composePath)) {
+      throw new Error(`Server compose file not found: ${serverName}`);
+    }
+
+    const content = readFileSync(composePath, 'utf-8');
+    const rawHostnames = this.parseHostnames(content);
+
+    const classified = rawHostnames.map((h) => this.classifyHostname(h, serverName));
+    const systemHostnames = classified.filter((h) => h.type === 'system');
+    const customHostnames = classified.filter((h) => h.type === 'custom').map((h) => h.hostname);
+
+    return {
+      serverName,
+      hostnames: rawHostnames,
+      systemHostnames,
+      customHostnames,
+    };
+  }
+
+  /**
+   * Validate a custom hostname
+   * Returns error message if invalid, null if valid
+   */
+  validateCustomHostname(hostname: string, serverName: string): string | null {
+    const trimmed = hostname.trim().toLowerCase();
+
+    // Length check (RFC 1123)
+    if (trimmed.length === 0 || trimmed.length > 253) {
+      return `Hostname must be between 1 and 253 characters: ${hostname}`;
+    }
+
+    // RFC 1123 hostname validation
+    const hostnamePattern = /^[a-z0-9]([a-z0-9\-.]*[a-z0-9])?$/;
+    if (!hostnamePattern.test(trimmed)) {
+      return `Invalid hostname format (RFC 1123): ${hostname}`;
+    }
+
+    // Each label must be <= 63 characters
+    const labels = trimmed.split('.');
+    for (const label of labels) {
+      if (label.length > 63) {
+        return `Hostname label exceeds 63 characters: ${label}`;
+      }
+      if (label.startsWith('-') || label.endsWith('-')) {
+        return `Hostname label cannot start or end with hyphen: ${label}`;
+      }
+    }
+
+    // Block system hostname patterns
+    if (SYSTEM_LOCAL_PATTERN.test(trimmed)) {
+      return `Cannot use .local system hostname pattern: ${hostname}`;
+    }
+    if (SYSTEM_NIPIO_PATTERN.test(trimmed)) {
+      return `Cannot use .nip.io system hostname pattern: ${hostname}`;
+    }
+
+    return null;
+  }
+
+  /**
+   * Update custom hostnames for a server
+   * Preserves system hostnames and replaces all custom hostnames
+   */
+  updateCustomHostnames(
+    serverName: string,
+    customHostnames: string[]
+  ): HostnameData {
+    const composePath = this.getComposePath(serverName);
+
+    if (!existsSync(composePath)) {
+      throw new Error(`Server compose file not found: ${serverName}`);
+    }
+
+    // Validate all custom hostnames
+    const normalized = customHostnames.map((h) => h.trim().toLowerCase());
+
+    // Check for duplicates
+    const seen = new Set<string>();
+    for (const hostname of normalized) {
+      if (seen.has(hostname)) {
+        throw new Error(`Duplicate hostname: ${hostname}`);
+      }
+      seen.add(hostname);
+    }
+
+    // Validate each hostname
+    for (const hostname of normalized) {
+      const error = this.validateCustomHostname(hostname, serverName);
+      if (error) {
+        throw new Error(error);
+      }
+    }
+
+    // Read current compose file
+    let content = readFileSync(composePath, 'utf-8');
+    const currentHostnames = this.parseHostnames(content);
+
+    // Get system hostnames from current config
+    const systemHostnames = currentHostnames
+      .map((h) => this.classifyHostname(h, serverName))
+      .filter((h) => h.type === 'system')
+      .map((h) => h.hostname);
+
+    // Build new hostname string: system hostnames + custom hostnames
+    const newHostnames = [...systemHostnames, ...normalized].join(',');
+
+    // Replace in compose file
+    const match = content.match(HOST_LABEL_REGEX);
+    if (match) {
+      content = content.replace(HOST_LABEL_REGEX, `$1${newHostnames}$3`);
+    } else {
+      throw new Error(`mc-router.host label not found in docker-compose.yml for server: ${serverName}`);
+    }
+
+    writeFileSync(composePath, content, 'utf-8');
+
+    // Return updated data
+    return this.getHostnames(serverName);
+  }
+}
+
+/**
+ * Create a HostnameService instance
+ */
+export function createHostnameService(platformPath: string): HostnameService {
+  return new HostnameService(platformPath);
+}

--- a/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
+++ b/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
@@ -30,6 +30,8 @@ import {
   PlayerActionResponse,
   OperatorsListResponse,
   OperatorActionResponse,
+  HostnameResponse,
+  UpdateHostnamesResponse,
   ApiError,
 } from '../ports/api/IMcctlApiClient';
 
@@ -399,6 +401,26 @@ export class McctlApiAdapter implements IMcctlApiClient {
       message: response.message || `Added ${player} as operator`,
       source: response.source,
     }));
+  }
+
+  // ============================================================
+  // Hostname Management Operations
+  // ============================================================
+
+  async getHostnames(serverName: string): Promise<HostnameResponse> {
+    return this.fetch<HostnameResponse>(
+      `/api/servers/${encodeURIComponent(serverName)}/hostnames`
+    );
+  }
+
+  async updateHostnames(serverName: string, customHostnames: string[]): Promise<UpdateHostnamesResponse> {
+    return this.fetch<UpdateHostnamesResponse>(
+      `/api/servers/${encodeURIComponent(serverName)}/hostnames`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({ customHostnames }),
+      }
+    );
   }
 }
 

--- a/platform/services/mcctl-console/src/app/api/servers/[name]/hostnames/route.ts
+++ b/platform/services/mcctl-console/src/app/api/servers/[name]/hostnames/route.ts
@@ -1,0 +1,94 @@
+/**
+ * Server Hostnames API Route
+ * GET/PUT /api/servers/:name/hostnames
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createMcctlApiClient, McctlApiError, UserContext } from '@/adapters/McctlApiAdapter';
+import { requireServerPermission, AuthError } from '@/lib/auth-utils';
+import { headers } from 'next/headers';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ name: string }>;
+}
+
+function getUserContext(session: { user: { name?: string | null; email: string; role?: string | null } }): UserContext {
+  return {
+    username: session.user.name || session.user.email,
+    role: session.user.role || 'user',
+  };
+}
+
+/**
+ * GET /api/servers/:name/hostnames
+ * Fetch server hostnames
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { name } = await params;
+    const session = await requireServerPermission(await headers(), name, 'view');
+
+    const client = createMcctlApiClient(getUserContext(session));
+    const data = await client.getHostnames(name);
+
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: error.message },
+        { status: error.statusCode }
+      );
+    }
+    if (error instanceof McctlApiError) {
+      return NextResponse.json(
+        { error: error.error, message: error.message },
+        { status: error.statusCode }
+      );
+    }
+
+    console.error('Failed to fetch server hostnames:', error);
+    return NextResponse.json(
+      { error: 'InternalServerError', message: 'Failed to fetch server hostnames' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PUT /api/servers/:name/hostnames
+ * Update custom hostnames
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { name } = await params;
+    const session = await requireServerPermission(await headers(), name, 'manage');
+
+    const body = await request.json();
+
+    const client = createMcctlApiClient(getUserContext(session));
+    const data = await client.updateHostnames(name, body.customHostnames);
+
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: error.message },
+        { status: error.statusCode }
+      );
+    }
+    if (error instanceof McctlApiError) {
+      return NextResponse.json(
+        { error: error.error, message: error.message },
+        { status: error.statusCode }
+      );
+    }
+
+    console.error('Failed to update server hostnames:', error);
+    return NextResponse.json(
+      { error: 'InternalServerError', message: 'Failed to update server hostnames' },
+      { status: 500 }
+    );
+  }
+}

--- a/platform/services/mcctl-console/src/components/servers/HostnameSection.tsx
+++ b/platform/services/mcctl-console/src/components/servers/HostnameSection.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Chip from '@mui/material/Chip';
+import Alert from '@mui/material/Alert';
+import Divider from '@mui/material/Divider';
+import Stack from '@mui/material/Stack';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import LockIcon from '@mui/icons-material/Lock';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import LanguageIcon from '@mui/icons-material/Language';
+import CloseIcon from '@mui/icons-material/Close';
+import { useServerHostnames, useUpdateHostnames } from '@/hooks/useMcctl';
+
+interface HostnameSectionProps {
+  serverName: string;
+}
+
+export function HostnameSection({ serverName }: HostnameSectionProps) {
+  const { data, isLoading } = useServerHostnames(serverName);
+  const updateHostnames = useUpdateHostnames();
+
+  const [customDomains, setCustomDomains] = useState<string[]>([]);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [isAdding, setIsAdding] = useState(false);
+  const [newDomain, setNewDomain] = useState('');
+  const [newDomainError, setNewDomainError] = useState('');
+  const [savedSuccess, setSavedSuccess] = useState(false);
+
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error' | 'warning';
+  }>({ open: false, message: '', severity: 'success' });
+
+  // Sync state from API data
+  useEffect(() => {
+    if (data?.customHostnames) {
+      setCustomDomains(data.customHostnames);
+      setHasChanges(false);
+      setSavedSuccess(false);
+    }
+  }, [data]);
+
+  const validateDomain = (domain: string): string => {
+    const trimmed = domain.trim().toLowerCase();
+    if (!trimmed) return 'Domain cannot be empty';
+    if (trimmed.length > 253) return 'Domain exceeds 253 characters';
+
+    const hostnamePattern = /^[a-z0-9]([a-z0-9\-.]*[a-z0-9])?$/;
+    if (!hostnamePattern.test(trimmed)) return 'Invalid domain format';
+
+    if (trimmed.endsWith('.local')) return 'Cannot use .local system domain';
+    if (trimmed.endsWith('.nip.io')) return 'Cannot use .nip.io system domain';
+
+    if (customDomains.includes(trimmed)) return 'Domain already exists';
+
+    return '';
+  };
+
+  const handleAddDomain = () => {
+    const trimmed = newDomain.trim().toLowerCase();
+    const error = validateDomain(trimmed);
+
+    if (error) {
+      setNewDomainError(error);
+      return;
+    }
+
+    setCustomDomains((prev) => [...prev, trimmed]);
+    setNewDomain('');
+    setNewDomainError('');
+    setIsAdding(false);
+    setHasChanges(true);
+  };
+
+  const handleRemoveDomain = (domain: string) => {
+    setCustomDomains((prev) => prev.filter((d) => d !== domain));
+    setHasChanges(true);
+  };
+
+  const handleSave = async () => {
+    try {
+      await updateHostnames.mutateAsync({
+        serverName,
+        customHostnames: customDomains,
+      });
+
+      setHasChanges(false);
+      setSavedSuccess(true);
+      setSnackbar({
+        open: true,
+        message: 'Hostnames saved. Container recreation required to apply changes.',
+        severity: 'warning',
+      });
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: error instanceof Error ? error.message : 'Failed to save hostnames',
+        severity: 'error',
+      });
+    }
+  };
+
+  const handleCancelAdd = () => {
+    setIsAdding(false);
+    setNewDomain('');
+    setNewDomainError('');
+  };
+
+  if (isLoading) {
+    return (
+      <Card sx={{ mb: 3, borderRadius: 3 }}>
+        <CardContent>
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress size={24} />
+          </Box>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card sx={{ mb: 3, borderRadius: 3 }}>
+        <CardContent>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+            <LanguageIcon color="primary" />
+            <Typography variant="h6" fontWeight={600}>
+              Hostnames / Domains
+            </Typography>
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Manage hostnames used by mc-router to route connections to this server.
+          </Typography>
+          <Divider sx={{ mb: 3 }} />
+
+          {/* System Hostnames */}
+          {data?.systemHostnames && data.systemHostnames.length > 0 && (
+            <Box sx={{ mb: 3 }}>
+              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                System Hostnames (read-only)
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={1}>
+                {data.systemHostnames.map((h) => (
+                  <Chip
+                    key={h.hostname}
+                    icon={<LockIcon sx={{ fontSize: 16 }} />}
+                    label={h.hostname}
+                    title={h.description}
+                    variant="outlined"
+                    color="default"
+                    size="small"
+                  />
+                ))}
+              </Stack>
+            </Box>
+          )}
+
+          {/* Custom Domains */}
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+              Custom Domains
+            </Typography>
+
+            {customDomains.length === 0 && !isAdding && (
+              <Typography variant="body2" color="text.disabled" sx={{ mb: 1 }}>
+                No custom domains configured.
+              </Typography>
+            )}
+
+            <Stack spacing={1}>
+              {customDomains.map((domain) => (
+                <Box
+                  key={domain}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    py: 0.5,
+                    px: 1.5,
+                    borderRadius: 1,
+                    bgcolor: 'action.hover',
+                  }}
+                >
+                  <Typography variant="body2" fontFamily="monospace">
+                    {domain}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={() => handleRemoveDomain(domain)}
+                    title="Remove domain"
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              ))}
+            </Stack>
+
+            {/* Add Domain Inline */}
+            {isAdding ? (
+              <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mt: 1 }}>
+                <TextField
+                  size="small"
+                  placeholder="e.g. play.example.com"
+                  value={newDomain}
+                  onChange={(e) => {
+                    setNewDomain(e.target.value);
+                    setNewDomainError('');
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleAddDomain();
+                    if (e.key === 'Escape') handleCancelAdd();
+                  }}
+                  error={!!newDomainError}
+                  helperText={newDomainError}
+                  autoFocus
+                  sx={{ flex: 1 }}
+                />
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={handleAddDomain}
+                >
+                  Add
+                </Button>
+                <IconButton size="small" onClick={handleCancelAdd}>
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            ) : (
+              <Button
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={() => setIsAdding(true)}
+                sx={{ mt: 1 }}
+              >
+                Add Domain
+              </Button>
+            )}
+          </Box>
+
+          {/* Recreate Warning */}
+          {savedSuccess && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              Container recreation is required for hostname changes to take effect.
+              Run <code>docker compose up -d</code> or restart the server from the dashboard.
+            </Alert>
+          )}
+
+          {/* Save Button */}
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<SaveIcon />}
+              onClick={handleSave}
+              disabled={!hasChanges || updateHostnames.isPending}
+            >
+              {updateHostnames.isPending ? 'Saving...' : 'Save Hostnames'}
+            </Button>
+          </Box>
+        </CardContent>
+      </Card>
+
+      {/* Snackbar */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          severity={snackbar.severity}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/ServerOptionsTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerOptionsTab.tsx
@@ -27,6 +27,7 @@ import WarningIcon from '@mui/icons-material/Warning';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { useServerConfig, useUpdateServerConfig, useResetWorld } from '@/hooks/useMcctl';
+import { HostnameSection } from './HostnameSection';
 import type { Difficulty, GameMode, ServerConfig, UpdateServerConfigRequest } from '@/ports/api/IMcctlApiClient';
 
 interface ServerOptionsTabProps {
@@ -145,6 +146,9 @@ export function ServerOptionsTab({ serverName, isRunning }: ServerOptionsTabProp
 
   return (
     <Box>
+      {/* Hostname / Domain Section */}
+      <HostnameSection serverName={serverName} />
+
       {/* Performance Warning Alert */}
       {performanceChanged && (
         <Alert severity="warning" icon={<WarningIcon />} sx={{ mb: 3 }}>

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -204,6 +204,32 @@ export interface WorldResetResponse {
 }
 
 // ============================================================
+// Hostname Management Types
+// ============================================================
+
+export interface HostnameInfo {
+  hostname: string;
+  type: 'system' | 'custom';
+  description?: string;
+}
+
+export interface HostnameResponse {
+  serverName: string;
+  hostnames: string[];
+  systemHostnames: HostnameInfo[];
+  customHostnames: string[];
+}
+
+export interface UpdateHostnamesResponse {
+  success: boolean;
+  serverName: string;
+  hostnames: string[];
+  systemHostnames: HostnameInfo[];
+  customHostnames: string[];
+  recreateRequired: boolean;
+}
+
+// ============================================================
 // Router Status Types
 // ============================================================
 
@@ -421,4 +447,8 @@ export interface IMcctlApiClient {
   // Legacy OP operations (backwards compatibility)
   getOps(serverName: string): Promise<PlayerListResponse>;
   addOp(serverName: string, player: string): Promise<PlayerActionResponse>;
+
+  // Hostname management operations
+  getHostnames(serverName: string): Promise<HostnameResponse>;
+  updateHostnames(serverName: string, customHostnames: string[]): Promise<UpdateHostnamesResponse>;
 }


### PR DESCRIPTION
## Summary
- 서버 Options 탭에 호스트네임/도메인 관리 섹션 추가
- 시스템 호스트네임(`.local`, `.nip.io`)은 읽기 전용 표시
- 커스텀 도메인(playit.gg 등) 추가/삭제/저장 지원
- RFC 1123 유효성 검증, 중복 방지, 시스템 패턴 차단

## Changes

### Backend (mcctl-api)
- `schemas/hostname.ts`: Typebox 스키마 (HostnameInfo, UpdateCustomHostnamesRequest 등)
- `services/HostnameService.ts`: docker-compose.yml `mc-router.host` 라벨 파싱/갱신
- `routes/servers/hostnames.ts`: `GET/PUT /api/servers/:name/hostnames`
- `app.ts`: 라우트 플러그인 등록

### Frontend (mcctl-console)
- `IMcctlApiClient.ts`: Hostname 타입 + 인터페이스 메서드 추가
- `McctlApiAdapter.ts`: `getHostnames()`, `updateHostnames()` 구현
- `hostnames/route.ts`: BFF 프록시 (GET/PUT)
- `useMcctl.ts`: `useServerHostnames()`, `useUpdateHostnames()` React Query 훅
- `HostnameSection.tsx`: UI 컴포넌트 (시스템 Chip + 커스텀 CRUD + 저장)
- `ServerOptionsTab.tsx`: HostnameSection 통합 (Server Properties 위에 배치)

## Test plan
- [ ] `pnpm --filter mcctl-api build` 성공 확인
- [ ] `pnpm --filter mcctl-console build` 성공 확인
- [ ] GET `/api/servers/<name>/hostnames` → 시스템/커스텀 호스트네임 분류 확인
- [ ] PUT `/api/servers/<name>/hostnames` → 커스텀 도메인 교체 후 docker-compose.yml 갱신 확인
- [ ] Options 탭에서 시스템 호스트네임 읽기 전용 확인
- [ ] Options 탭에서 커스텀 도메인 추가/삭제/저장 동작 확인
- [ ] 저장 후 "컨테이너 재생성 필요" 경고 표시 확인

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)