### PR TITLE
fix(console): unify Add and Bulk button sizes in WhitelistManager

### DIFF
--- a/platform/services/mcctl-console/src/components/players/WhitelistManager.tsx
+++ b/platform/services/mcctl-console/src/components/players/WhitelistManager.tsx
@@ -233,10 +233,9 @@ export function WhitelistManager({ serverName }: WhitelistManagerProps) {
               setBulkMode(!bulkMode);
               setBulkResult(null);
             }}
-            size="small"
             aria-label="Toggle bulk mode"
             data-testid="bulk-toggle"
-            sx={{ minWidth: 'auto', whiteSpace: 'nowrap' }}
+            sx={{ whiteSpace: 'nowrap' }}
           >
             Bulk
           </Button>


### PR DESCRIPTION
## Summary
- Remove `size="small"` from Bulk toggle button to match Add button's default medium size

Closes #322

## Test plan
- [x] WhitelistManager tests pass (24/24)

🤖 Generated with [Claude Code](https://claude.ai/code)