### PR TITLE
feat(cli): add playit.gg domain registration to mcctl create (#272)

### DIFF
--- a/platform/scripts/create-server.sh
+++ b/platform/scripts/create-server.sh
@@ -25,6 +25,8 @@
 #   --whitelist PLAYERS  Initial whitelist players (comma-separated)
 #   --no-start           Don't start the server after creation
 #   --start              Start the server after creation (default)
+#   --playit-domain DOMAIN  Register playit.gg external domain (e.g., aa.example.com)
+#   --no-playit-domain   Skip playit domain registration (explicit)
 #
 # World options are mutually exclusive (only one can be specified).
 #
@@ -35,6 +37,7 @@
 #   ./scripts/create-server.sh myserver --seed 12345 --no-start
 #   ./scripts/create-server.sh myserver --world-url https://example.com/world.zip
 #   ./scripts/create-server.sh myserver --world existing-world --version 1.21.1
+#   ./scripts/create-server.sh myserver --playit-domain aa.example.com
 # =============================================================================
 
 set -e
@@ -156,6 +159,11 @@ build_hostnames() {
         done
     fi
 
+    # Add playit domain if set
+    if [ -n "${PLAYIT_DOMAIN:-}" ]; then
+        hostnames="$hostnames,$PLAYIT_DOMAIN"
+    fi
+
     echo "$hostnames"
 }
 
@@ -234,6 +242,8 @@ MOD_LOADER=""
 ENABLE_WHITELIST="true"
 WHITELIST_PLAYERS=""
 START_SERVER="true"
+PLAYIT_DOMAIN=""
+NO_PLAYIT_DOMAIN="false"
 
 # Show usage
 show_usage() {
@@ -255,6 +265,8 @@ show_usage() {
     echo "  --whitelist PLAYERS  Initial whitelist players (comma-separated)"
     echo "  --no-start           Don't start the server after creation"
     echo "  --start              Start the server after creation (default)"
+    echo "  --playit-domain DOMAIN  Register playit.gg external domain (e.g., aa.example.com)"
+    echo "  --no-playit-domain   Skip playit domain registration (explicit)"
     echo ""
     echo "World options (--seed, --world-url, --world) are mutually exclusive."
     echo ""
@@ -266,6 +278,7 @@ show_usage() {
     echo "  $0 myserver --world-url https://example.com/world.zip"
     echo "  $0 myserver --world existing-world -v 1.21.1 --no-start"
     echo "  $0 myserver -t MODRINTH --modpack fabric-example --modpack-version 1.0.0"
+    echo "  $0 myserver --playit-domain aa.example.com"
 }
 
 # Check if first argument exists
@@ -329,6 +342,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --start)
             START_SERVER="true"
+            shift
+            ;;
+        --playit-domain)
+            PLAYIT_DOMAIN="$2"
+            shift 2
+            ;;
+        --no-playit-domain)
+            NO_PLAYIT_DOMAIN="true"
             shift
             ;;
         -h|--help)
@@ -527,6 +548,14 @@ if [ -f "$CONFIG_FILE" ]; then
         else
             echo "   Whitelist: enabled (no initial players)"
         fi
+    fi
+
+    # Apply playit.gg domain if provided
+    if [ -n "$PLAYIT_DOMAIN" ]; then
+        echo "" >> "$CONFIG_FILE"
+        echo "# playit.gg External Domain" >> "$CONFIG_FILE"
+        echo "PLAYIT_DOMAIN=$PLAYIT_DOMAIN" >> "$CONFIG_FILE"
+        echo "   playit.gg domain: $PLAYIT_DOMAIN"
     fi
 fi
 

--- a/platform/services/cli/src/commands/create.ts
+++ b/platform/services/cli/src/commands/create.ts
@@ -25,6 +25,8 @@ export interface CreateCommandOptions {
   modpack?: string;
   modpackVersion?: string;
   modLoader?: string;
+  playitDomain?: string;
+  noPlayitDomain?: boolean;
 }
 
 /**
@@ -97,6 +99,8 @@ async function createWithArguments(
       whitelistPlayers: options.whitelist
         ? options.whitelist.split(',').map((p) => p.trim()).filter(Boolean)
         : undefined,
+      playitDomain: options.playitDomain,
+      noPlayitDomain: options.noPlayitDomain,
     });
 
     console.log('');

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -274,6 +274,8 @@ ${colors.cyan('Create Options:')}
   --modpack SLUG             Modrinth modpack slug (required for MODRINTH type)
   --modpack-version VERSION  Modpack version (optional, default: latest)
   --mod-loader LOADER        Mod loader (auto/fabric/forge/quilt, default: auto)
+  --playit-domain DOMAIN     Register playit.gg external domain (e.g., aa.example.com)
+  --no-playit-domain         Skip playit domain registration (explicit)
 
 ${colors.cyan('Status Options:')}
   --detail, -d               Show detailed info (memory, CPU, players)
@@ -348,7 +350,7 @@ function parseArgs(args: string[]): {
       const nextArg = args[i + 1];
 
       // Boolean-only flags (never take a value)
-      const booleanOnlyFlags = ['all', 'json', 'help', 'version', 'force', 'yes', 'follow', 'detail', 'watch', 'offline', 'no-start', 'no-whitelist', 'list', 'dry-run', 'api', 'console', 'build', 'no-build', 'keep-config', 'check', 'reconfigure', 'no-playit'];
+      const booleanOnlyFlags = ['all', 'json', 'help', 'version', 'force', 'yes', 'follow', 'detail', 'watch', 'offline', 'no-start', 'no-whitelist', 'list', 'dry-run', 'api', 'console', 'build', 'no-build', 'keep-config', 'check', 'reconfigure', 'no-playit', 'no-playit-domain'];
 
       if (booleanOnlyFlags.includes(key)) {
         result.flags[key] = true;
@@ -508,6 +510,8 @@ async function main(): Promise<void> {
           modpack: flags['modpack'] as string | undefined,
           modpackVersion: flags['modpack-version'] as string | undefined,
           modLoader: flags['mod-loader'] as string | undefined,
+          playitDomain: flags['playit-domain'] as string | undefined,
+          noPlayitDomain: flags['no-playit-domain'] === true,
         });
         break;
       }

--- a/platform/services/cli/src/infrastructure/di/container.ts
+++ b/platform/services/cli/src/infrastructure/di/container.ts
@@ -135,6 +135,7 @@ export class Container {
       this.promptPort,
       this.shellPort,
       this.serverRepository,
+      this.paths,
       this.worldRepository,
       this.auditLogPort,
       this.modSourcePort

--- a/platform/services/cli/tests/unit/commands/create.test.ts
+++ b/platform/services/cli/tests/unit/commands/create.test.ts
@@ -437,4 +437,102 @@ describe('create command - MODRINTH modpack support', () => {
       expect(mockCreateServerUseCase.execute).toHaveBeenCalled();
     });
   });
+
+  describe('playit.gg domain registration (#272)', () => {
+    it('should pass playit domain to executeWithConfig when --playit-domain is provided', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'PAPER',
+        playitDomain: 'aa.example.com',
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver', hostname: 'myserver.local' },
+        containerName: 'mc-myserver',
+        type: { label: 'Paper', isModpack: false },
+        version: { value: '1.21.1' },
+        memory: { value: '4G' },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      expect(mockCreateServerUseCase.executeWithConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'myserver',
+          type: 'PAPER',
+          playitDomain: 'aa.example.com',
+        })
+      );
+    });
+
+    it('should pass noPlayitDomain when --no-playit-domain is provided', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'PAPER',
+        noPlayitDomain: true,
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver', hostname: 'myserver.local' },
+        containerName: 'mc-myserver',
+        type: { label: 'Paper', isModpack: false },
+        version: { value: '1.21.1' },
+        memory: { value: '4G' },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      expect(mockCreateServerUseCase.executeWithConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'myserver',
+          noPlayitDomain: true,
+        })
+      );
+    });
+
+    it('should not pass playit options when neither flag is provided', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'PAPER',
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver', hostname: 'myserver.local' },
+        containerName: 'mc-myserver',
+        type: { label: 'Paper', isModpack: false },
+        version: { value: '1.21.1' },
+        memory: { value: '4G' },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      expect(mockCreateServerUseCase.executeWithConfig).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          playitDomain: expect.anything(),
+          noPlayitDomain: expect.anything(),
+        })
+      );
+    });
+  });
 });

--- a/platform/services/shared/src/application/ports/inbound/ICreateServerUseCase.ts
+++ b/platform/services/shared/src/application/ports/inbound/ICreateServerUseCase.ts
@@ -36,4 +36,6 @@ export interface CreateServerConfig {
   modLoader?: string;
   enableWhitelist?: boolean;
   whitelistPlayers?: string[];
+  playitDomain?: string;
+  noPlayitDomain?: boolean;
 }

--- a/platform/services/shared/src/application/ports/outbound/IShellPort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IShellPort.ts
@@ -147,6 +147,8 @@ export interface CreateServerOptions {
   modLoader?: string;
   enableWhitelist?: boolean;
   whitelistPlayers?: string[];
+  playitDomain?: string;
+  noPlayitDomain?: boolean;
 }
 
 /**

--- a/platform/services/shared/src/infrastructure/adapters/ShellAdapter.ts
+++ b/platform/services/shared/src/infrastructure/adapters/ShellAdapter.ts
@@ -121,6 +121,14 @@ export class ShellAdapter implements IShellPort {
       args.push('--whitelist', options.whitelistPlayers.join(','));
     }
 
+    // Add playit domain options
+    if (options.playitDomain) {
+      args.push('--playit-domain', options.playitDomain);
+    }
+    if (options.noPlayitDomain) {
+      args.push('--no-playit-domain');
+    }
+
     if (options.autoStart === false) {
       args.push('--no-start');
     }


### PR DESCRIPTION
## Summary

Implements GitHub Issue #272: Add playit.gg domain registration to `mcctl create` command.

## Changes

### CLI Command
- Added `--playit-domain <domain>` flag for non-interactive mode
- Added `--no-playit-domain` flag to explicitly skip domain registration
- Added interactive prompt when playit is enabled (reads `.mcctl.json`)

### Domain Registration Flow
When playit is enabled (`playitEnabled: true` in `.mcctl.json`):
1. Prompts user: "Register external domain for playit.gg? (y/N)"
2. If yes, prompts for domain: "External domain: aa.example.com"
3. Validates domain format
4. Saves `PLAYIT_DOMAIN=aa.example.com` to server's `config.env`
5. Adds playit domain to `mc-router.host` label in `docker-compose.yml`

### Modified Files
- `platform/services/cli/src/commands/create.ts` - Added playit options to CLI interface
- `platform/services/cli/src/index.ts` - Registered new CLI flags
- `platform/services/shared/src/application/use-cases/CreateServerUseCase.ts` - Added playit domain prompt logic
- `platform/services/shared/src/application/ports/inbound/ICreateServerUseCase.ts` - Updated CreateServerConfig interface
- `platform/services/shared/src/application/ports/outbound/IShellPort.ts` - Updated CreateServerOptions interface
- `platform/services/shared/src/infrastructure/adapters/ShellAdapter.ts` - Pass playit domain to bash script
- `platform/scripts/create-server.sh` - Handle playit domain flags and include in hostnames

### Tests
- Added unit tests for CLI argument mode with playit flags
- All existing tests pass (171 tests)
- TDD approach: Red → Green → Refactor

## Non-interactive Mode Examples

```bash
# With playit domain
mcctl create survival -t PAPER -v 1.21.1 --playit-domain aa.example.com

# Explicitly skip playit domain
mcctl create creative -t PAPER -v 1.21.1 --no-playit-domain
```

## Interactive Mode

When playit is enabled, the create flow prompts for external domain after whitelist setup:

```
? Register external domain for playit.gg? (y/N) y
? External domain: aa.example.com

  ✓ External domain registered: aa.example.com
```

## Prerequisites

- #270: playit service in docker-compose.yml ✅
- #271: mcctl init with playit setup, .mcctl.json has playitEnabled flag ✅

## Closes

Closes #272