### PR TITLE
feat(api): add playit.gg status and control API endpoints (#292)

### DIFF
--- a/platform/services/mcctl-api/src/app.ts
+++ b/platform/services/mcctl-api/src/app.ts
@@ -15,6 +15,7 @@ import routerRoutes from './routes/router.js';
 import playersRoutes from './routes/players.js';
 import backupRoutes from './routes/backup.js';
 import auditLogsRoutes from './routes/audit-logs.js';
+import playitRoutes from './routes/playit.js';
 
 export interface BuildAppOptions {
   logger?: boolean;
@@ -74,6 +75,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
 
   // Register audit log routes
   await app.register(auditLogsRoutes);
+
+  // Register playit routes
+  await app.register(playitRoutes);
 
   // Health check endpoint
   app.get('/health', async () => {

--- a/platform/services/mcctl-api/src/routes/playit.ts
+++ b/platform/services/mcctl-api/src/routes/playit.ts
@@ -1,0 +1,214 @@
+import { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+import {
+  getPlayitAgentStatus as getPlayitStatus,
+  startPlayitAgent as startAgent,
+  stopPlayitAgent as stopAgent,
+  getServerPlayitDomain,
+  getAllServers,
+  getServerInfoFromConfig,
+} from '@minecraft-docker/shared';
+import {
+  PlayitAgentStatusSchema,
+  PlayitActionResponseSchema,
+  ErrorResponseSchema,
+  type PlayitAgentStatus,
+  type PlayitServerInfo,
+} from '../schemas/playit.js';
+import { writeAuditLog } from '../services/audit-log-service.js';
+import { AuditActionEnum } from '@minecraft-docker/shared';
+
+/**
+ * Playit routes plugin
+ * Provides REST API for playit.gg agent control and status
+ */
+const playitPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+  /**
+   * GET /api/playit/status
+   * Get playit agent status and per-server external access info
+   */
+  fastify.get('/api/playit/status', {
+    schema: {
+      description: 'Get playit.gg agent status and server external access info',
+      tags: ['playit'],
+      response: {
+        200: PlayitAgentStatusSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (_request, reply) => {
+    try {
+      // Get playit agent status
+      const status = await getPlayitStatus();
+
+      // Get all servers and their playit domains
+      const serverNames = getAllServers();
+      const servers: PlayitServerInfo[] = serverNames.map((serverName) => {
+        const info = getServerInfoFromConfig(serverName);
+        const playitDomain = getServerPlayitDomain(serverName);
+
+        return {
+          serverName,
+          playitDomain,
+          lanHostname: info.hostname,
+        };
+      });
+
+      const response: PlayitAgentStatus = {
+        ...status,
+        servers,
+      };
+
+      return reply.send(response);
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get playit status');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to get playit status',
+      });
+    }
+  });
+
+  /**
+   * POST /api/playit/start
+   * Start playit-agent container
+   */
+  fastify.post('/api/playit/start', {
+    schema: {
+      description: 'Start playit.gg agent container',
+      tags: ['playit'],
+      response: {
+        200: PlayitActionResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (_request, reply) => {
+    try {
+      const success = await startAgent();
+
+      if (!success) {
+        await writeAuditLog({
+          action: AuditActionEnum.PLAYIT_START,
+          actor: 'api:console',
+          targetType: 'service',
+          targetName: 'playit',
+          status: 'failure',
+          details: null,
+          errorMessage: 'Failed to start playit-agent',
+        });
+
+        return reply.code(500).send({
+          error: 'InternalServerError',
+          message: 'Failed to start playit-agent',
+        });
+      }
+
+      await writeAuditLog({
+        action: AuditActionEnum.PLAYIT_START,
+        actor: 'api:console',
+        targetType: 'service',
+        targetName: 'playit',
+        status: 'success',
+        details: null,
+        errorMessage: null,
+      });
+
+      return reply.send({
+        success: true,
+        message: 'playit-agent started',
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to start playit agent');
+
+      await writeAuditLog({
+        action: AuditActionEnum.PLAYIT_START,
+        actor: 'api:console',
+        targetType: 'service',
+        targetName: 'playit',
+        status: 'failure',
+        details: null,
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      });
+
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to start playit agent',
+      });
+    }
+  });
+
+  /**
+   * POST /api/playit/stop
+   * Stop playit-agent container
+   */
+  fastify.post('/api/playit/stop', {
+    schema: {
+      description: 'Stop playit.gg agent container',
+      tags: ['playit'],
+      response: {
+        200: PlayitActionResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (_request, reply) => {
+    try {
+      const success = await stopAgent();
+
+      if (!success) {
+        await writeAuditLog({
+          action: AuditActionEnum.PLAYIT_STOP,
+          actor: 'api:console',
+          targetType: 'service',
+          targetName: 'playit',
+          status: 'failure',
+          details: null,
+          errorMessage: 'Failed to stop playit-agent',
+        });
+
+        return reply.code(500).send({
+          error: 'InternalServerError',
+          message: 'Failed to stop playit-agent',
+        });
+      }
+
+      await writeAuditLog({
+        action: AuditActionEnum.PLAYIT_STOP,
+        actor: 'api:console',
+        targetType: 'service',
+        targetName: 'playit',
+        status: 'success',
+        details: null,
+        errorMessage: null,
+      });
+
+      return reply.send({
+        success: true,
+        message: 'playit-agent stopped',
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to stop playit agent');
+
+      await writeAuditLog({
+        action: AuditActionEnum.PLAYIT_STOP,
+        actor: 'api:console',
+        targetType: 'service',
+        targetName: 'playit',
+        status: 'failure',
+        details: null,
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      });
+
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to stop playit agent',
+      });
+    }
+  });
+};
+
+export default fp(playitPlugin, {
+  name: 'playit-routes',
+  fastify: '5.x',
+});
+
+export { playitPlugin };

--- a/platform/services/mcctl-api/src/routes/servers.ts
+++ b/platform/services/mcctl-api/src/routes/servers.ts
@@ -10,6 +10,7 @@ import {
   getContainerStatus,
   getContainerHealth,
   stopContainer,
+  getServerPlayitDomain,
 } from '@minecraft-docker/shared';
 import {
   ServerListResponseSchema,
@@ -285,6 +286,9 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 
       const info = await getServerDetailedInfo(name);
 
+      // Get playit domain for this server
+      const playitDomain = getServerPlayitDomain(name);
+
       const server: ServerDetail = {
         name: info.name,
         container: info.container,
@@ -300,6 +304,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         stats: info.stats,
         worldName: info.worldName,
         worldSize: info.worldSize,
+        playitDomain,
       };
 
       return reply.send({ server });

--- a/platform/services/mcctl-api/src/schemas/playit.ts
+++ b/platform/services/mcctl-api/src/schemas/playit.ts
@@ -1,0 +1,50 @@
+import { Type, Static } from '@sinclair/typebox';
+import { ContainerStatusSchema, ErrorResponseSchema } from './server.js';
+
+/**
+ * Playit server info schema
+ */
+export const PlayitServerInfoSchema = Type.Object({
+  serverName: Type.String(),
+  playitDomain: Type.Union([Type.String(), Type.Null()]),
+  lanHostname: Type.String(),
+});
+
+/**
+ * Playit agent status schema
+ */
+export const PlayitAgentStatusSchema = Type.Object({
+  enabled: Type.Boolean(),
+  agentRunning: Type.Boolean(),
+  secretKeyConfigured: Type.Boolean(),
+  containerStatus: ContainerStatusSchema,
+  uptime: Type.Optional(Type.String()),
+  uptimeSeconds: Type.Optional(Type.Number()),
+  servers: Type.Array(PlayitServerInfoSchema),
+});
+
+/**
+ * Playit start/stop response schema
+ */
+export const PlayitActionResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  message: Type.String(),
+});
+
+/**
+ * Playit summary schema for router status
+ */
+export const PlayitSummarySchema = Type.Object({
+  enabled: Type.Boolean(),
+  agentRunning: Type.Boolean(),
+  secretKeyConfigured: Type.Boolean(),
+});
+
+// Re-export error schema
+export { ErrorResponseSchema };
+
+// Type exports
+export type PlayitServerInfo = Static<typeof PlayitServerInfoSchema>;
+export type PlayitAgentStatus = Static<typeof PlayitAgentStatusSchema>;
+export type PlayitActionResponse = Static<typeof PlayitActionResponseSchema>;
+export type PlayitSummary = Static<typeof PlayitSummarySchema>;

--- a/platform/services/mcctl-api/src/schemas/router.ts
+++ b/platform/services/mcctl-api/src/schemas/router.ts
@@ -1,5 +1,6 @@
 import { Type, Static } from '@sinclair/typebox';
 import { ContainerStatusSchema, HealthStatusSchema, ErrorResponseSchema } from './server.js';
+import { PlayitSummarySchema } from './playit.js';
 
 // Route info schema
 export const RouteInfoSchema = Type.Object({
@@ -33,6 +34,7 @@ export const AvahiInfoSchema = Type.Object({
 export const RouterStatusResponseSchema = Type.Object({
   router: RouterDetailSchema,
   avahi: Type.Optional(AvahiInfoSchema),
+  playit: Type.Optional(PlayitSummarySchema),
 });
 
 // Re-export error schema

--- a/platform/services/mcctl-api/src/schemas/server.ts
+++ b/platform/services/mcctl-api/src/schemas/server.ts
@@ -58,6 +58,7 @@ export const ServerDetailSchema = Type.Object({
   stats: Type.Optional(ContainerStatsSchema),
   worldName: Type.Optional(Type.String()),
   worldSize: Type.Optional(Type.String()),
+  playitDomain: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 });
 
 // Request Schemas

--- a/platform/services/mcctl-api/tests/playit.test.ts
+++ b/platform/services/mcctl-api/tests/playit.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+
+// Mock @minecraft-docker/shared module
+vi.mock('@minecraft-docker/shared', () => ({
+  // Existing mocks (keep them for other tests)
+  getAllServers: vi.fn(),
+  getServerInfoFromConfig: vi.fn(),
+  serverExists: vi.fn(),
+  getRouterDetailInfo: vi.fn(),
+  getAvahiStatus: vi.fn(),
+
+  // Playit-specific mocks
+  getPlayitAgentStatus: vi.fn(),
+  startPlayitAgent: vi.fn(),
+  stopPlayitAgent: vi.fn(),
+  getServerPlayitDomain: vi.fn(),
+
+  // Audit log enum
+  AuditActionEnum: {
+    PLAYIT_START: 'PLAYIT_START',
+    PLAYIT_STOP: 'PLAYIT_STOP',
+  },
+}));
+
+// Mock audit log service
+vi.mock('../src/services/audit-log-service.js', () => ({
+  writeAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('Playit Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/playit/status', () => {
+    it('should return playit status with running agent', async () => {
+      const { getPlayitAgentStatus, getAllServers, getServerPlayitDomain, getServerInfoFromConfig } = await import('@minecraft-docker/shared');
+
+      // Mock playit agent status
+      vi.mocked(getPlayitAgentStatus).mockResolvedValue({
+        enabled: true,
+        agentRunning: true,
+        secretKeyConfigured: true,
+        containerStatus: 'running',
+        uptime: '2h 30m',
+        uptimeSeconds: 9000,
+      });
+
+      // Mock servers list
+      vi.mocked(getAllServers).mockReturnValue(['survival', 'creative']);
+
+      // Mock server info for hostnames
+      vi.mocked(getServerInfoFromConfig)
+        .mockReturnValueOnce({
+          name: 'survival',
+          container: 'mc-survival',
+          status: 'running',
+          health: 'healthy',
+          hostname: 'survival.192.168.1.5.nip.io',
+        })
+        .mockReturnValueOnce({
+          name: 'creative',
+          container: 'mc-creative',
+          status: 'running',
+          health: 'healthy',
+          hostname: 'creative.192.168.1.5.nip.io',
+        });
+
+      // Mock playit domains
+      vi.mocked(getServerPlayitDomain)
+        .mockReturnValueOnce('aa.example.com')
+        .mockReturnValueOnce(null);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/playit/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body).toEqual({
+        enabled: true,
+        agentRunning: true,
+        secretKeyConfigured: true,
+        containerStatus: 'running',
+        uptime: '2h 30m',
+        uptimeSeconds: 9000,
+        servers: [
+          {
+            serverName: 'survival',
+            playitDomain: 'aa.example.com',
+            lanHostname: 'survival.192.168.1.5.nip.io',
+          },
+          {
+            serverName: 'creative',
+            playitDomain: null,
+            lanHostname: 'creative.192.168.1.5.nip.io',
+          },
+        ],
+      });
+    });
+
+    it('should return playit status when agent is stopped', async () => {
+      const { getPlayitAgentStatus, getAllServers } = await import('@minecraft-docker/shared');
+
+      vi.mocked(getPlayitAgentStatus).mockResolvedValue({
+        enabled: true,
+        agentRunning: false,
+        secretKeyConfigured: true,
+        containerStatus: 'exited',
+      });
+
+      vi.mocked(getAllServers).mockReturnValue([]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/playit/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body.enabled).toBe(true);
+      expect(body.agentRunning).toBe(false);
+      expect(body.servers).toEqual([]);
+    });
+
+    it('should return playit status when not configured', async () => {
+      const { getPlayitAgentStatus, getAllServers } = await import('@minecraft-docker/shared');
+
+      vi.mocked(getPlayitAgentStatus).mockResolvedValue({
+        enabled: false,
+        agentRunning: false,
+        secretKeyConfigured: false,
+        containerStatus: 'not_found',
+      });
+
+      vi.mocked(getAllServers).mockReturnValue([]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/playit/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body.enabled).toBe(false);
+      expect(body.agentRunning).toBe(false);
+      expect(body.secretKeyConfigured).toBe(false);
+    });
+
+    it('should handle errors gracefully', async () => {
+      const { getPlayitAgentStatus } = await import('@minecraft-docker/shared');
+
+      vi.mocked(getPlayitAgentStatus).mockRejectedValue(new Error('Docker not available'));
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/playit/status',
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('InternalServerError');
+    });
+  });
+
+  describe('POST /api/playit/start', () => {
+    it('should start playit agent successfully', async () => {
+      const { startPlayitAgent } = await import('@minecraft-docker/shared');
+
+      vi.mocked(startPlayitAgent).mockResolvedValue(true);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/playit/start',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body).toEqual({
+        success: true,
+        message: 'playit-agent started',
+      });
+      expect(startPlayitAgent).toHaveBeenCalledOnce();
+    });
+
+    it('should handle start failure', async () => {
+      const { startPlayitAgent } = await import('@minecraft-docker/shared');
+
+      vi.mocked(startPlayitAgent).mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/playit/start',
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+
+      expect(body.error).toBe('InternalServerError');
+      expect(body.message).toContain('Failed to start');
+    });
+
+    it('should handle errors gracefully', async () => {
+      const { startPlayitAgent } = await import('@minecraft-docker/shared');
+
+      vi.mocked(startPlayitAgent).mockRejectedValue(new Error('Docker not available'));
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/playit/start',
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('InternalServerError');
+    });
+  });
+
+  describe('POST /api/playit/stop', () => {
+    it('should stop playit agent successfully', async () => {
+      const { stopPlayitAgent } = await import('@minecraft-docker/shared');
+
+      vi.mocked(stopPlayitAgent).mockResolvedValue(true);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/playit/stop',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body).toEqual({
+        success: true,
+        message: 'playit-agent stopped',
+      });
+      expect(stopPlayitAgent).toHaveBeenCalledOnce();
+    });
+
+    it('should handle stop failure', async () => {
+      const { stopPlayitAgent } = await import('@minecraft-docker/shared');
+
+      vi.mocked(stopPlayitAgent).mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/playit/stop',
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+
+      expect(body.error).toBe('InternalServerError');
+      expect(body.message).toContain('Failed to stop');
+    });
+
+    it('should handle errors gracefully', async () => {
+      const { stopPlayitAgent } = await import('@minecraft-docker/shared');
+
+      vi.mocked(stopPlayitAgent).mockRejectedValue(new Error('Docker not available'));
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/playit/stop',
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('InternalServerError');
+    });
+  });
+});

--- a/platform/services/mcctl-api/tests/router-playit.test.ts
+++ b/platform/services/mcctl-api/tests/router-playit.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+
+// Mock @minecraft-docker/shared module
+vi.mock('@minecraft-docker/shared', () => ({
+  getRouterDetailInfo: vi.fn(),
+  getAvahiStatus: vi.fn(),
+  getPlayitAgentStatus: vi.fn(),
+  getAllServers: vi.fn(),
+  getServerInfoFromConfig: vi.fn(),
+  serverExists: vi.fn(),
+  getServerDetailedInfo: vi.fn(),
+  getServerPlayitDomain: vi.fn(),
+  AuditActionEnum: {},
+}));
+
+// Mock audit log service
+vi.mock('../src/services/audit-log-service.js', () => ({
+  writeAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('Router Routes - Playit Integration', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/router/status - with playit field', () => {
+    it('should include playit status in router response', async () => {
+      const { getRouterDetailInfo, getAvahiStatus, getPlayitAgentStatus } = await import('@minecraft-docker/shared');
+
+      vi.mocked(getRouterDetailInfo).mockReturnValue({
+        name: 'mc-router',
+        status: 'running',
+        health: 'healthy',
+        port: 25565,
+        uptime: '1h 30m',
+        uptimeSeconds: 5400,
+        mode: 'auto-scale',
+        routes: [],
+      });
+
+      vi.mocked(getAvahiStatus).mockReturnValue('running');
+
+      vi.mocked(getPlayitAgentStatus).mockResolvedValue({
+        enabled: true,
+        agentRunning: true,
+        secretKeyConfigured: true,
+        containerStatus: 'running',
+        uptime: '2h 30m',
+        uptimeSeconds: 9000,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/router/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body).toHaveProperty('router');
+      expect(body).toHaveProperty('avahi');
+      expect(body).toHaveProperty('playit');
+
+      expect(body.playit).toEqual({
+        enabled: true,
+        agentRunning: true,
+        secretKeyConfigured: true,
+      });
+    });
+
+    it('should omit playit field when playit status fails', async () => {
+      const { getRouterDetailInfo, getAvahiStatus, getPlayitAgentStatus } = await import('@minecraft-docker/shared');
+
+      vi.mocked(getRouterDetailInfo).mockReturnValue({
+        name: 'mc-router',
+        status: 'running',
+        health: 'healthy',
+        port: 25565,
+        routes: [],
+      });
+
+      vi.mocked(getAvahiStatus).mockReturnValue('running');
+
+      vi.mocked(getPlayitAgentStatus).mockRejectedValue(new Error('Docker not available'));
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/router/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body).toHaveProperty('router');
+      expect(body).toHaveProperty('avahi');
+      expect(body).not.toHaveProperty('playit');
+    });
+
+    it('should include playit status when agent is disabled', async () => {
+      const { getRouterDetailInfo, getAvahiStatus, getPlayitAgentStatus } = await import('@minecraft-docker/shared');
+
+      vi.mocked(getRouterDetailInfo).mockReturnValue({
+        name: 'mc-router',
+        status: 'running',
+        health: 'healthy',
+        port: 25565,
+        routes: [],
+      });
+
+      vi.mocked(getAvahiStatus).mockReturnValue('running');
+
+      vi.mocked(getPlayitAgentStatus).mockResolvedValue({
+        enabled: false,
+        agentRunning: false,
+        secretKeyConfigured: false,
+        containerStatus: 'not_found',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/router/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body.playit).toEqual({
+        enabled: false,
+        agentRunning: false,
+        secretKeyConfigured: false,
+      });
+    });
+  });
+});

--- a/platform/services/mcctl-api/tests/servers-playit.test.ts
+++ b/platform/services/mcctl-api/tests/servers-playit.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+
+// Mock @minecraft-docker/shared module
+vi.mock('@minecraft-docker/shared', () => ({
+  getAllServers: vi.fn(),
+  getServerInfoFromConfig: vi.fn(),
+  serverExists: vi.fn(),
+  getServerDetailedInfo: vi.fn(),
+  getServerPlayitDomain: vi.fn(),
+  containerExists: vi.fn(),
+  getContainerLogs: vi.fn(),
+  getContainerStatus: vi.fn(),
+  getContainerHealth: vi.fn(),
+  stopContainer: vi.fn(),
+  AuditActionEnum: {},
+}));
+
+// Mock audit log service
+vi.mock('../src/services/audit-log-service.js', () => ({
+  writeAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('Server Routes - Playit Domain Integration', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/servers/:name - with playitDomain field', () => {
+    it('should include playitDomain when server has external access configured', async () => {
+      const { serverExists, getServerDetailedInfo, getServerPlayitDomain } = await import('@minecraft-docker/shared');
+
+      vi.mocked(serverExists).mockReturnValue(true);
+
+      vi.mocked(getServerDetailedInfo).mockResolvedValue({
+        name: 'survival',
+        container: 'mc-survival',
+        status: 'running',
+        health: 'healthy',
+        hostname: 'survival.192.168.1.5.nip.io',
+        type: 'PAPER',
+        version: '1.21.1',
+        memory: '4G',
+        uptime: '1h 30m',
+        uptimeSeconds: 5400,
+      });
+
+      vi.mocked(getServerPlayitDomain).mockReturnValue('aa.example.com');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/servers/survival',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body.server).toHaveProperty('playitDomain');
+      expect(body.server.playitDomain).toBe('aa.example.com');
+    });
+
+    it('should include null playitDomain when server has no external access', async () => {
+      const { serverExists, getServerDetailedInfo, getServerPlayitDomain } = await import('@minecraft-docker/shared');
+
+      vi.mocked(serverExists).mockReturnValue(true);
+
+      vi.mocked(getServerDetailedInfo).mockResolvedValue({
+        name: 'creative',
+        container: 'mc-creative',
+        status: 'running',
+        health: 'healthy',
+        hostname: 'creative.192.168.1.5.nip.io',
+        type: 'VANILLA',
+        version: '1.21.1',
+      });
+
+      vi.mocked(getServerPlayitDomain).mockReturnValue(null);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/servers/creative',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body.server).toHaveProperty('playitDomain');
+      expect(body.server.playitDomain).toBeNull();
+    });
+  });
+});

--- a/platform/services/mcctl-api/tests/servers.test.ts
+++ b/platform/services/mcctl-api/tests/servers.test.ts
@@ -95,6 +95,7 @@ vi.mock('@minecraft-docker/shared', () => ({
   getContainerStatus: vi.fn(),
   getContainerHealth: vi.fn(),
   stopContainer: vi.fn(),
+  getServerPlayitDomain: vi.fn(),
   AuditActionEnum: {
     SERVER_CREATE: 'SERVER_CREATE',
     SERVER_DELETE: 'SERVER_DELETE',
@@ -125,12 +126,14 @@ import {
   getContainerLogs,
   containerExists,
   serverExists,
+  getServerPlayitDomain,
 } from '@minecraft-docker/shared';
 import { spawn } from 'node:child_process';
 
 const mockedGetAllServers = vi.mocked(getAllServers);
 const mockedGetServerInfoFromConfig = vi.mocked(getServerInfoFromConfig);
 const mockedGetServerDetailedInfo = vi.mocked(getServerDetailedInfo);
+const mockedGetServerPlayitDomain = vi.mocked(getServerPlayitDomain);
 const mockedGetContainerLogs = vi.mocked(getContainerLogs);
 const mockedContainerExists = vi.mocked(containerExists);
 const mockedServerExists = vi.mocked(serverExists);
@@ -234,6 +237,7 @@ describe('Server Routes', () => {
         worldName: 'world',
         worldSize: '500MB',
       });
+      mockedGetServerPlayitDomain.mockReturnValue(null);
 
       const response = await app.inject({
         method: 'GET',

--- a/platform/services/shared/src/domain/value-objects/AuditAction.ts
+++ b/platform/services/shared/src/domain/value-objects/AuditAction.ts
@@ -33,4 +33,8 @@ export enum AuditActionEnum {
 
   // System
   AUDIT_PURGE = 'audit.purge',
+
+  // Playit.gg agent
+  PLAYIT_START = 'playit.start',
+  PLAYIT_STOP = 'playit.stop',
 }


### PR DESCRIPTION
## Summary

Implements REST API endpoints for playit.gg agent management and status querying.

Closes #292

## Changes

### New Endpoints

#### GET /api/playit/status
Query playit-agent status and per-server external access info.

**Response:**
```json
{
  "enabled": true,
  "agentRunning": true,
  "secretKeyConfigured": true,
  "containerStatus": "running",
  "uptime": "2h 30m",
  "uptimeSeconds": 9000,
  "servers": [
    {
      "serverName": "survival",
      "playitDomain": "aa.example.com",
      "lanHostname": "survival.192.168.1.5.nip.io"
    },
    {
      "serverName": "creative",
      "playitDomain": null,
      "lanHostname": "creative.192.168.1.5.nip.io"
    }
  ]
}
```

#### POST /api/playit/start
Start playit-agent container.

**Response:**
```json
{ "success": true, "message": "playit-agent started" }
```

#### POST /api/playit/stop
Stop playit-agent container.

**Response:**
```json
{ "success": true, "message": "playit-agent stopped" }
```

### Extended Endpoints

#### GET /api/router/status — added playit field
Now includes playit agent summary in router status response.

#### GET /api/servers/:name — added playitDomain field
Server detail response now includes external playit domain if configured.

## Technical Details

- Uses shared package helpers: `getPlayitAgentStatus()`, `startPlayitAgent()`, `stopPlayitAgent()`, `getServerPlayitDomain()`
- Authentication: existing 5-mode auth plugin
- Audit logging: all start/stop operations logged with `PLAYIT_START` and `PLAYIT_STOP` actions
- OpenAPI/Swagger schema documentation for all endpoints
- Graceful fallback when playit not configured (enabled: false)

## Testing

- 10 tests for playit routes (status, start, stop)
- 3 tests for router playit integration
- 2 tests for server playit domain integration
- All 250 tests passing

## Files Changed

### New Files
- `platform/services/mcctl-api/src/routes/playit.ts` - playit routes implementation
- `platform/services/mcctl-api/src/schemas/playit.ts` - OpenAPI schemas
- `platform/services/mcctl-api/tests/playit.test.ts` - playit route tests
- `platform/services/mcctl-api/tests/router-playit.test.ts` - router integration tests
- `platform/services/mcctl-api/tests/servers-playit.test.ts` - server integration tests

### Modified Files
- `platform/services/mcctl-api/src/app.ts` - register playit routes
- `platform/services/mcctl-api/src/routes/router.ts` - add playit field to response
- `platform/services/mcctl-api/src/routes/servers.ts` - add playitDomain field to response
- `platform/services/mcctl-api/src/schemas/router.ts` - extend schema with playit summary
- `platform/services/mcctl-api/src/schemas/server.ts` - extend schema with playitDomain
- `platform/services/mcctl-api/tests/servers.test.ts` - add getServerPlayitDomain mock
- `platform/services/shared/src/domain/value-objects/AuditAction.ts` - add PLAYIT_START/STOP

## Dependencies

Requires:
- #270: playit service in docker-compose.yml ✅
- #291: Shared package playit helpers ✅

## Checklist

- [x] New endpoints: GET /api/playit/status
- [x] New endpoints: POST /api/playit/start
- [x] New endpoints: POST /api/playit/stop
- [x] Extended: GET /api/router/status with playit field
- [x] Extended: GET /api/servers/:name with playitDomain field
- [x] OpenAPI/Swagger documentation
- [x] Audit logging for start/stop
- [x] Unit tests (15 tests, all passing)
- [x] Error handling (graceful fallback when playit not configured)