### PR TITLE
fix(cli): handle missing .mcctl.json in mcctl init --reconfigure

### DIFF
--- a/platform/services/cli/src/commands/init.ts
+++ b/platform/services/cli/src/commands/init.ts
@@ -367,11 +367,22 @@ async function reconfigureCommand(paths: Paths, config: Config): Promise<number>
 
   // Load current settings
   const envConfig = config.loadEnv();
-  const mcctlConfig = config.load();
+  let mcctlConfig = config.load();
 
   if (!mcctlConfig) {
-    log.error('Configuration file not found');
-    return 1;
+    // Create default config from .env values for platforms initialized before v2.3.0
+    log.warn('Configuration file (.mcctl.json) not found, creating with defaults...');
+    mcctlConfig = {
+      version: '2.3.0',
+      initialized: new Date().toISOString(),
+      dataDir: paths.root,
+      defaultType: 'PAPER' as const,
+      defaultVersion: envConfig.DEFAULT_VERSION || '1.21.1',
+      autoStart: true,
+      avahiEnabled: false,
+      playitEnabled: !!envConfig.PLAYIT_SECRET_KEY,
+    };
+    config.save(mcctlConfig);
   }
 
   // Display current settings

--- a/platform/services/shared/src/types/index.ts
+++ b/platform/services/shared/src/types/index.ts
@@ -71,6 +71,7 @@ export interface EnvConfig {
   BACKUP_GITHUB_REPO?: string;
   BACKUP_GITHUB_BRANCH?: string;
   BACKUP_AUTO_ON_STOP?: boolean;
+  PLAYIT_SECRET_KEY?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix `mcctl init --reconfigure` failing with "Configuration file not found" on platforms initialized before v2.3.0
- When `.mcctl.json` is missing, create default config from `.env` values instead of failing
- Add `PLAYIT_SECRET_KEY` to `EnvConfig` type for type safety

## Root Cause
`isInitialized()` checks for `docker-compose.yml`, but `reconfigureCommand()` requires `.mcctl.json` which was introduced in v2.3.0. Platforms initialized before this version have the former but not the latter.

## Changes
- `platform/services/cli/src/commands/init.ts`: Create default McctlConfig from .env when .mcctl.json is missing
- `platform/services/shared/src/types/index.ts`: Add `PLAYIT_SECRET_KEY` to EnvConfig
- `platform/services/cli/tests/unit/commands/init-playit.test.ts`: Add test for reconfigure with missing config

## Test plan
- [x] TDD: Red → Green → Refactor cycle followed
- [x] New test: reconfigure with missing .mcctl.json creates default config
- [x] All 10 init-playit tests pass
- [x] Shared package builds successfully
- [x] CLI package builds successfully

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)