### PR TITLE
fix(shared): check .mcctl.json for playit enabled state instead of container existence

### DIFF
--- a/platform/services/cli/tests/unit/commands/playit.test.ts
+++ b/platform/services/cli/tests/unit/commands/playit.test.ts
@@ -136,6 +136,29 @@ describe('mcctl playit subcommand', () => {
       expect(exitCode).toBe(1);
       expect(shared.startPlayitAgent).not.toHaveBeenCalled();
     });
+
+    it('should start when key is configured but container never created (first start)', async () => {
+      // This is the chicken-and-egg scenario: container doesn't exist yet
+      // because it has never been started, but start should still work
+      createInitializedPlatform(true, 'test-key-123');
+
+      vi.mocked(shared.getPlayitAgentStatus).mockResolvedValueOnce({
+        enabled: true, // Should be true based on config, not container existence
+        agentRunning: false,
+        secretKeyConfigured: true,
+        containerStatus: 'not_found', // Container never created
+      });
+
+      vi.mocked(shared.startPlayitAgent).mockResolvedValueOnce(true);
+
+      const exitCode = await playitCommand({
+        root: testRoot,
+        subCommand: 'start',
+      });
+
+      expect(exitCode).toBe(0);
+      expect(shared.startPlayitAgent).toHaveBeenCalled();
+    });
   });
 
   describe('playit stop', () => {

--- a/platform/services/shared/src/docker/index.ts
+++ b/platform/services/shared/src/docker/index.ts
@@ -981,6 +981,18 @@ export async function getPlayitAgentStatus(): Promise<import('../types/index.js'
     }
   }
 
+  // Check if playit is enabled in .mcctl.json config
+  const configPath = join(platformRoot, '.mcctl.json');
+  let playitEnabled = false;
+  if (existsSync(configPath)) {
+    try {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+      playitEnabled = config.playitEnabled === true;
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
   // Get uptime if running
   let uptime: string | undefined;
   let uptimeSeconds: number | undefined;
@@ -994,7 +1006,7 @@ export async function getPlayitAgentStatus(): Promise<import('../types/index.js'
   }
 
   return {
-    enabled: containerExists(containerName) && secretKeyConfigured,
+    enabled: playitEnabled || secretKeyConfigured,
     agentRunning,
     secretKeyConfigured,
     containerStatus: status,


### PR DESCRIPTION
## Summary
- Fix `mcctl playit start` failing with "playit.gg is not enabled" when container has never been started
- Change `enabled` field in `getPlayitAgentStatus()` to check `.mcctl.json` config flag instead of container existence

## Root Cause
`enabled` was calculated as `containerExists('playit') && secretKeyConfigured`, creating a chicken-and-egg problem: the container doesn't exist before first start, but can't be started because `enabled` is `false`.

## Changes
- `platform/services/shared/src/docker/index.ts`: Read `.mcctl.json` `playitEnabled` flag, use `playitEnabled || secretKeyConfigured` for `enabled`
- `platform/services/cli/tests/unit/commands/playit.test.ts`: Add test for first-start scenario (container never created)

## Test plan
- [x] New test: "should start when key is configured but container never created"
- [x] All 15 playit command tests pass
- [x] Both shared and CLI packages build successfully

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)