### PR TITLE
fix(shared): pass cwd to docker compose in playit start/stop

### DIFF
--- a/platform/services/shared/src/docker/index.ts
+++ b/platform/services/shared/src/docker/index.ts
@@ -344,11 +344,13 @@ export function getContainerLogs(container: string, lines: number = 50): string 
  */
 export function execCommandAsync(
   command: string,
-  args: string[]
+  args: string[],
+  options?: { cwd?: string }
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: options?.cwd,
     });
 
     let stdout = '';
@@ -1030,7 +1032,7 @@ export async function startPlayitAgent(): Promise<boolean> {
       'up',
       '-d',
       'playit',
-    ]);
+    ], { cwd: platformRoot });
 
     return result.code === 0;
   } catch {
@@ -1052,7 +1054,7 @@ export async function stopPlayitAgent(): Promise<boolean> {
       'playit',
       'stop',
       'playit',
-    ]);
+    ], { cwd: platformRoot });
 
     return result.code === 0;
   } catch {


### PR DESCRIPTION
## Summary
- Fix `mcctl playit start` / `mcctl playit stop` failing because `docker compose` runs without `cwd` set to the platform root directory

## Root Cause
`startPlayitAgent()` and `stopPlayitAgent()` calculated `platformRoot` but never passed it to `execCommandAsync()`. Without `cwd`, `docker compose` looks for `docker-compose.yml` in `process.cwd()` which is unlikely to be the platform root.

## Changes
- `platform/services/shared/src/docker/index.ts`:
  - Add optional `cwd` parameter to `execCommandAsync()`
  - Pass `platformRoot` as `cwd` in `startPlayitAgent()` and `stopPlayitAgent()`

## Test plan
- [x] All 15 playit command tests pass
- [x] Shared and CLI packages build successfully

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)