### PR TITLE
fix(cli): add playit service to docker-compose.yml during setup

### DIFF
--- a/platform/services/mcctl-api/src/routes/playit.ts
+++ b/platform/services/mcctl-api/src/routes/playit.ts
@@ -84,9 +84,10 @@ const playitPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     },
   }, async (_request, reply) => {
     try {
-      const success = await startAgent();
+      const result = await startAgent();
 
-      if (!success) {
+      if (!result.success) {
+        const errorMsg = result.error || 'Failed to start playit-agent';
         await writeAuditLog({
           action: AuditActionEnum.PLAYIT_START,
           actor: 'api:console',
@@ -94,12 +95,12 @@ const playitPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
           targetName: 'playit',
           status: 'failure',
           details: null,
-          errorMessage: 'Failed to start playit-agent',
+          errorMessage: errorMsg,
         });
 
         return reply.code(500).send({
           error: 'InternalServerError',
-          message: 'Failed to start playit-agent',
+          message: errorMsg,
         });
       }
 

--- a/platform/services/mcctl-api/tests/playit.test.ts
+++ b/platform/services/mcctl-api/tests/playit.test.ts
@@ -184,7 +184,7 @@ describe('Playit Routes', () => {
     it('should start playit agent successfully', async () => {
       const { startPlayitAgent } = await import('@minecraft-docker/shared');
 
-      vi.mocked(startPlayitAgent).mockResolvedValue(true);
+      vi.mocked(startPlayitAgent).mockResolvedValue({ success: true });
 
       const response = await app.inject({
         method: 'POST',
@@ -204,7 +204,7 @@ describe('Playit Routes', () => {
     it('should handle start failure', async () => {
       const { startPlayitAgent } = await import('@minecraft-docker/shared');
 
-      vi.mocked(startPlayitAgent).mockResolvedValue(false);
+      vi.mocked(startPlayitAgent).mockResolvedValue({ success: false, error: 'compose failed' });
 
       const response = await app.inject({
         method: 'POST',
@@ -215,7 +215,7 @@ describe('Playit Routes', () => {
       const body = JSON.parse(response.body);
 
       expect(body.error).toBe('InternalServerError');
-      expect(body.message).toContain('Failed to start');
+      expect(body.message).toBe('compose failed');
     });
 
     it('should handle errors gracefully', async () => {

--- a/platform/services/shared/src/docker/index.ts
+++ b/platform/services/shared/src/docker/index.ts
@@ -1021,7 +1021,7 @@ export async function getPlayitAgentStatus(): Promise<import('../types/index.js'
  * Start playit-agent container
  * Uses docker compose with playit profile
  */
-export async function startPlayitAgent(): Promise<boolean> {
+export async function startPlayitAgent(): Promise<{ success: boolean; error?: string }> {
   const platformRoot = process.env['MCCTL_ROOT'] ?? join(homedir(), 'minecraft-servers');
 
   try {
@@ -1034,9 +1034,12 @@ export async function startPlayitAgent(): Promise<boolean> {
       'playit',
     ], { cwd: platformRoot });
 
-    return result.code === 0;
-  } catch {
-    return false;
+    if (result.code === 0) {
+      return { success: true };
+    }
+    return { success: false, error: result.stderr || result.stdout };
+  } catch (e) {
+    return { success: false, error: String(e) };
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix `mcctl playit start` failing on pre-v2.3.0 platforms that don't have the playit service in `docker-compose.yml`
- `mcctl playit setup` now automatically adds the playit service definition if missing
- Improved error diagnostics: actual docker compose errors are now displayed

## Root Cause
Platforms initialized before v2.3.0 don't have the playit service in `docker-compose.yml`. `mcctl playit setup` only updated `.env` and `.mcctl.json` but never added the service to the compose file.

## Changes
- `platform/services/cli/src/commands/playit.ts`: Add `ensurePlayitService()` that checks and adds the playit service to docker-compose.yml
- `platform/services/shared/src/docker/index.ts`: `startPlayitAgent()` returns `{ success, error }` instead of boolean
- `platform/services/cli/src/commands/playit.ts`: Display actual error from docker compose on failure
- `platform/services/mcctl-api/src/routes/playit.ts`: Updated to use new return type
- Tests updated for all affected packages

## Test plan
- [x] 17 CLI playit tests pass (including 2 new: add service + no duplicate)
- [x] 10 API playit tests pass
- [x] All packages build successfully

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)