### PR TITLE
fix(console): improve playit section layout and server domains display

### DIFF
--- a/platform/services/mcctl-console/src/components/settings/PlayitSection.test.tsx
+++ b/platform/services/mcctl-console/src/components/settings/PlayitSection.test.tsx
@@ -116,11 +116,12 @@ describe('PlayitSection', () => {
     expect(screen.getByText('Running')).toBeInTheDocument();
     expect(screen.getByText('2h 15m')).toBeInTheDocument();
 
-    // Server table
+    // Configured server in table
     expect(screen.getByText('survival')).toBeInTheDocument();
     expect(screen.getByText('survival.example.playit.gg')).toBeInTheDocument();
-    expect(screen.getByText('creative')).toBeInTheDocument();
-    expect(screen.getByText('Not configured')).toBeInTheDocument();
+    // Unconfigured server shown as summary text
+    expect(screen.getByText(/creative/)).toBeInTheDocument();
+    expect(screen.getByText(/without external domain/)).toBeInTheDocument();
   });
 
   it('shows stop button when agent is running', () => {

--- a/platform/services/mcctl-console/src/components/settings/PlayitSection.tsx
+++ b/platform/services/mcctl-console/src/components/settings/PlayitSection.tsx
@@ -139,49 +139,49 @@ export function PlayitSection() {
   return (
     <Card>
       <CardContent>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
           <PublicIcon color="primary" />
           <Typography variant="h6" component="h2">
             External Access (playit.gg)
           </Typography>
-          <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
+          {isRunning ? (
             <Button
-              component="a"
-              href="https://playit.gg/account/tunnels"
-              target="_blank"
-              rel="noopener noreferrer"
+              variant="outlined"
               size="small"
-              startIcon={<OpenInNewIcon />}
+              color="error"
+              startIcon={isActionPending ? <CircularProgress size={16} /> : <StopIcon />}
+              onClick={handleStop}
+              disabled={isActionPending}
               sx={{ fontSize: 12 }}
             >
-              View Dashboard
+              {isActionPending ? 'Stopping...' : 'Stop Agent'}
             </Button>
-            {isRunning ? (
-              <Button
-                variant="outlined"
-                size="small"
-                color="error"
-                startIcon={isActionPending ? <CircularProgress size={16} /> : <StopIcon />}
-                onClick={handleStop}
-                disabled={isActionPending}
-                sx={{ fontSize: 12 }}
-              >
-                {isActionPending ? 'Stopping...' : 'Stop Agent'}
-              </Button>
-            ) : (
-              <Button
-                variant="contained"
-                size="small"
-                color="success"
-                startIcon={isActionPending ? <CircularProgress size={16} color="inherit" /> : <PlayArrowIcon />}
-                onClick={handleStart}
-                disabled={isActionPending}
-                sx={{ fontSize: 12 }}
-              >
-                {isActionPending ? 'Starting...' : 'Start Agent'}
-              </Button>
-            )}
-          </Box>
+          ) : (
+            <Button
+              variant="contained"
+              size="small"
+              color="success"
+              startIcon={isActionPending ? <CircularProgress size={16} color="inherit" /> : <PlayArrowIcon />}
+              onClick={handleStart}
+              disabled={isActionPending}
+              sx={{ fontSize: 12 }}
+            >
+              {isActionPending ? 'Starting...' : 'Start Agent'}
+            </Button>
+          )}
+          <Button
+            component="a"
+            href="https://playit.gg/account/tunnels"
+            target="_blank"
+            rel="noopener noreferrer"
+            size="small"
+            startIcon={<OpenInNewIcon />}
+            sx={{ fontSize: 12 }}
+          >
+            View Dashboard
+          </Button>
         </Box>
 
         {/* Agent Status */}
@@ -208,48 +208,59 @@ export function PlayitSection() {
         </Table>
 
         {/* Server Domains Table */}
-        {data.servers && data.servers.length > 0 && (
-          <>
-            <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
-              Server Domains
-            </Typography>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{ fontWeight: 600, borderBottom: 2, borderColor: 'divider' }}>
-                    Server
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, borderBottom: 2, borderColor: 'divider' }}>
-                    External Domain
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {data.servers.map((server) => (
-                  <TableRow key={server.serverName}>
-                    <TableCell sx={{ py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
-                      {server.serverName}
-                    </TableCell>
-                    <TableCell sx={{ py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
-                      {server.playitDomain ? (
-                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                          <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                            {server.playitDomain}
-                          </Typography>
-                          <CopyButton text={server.playitDomain} />
-                        </Box>
-                      ) : (
-                        <Typography variant="body2" color="text.secondary">
-                          Not configured
-                        </Typography>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </>
-        )}
+        {data.servers && data.servers.length > 0 && (() => {
+          const configured = data.servers.filter((s) => s.playitDomain);
+          const unconfigured = data.servers.filter((s) => !s.playitDomain);
+
+          return (
+            <>
+              <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
+                Server Domains
+              </Typography>
+              {configured.length > 0 ? (
+                <Table size="small" sx={{ mb: unconfigured.length > 0 ? 2 : 0 }}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 600, borderBottom: 2, borderColor: 'divider' }}>
+                        Server
+                      </TableCell>
+                      <TableCell sx={{ fontWeight: 600, borderBottom: 2, borderColor: 'divider' }}>
+                        External Domain
+                      </TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {configured.map((server) => (
+                      <TableRow key={server.serverName}>
+                        <TableCell sx={{ py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
+                          {server.serverName}
+                        </TableCell>
+                        <TableCell sx={{ py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
+                          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                            <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                              {server.playitDomain}
+                            </Typography>
+                            <CopyButton text={server.playitDomain!} />
+                          </Box>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  No servers with external domains configured.
+                  Use <code>mcctl create --playit-domain</code> to register a domain.
+                </Typography>
+              )}
+              {unconfigured.length > 0 && (
+                <Typography variant="body2" color="text.secondary">
+                  {unconfigured.length} server{unconfigured.length > 1 ? 's' : ''} without external domain: {unconfigured.map((s) => s.serverName).join(', ')}
+                </Typography>
+              )}
+            </>
+          );
+        })()}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Fix playit section header buttons overflowing on narrow screens
- Improve server domains display: separate configured vs unconfigured servers

## Changes
- **Header layout**: Move action buttons (Start/Stop Agent, View Dashboard) to a separate row below the title with `flexWrap: 'wrap'`
- **Server domains**: Configured servers shown in a table with copy button; unconfigured servers shown as a compact summary line (e.g., "2 servers without external domain: factory, wild-deity")

## Before
Title + buttons crammed on one line, breaking on narrow screens. All servers in one table with "Not configured" cells.

## After
Title on its own line. Buttons on a separate row that wraps naturally. Only configured servers in the domain table; unconfigured servers listed as summary text.

## Test plan
- [x] 10 PlayitSection tests pass
- [x] Visual layout verified

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)