### PR TITLE
fix(shared): use correct container name in getPlayitAgentStatus (#345)

### DIFF
--- a/platform/services/shared/src/docker/index.ts
+++ b/platform/services/shared/src/docker/index.ts
@@ -961,7 +961,7 @@ export async function getServerDetailedInfo(
  * Returns status information about the playit.gg agent container
  */
 export async function getPlayitAgentStatus(): Promise<import('../types/index.js').PlayitAgentStatus> {
-  const containerName = 'playit';
+  const containerName = 'playit-agent';
 
   // Check if container exists
   const status = getContainerStatus(containerName);

--- a/platform/services/shared/tests/playit-docker.test.ts
+++ b/platform/services/shared/tests/playit-docker.test.ts
@@ -88,9 +88,11 @@ describe('Docker helper functions for playit.gg', () => {
 
   describe('startPlayitAgent', () => {
     test('should execute docker compose command to start playit-agent', async () => {
-      // This test validates the function exists and returns a boolean
+      // This test validates the function exists and returns { success, error? }
       const result = await dockerHelpers.startPlayitAgent();
-      assert.strictEqual(typeof result, 'boolean');
+      assert.strictEqual(typeof result, 'object');
+      assert.ok('success' in result);
+      assert.strictEqual(typeof result.success, 'boolean');
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix container name mismatch in `getPlayitAgentStatus()`: was using `'playit'` (Docker Compose service name) instead of `'playit-agent'` (`container_name` in docker-compose.yml)
- Fix `startPlayitAgent()` test assertion for updated return type (`{ success, error? }` instead of `boolean`)

## Root Cause
`docker inspect playit` fails because the container is named `playit-agent` via `container_name` directive. This caused `mcctl playit status` to always report "stopped" even when the agent was running.

## Test plan
- [x] shared package tests pass (189/189)
- [x] mcctl-api tests pass (250/250)
- [x] CLI tests pass (189/189 actual tests)
- [ ] Manual verification: `mcctl playit start` then `mcctl playit status` shows "running"

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)