### PR TITLE
feat(cli): add 'mcctl playit domain' subcommand (#347)

### DIFF
--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -357,7 +357,7 @@ function parseArgs(args: string[]): {
       const nextArg = args[i + 1];
 
       // Boolean-only flags (never take a value)
-      const booleanOnlyFlags = ['all', 'json', 'help', 'version', 'force', 'yes', 'follow', 'detail', 'watch', 'offline', 'no-start', 'no-whitelist', 'list', 'dry-run', 'api', 'console', 'build', 'no-build', 'keep-config', 'check', 'reconfigure', 'no-playit', 'no-playit-domain'];
+      const booleanOnlyFlags = ['all', 'json', 'help', 'version', 'force', 'yes', 'follow', 'detail', 'watch', 'offline', 'no-start', 'no-whitelist', 'list', 'dry-run', 'api', 'console', 'build', 'no-build', 'keep-config', 'check', 'reconfigure', 'no-playit', 'no-playit-domain', 'remove'];
 
       if (booleanOnlyFlags.includes(key)) {
         result.flags[key] = true;
@@ -945,12 +945,14 @@ async function main(): Promise<void> {
       }
 
       case 'playit': {
-        // playit command: playit <start|stop|status|setup>
+        // playit command: playit <start|stop|status|setup|domain>
         // subCommand = action
         exitCode = await playitCommand({
           root: rootDir,
-          subCommand: subCommand as 'start' | 'stop' | 'status' | 'setup' | undefined,
+          subCommand: subCommand as 'start' | 'stop' | 'status' | 'setup' | 'domain' | undefined,
           json: flags['json'] === true,
+          domainArgs: positional,
+          remove: flags['remove'] === true,
         });
         break;
       }

--- a/platform/services/shared/src/index.ts
+++ b/platform/services/shared/src/index.ts
@@ -73,6 +73,7 @@ export {
   startPlayitAgent,
   stopPlayitAgent,
   getServerPlayitDomain,
+  setServerPlayitDomain,
 } from './docker/index.js';
 
 // Re-export domain layer (Value Objects and Entities)


### PR DESCRIPTION
## Summary
- Add `mcctl playit domain <server> <domain>` to set playit.gg external domain for existing servers
- Add `mcctl playit domain <server> --remove` to remove domain
- Add interactive mode (prompts for server and domain when no args given)
- Add `setServerPlayitDomain()` to shared package for config.env manipulation

## Context
Previously `PLAYIT_DOMAIN` could only be set via `mcctl create --playit-domain` during server creation. Users who configured playit tunnels through the playit.gg dashboard had no way to register the domain in config.env, causing the console UI to show "No servers with external domains configured."

## Test plan
- [x] Shared package tests: 194/194 pass (including 5 new setServerPlayitDomain tests)
- [x] CLI tests: 21/21 pass (including 4 new domain subcommand tests)
- [x] API tests: 250/250 pass
- [ ] Manual: `mcctl playit domain factory possible-tracks.gl.joinmc.link` → verify in `mcctl playit status`

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)