### PR TITLE
refactor(console): rename 'Content' tab to 'Mods' in server detail page (#349)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/ServerDetail.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerDetail.test.tsx
@@ -60,7 +60,7 @@ describe('ServerDetail', () => {
     renderWithTheme(<ServerDetail server={mockServer} />);
 
     expect(screen.getByRole('button', { name: /overview/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /content/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mods/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /files/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /backups/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /options/i })).toBeInTheDocument();
@@ -88,13 +88,13 @@ describe('ServerDetail', () => {
     expect(screen.getByText('Console')).toBeInTheDocument();
   });
 
-  it('should switch to content tab', () => {
+  it('should switch to mods tab', () => {
     renderWithTheme(<ServerDetail server={mockServer} />);
 
-    const contentTab = screen.getByRole('button', { name: /content/i });
-    fireEvent.click(contentTab);
+    const modsTab = screen.getByRole('button', { name: /mods/i });
+    fireEvent.click(modsTab);
 
-    expect(screen.getByText(/content management coming soon/i)).toBeInTheDocument();
+    expect(screen.getByText(/mod management coming soon/i)).toBeInTheDocument();
   });
 
   it('should switch to files tab', () => {

--- a/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
@@ -37,7 +37,7 @@ interface ServerDetailProps {
 }
 
 // Tab configuration
-const TABS = ['Overview', 'Activity', 'Content', 'Files', 'Backups', 'Access', 'Options'] as const;
+const TABS = ['Overview', 'Activity', 'Mods', 'Files', 'Backups', 'Access', 'Options'] as const;
 type TabType = (typeof TABS)[number];
 
 // Icon size for stat cards
@@ -549,10 +549,10 @@ export function ServerDetail({ server, onSendCommand }: ServerDetailProps) {
         </Box>
       )}
 
-      {activeTab === 'Content' && (
+      {activeTab === 'Mods' && (
         <Box sx={{ mt: 3 }}>
           <Typography variant="body1" color="text.secondary">
-            Content management coming soon
+            Mod management coming soon
           </Typography>
         </Box>
       )}


### PR DESCRIPTION
## Summary
- 서버 상세 페이지의 "Content" 탭을 "Mods"로 이름 변경
- 모호한 탭 이름을 Modrinth 기반 모드/플러그인 관리 목적에 맞게 명확히 함

## Changes
- `ServerDetail.tsx`: TABS 배열, activeTab 조건문, placeholder 텍스트 변경
- `ServerDetail.test.tsx`: 탭 이름 참조 및 테스트 설명 업데이트

## Test plan
- [x] ServerDetail 단위 테스트 17개 통과 확인

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)