### PR TITLE
feat(cli): add creeper ASCII banner with version check on mcctl init (#353)

### DIFF
--- a/platform/services/cli/src/lib/banner.ts
+++ b/platform/services/cli/src/lib/banner.ts
@@ -1,0 +1,111 @@
+/**
+ * Creeper ASCII art banner for mcctl CLI
+ * Displays on init and version commands
+ */
+
+import { colors } from '@minecraft-docker/shared';
+
+export interface UpdateCheckResult {
+  currentVersion: string;
+  latestVersion: string;
+  updateCommand: string;
+}
+
+// 8x8 Creeper face pattern using emoji blocks
+export const CREEPER_ART: string[][] = [
+  ['🟩', '🟩', '🟩', '🟩', '🟩', '🟩', '🟩', '🟩'],
+  ['🟩', '⬛', '⬛', '🟩', '🟩', '⬛', '⬛', '🟩'],
+  ['🟩', '⬛', '⬛', '🟩', '🟩', '⬛', '⬛', '🟩'],
+  ['🟩', '🟩', '🟩', '⬛', '⬛', '🟩', '🟩', '🟩'],
+  ['🟩', '🟩', '⬛', '⬛', '⬛', '⬛', '🟩', '🟩'],
+  ['🟩', '🟩', '⬛', '⬛', '⬛', '⬛', '🟩', '🟩'],
+  ['🟩', '🟩', '⬛', '🟩', '🟩', '⬛', '🟩', '🟩'],
+  ['🟩', '🟩', '🟩', '🟩', '🟩', '🟩', '🟩', '🟩'],
+];
+
+// ASCII fallback for terminals without emoji support
+export const CREEPER_ASCII: string[][] = [
+  ['#', '#', '#', '#', '#', '#', '#', '#'],
+  ['#', '@', '@', '#', '#', '@', '@', '#'],
+  ['#', '@', '@', '#', '#', '@', '@', '#'],
+  ['#', '#', '#', '@', '@', '#', '#', '#'],
+  ['#', '#', '@', '@', '@', '@', '#', '#'],
+  ['#', '#', '@', '@', '@', '@', '#', '#'],
+  ['#', '#', '@', '#', '#', '@', '#', '#'],
+  ['#', '#', '#', '#', '#', '#', '#', '#'],
+];
+
+export interface BannerOptions {
+  version: string;
+  gitHash?: string;
+  updateInfo?: UpdateCheckResult | null;
+  useAscii?: boolean;
+}
+
+/**
+ * Generate the banner string with creeper art and version info
+ */
+export function generateBanner(options: BannerOptions): string {
+  const { version, gitHash, updateInfo, useAscii = false } = options;
+  const art = useAscii ? CREEPER_ASCII : CREEPER_ART;
+
+  // Build right-side info lines
+  const versionStr = gitHash ? `v${version} (${gitHash})` : `v${version}`;
+  const infoLines = [
+    '',
+    `⛏️  mcctl ${versionStr}`,
+    '─────────────────────────────',
+    'Docker Minecraft Server',
+    'Controller CLI',
+    '',
+    'https://minecraft-server-manager.readthedocs.io',
+    '',
+  ];
+
+  // Build banner lines
+  const lines: string[] = [];
+
+  for (let i = 0; i < art.length; i++) {
+    const artRow = art[i]!.join('');
+    const infoLine = infoLines[i] || '';
+    lines.push(`${artRow}   ${infoLine}`);
+  }
+
+  // Add empty line
+  lines.push('');
+
+  // Add update notification if available
+  if (updateInfo) {
+    lines.push(
+      colors.yellow(`⚠️  Update available: ${updateInfo.currentVersion} → ${updateInfo.latestVersion}`)
+    );
+    lines.push(colors.dim(`    Run: ${updateInfo.updateCommand}`));
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Print the banner to console
+ */
+export function printBanner(options: BannerOptions): void {
+  console.log('');
+  console.log(generateBanner(options));
+}
+
+/**
+ * Get git commit hash (short)
+ */
+export function getGitHash(): string | undefined {
+  try {
+    const { execSync } = require('node:child_process');
+    const hash = execSync('git rev-parse --short HEAD', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return hash || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/platform/services/cli/tests/unit/lib/banner.test.ts
+++ b/platform/services/cli/tests/unit/lib/banner.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { generateBanner, CREEPER_ART, type BannerOptions } from '../../../src/lib/banner.js';
+
+describe('banner', () => {
+  describe('CREEPER_ART', () => {
+    it('should be an 8x8 square array', () => {
+      expect(CREEPER_ART).toHaveLength(8);
+      for (const row of CREEPER_ART) {
+        expect(row).toHaveLength(8);
+      }
+    });
+
+    it('should contain only valid emoji characters', () => {
+      const validChars = ['🟩', '⬛'];
+      for (const row of CREEPER_ART) {
+        for (const char of row) {
+          expect(validChars).toContain(char);
+        }
+      }
+    });
+  });
+
+  describe('generateBanner', () => {
+    it('should include version information', () => {
+      const options: BannerOptions = {
+        version: '2.2.0',
+        gitHash: 'abc1234',
+      };
+
+      const banner = generateBanner(options);
+
+      expect(banner).toContain('mcctl');
+      expect(banner).toContain('v2.2.0');
+      expect(banner).toContain('abc1234');
+    });
+
+    it('should include description', () => {
+      const options: BannerOptions = {
+        version: '2.2.0',
+      };
+
+      const banner = generateBanner(options);
+
+      expect(banner).toContain('Docker Minecraft Server');
+      expect(banner).toContain('Controller CLI');
+    });
+
+    it('should include documentation URL', () => {
+      const options: BannerOptions = {
+        version: '2.2.0',
+      };
+
+      const banner = generateBanner(options);
+
+      expect(banner).toContain('minecraft-server-manager.readthedocs.io');
+    });
+
+    it('should include update info when provided', () => {
+      const options: BannerOptions = {
+        version: '2.2.0',
+        updateInfo: {
+          currentVersion: '2.2.0',
+          latestVersion: '2.3.0',
+          updateCommand: 'npm install -g @minecraft-docker/mcctl',
+        },
+      };
+
+      const banner = generateBanner(options);
+
+      expect(banner).toContain('Update available');
+      expect(banner).toContain('2.2.0');
+      expect(banner).toContain('2.3.0');
+      expect(banner).toContain('npm install -g @minecraft-docker/mcctl');
+    });
+
+    it('should not include update section when no update available', () => {
+      const options: BannerOptions = {
+        version: '2.2.0',
+        updateInfo: null,
+      };
+
+      const banner = generateBanner(options);
+
+      expect(banner).not.toContain('Update available');
+    });
+
+    it('should include creeper ASCII art', () => {
+      const options: BannerOptions = {
+        version: '2.2.0',
+      };
+
+      const banner = generateBanner(options);
+
+      expect(banner).toContain('🟩');
+      expect(banner).toContain('⬛');
+    });
+
+    it('should handle missing git hash gracefully', () => {
+      const options: BannerOptions = {
+        version: '2.2.0',
+        gitHash: undefined,
+      };
+
+      const banner = generateBanner(options);
+
+      expect(banner).toContain('v2.2.0');
+      expect(banner).not.toContain('undefined');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add OpenClaw-style onboarding banner with Minecraft creeper ASCII art
- Display 8x8 emoji creeper face on `mcctl init`
- Show version info with git commit hash
- Check npm registry for updates (non-blocking with timeout)

## Changes

| File | Description |
|------|-------------|
| `src/lib/banner.ts` | Creeper ASCII art + version display + git hash |
| `src/commands/init.ts` | Integrate banner on init |
| `tests/unit/lib/banner.test.ts` | Unit tests for banner |

## Banner Preview

```
🟩🟩🟩🟩🟩🟩🟩🟩
🟩⬛⬛🟩🟩⬛⬛🟩   ⛏️  mcctl v2.2.0 (abc1234)
🟩⬛⬛🟩🟩⬛⬛🟩   ─────────────────────────────
🟩🟩🟩⬛⬛🟩🟩🟩   Docker Minecraft Server
🟩🟩⬛⬛⬛⬛🟩🟩   Controller CLI
🟩🟩⬛⬛⬛⬛🟩🟩
🟩🟩⬛🟩🟩⬛🟩🟩   https://minecraft-server-manager.readthedocs.io
🟩🟩🟩🟩🟩🟩🟩🟩

⚠️  Update available: 2.2.0 → 2.3.0
    Run: npm install -g @minecraft-docker/mcctl
```

## Test Plan

- [x] Unit tests pass (`npm run test -- tests/unit/lib/banner.test.ts`)
- [x] Build succeeds (`npm run build`)
- [x] Banner displays correctly with emoji
- [x] Version and git hash shown
- [x] Update check works (non-blocking)
- [x] ASCII fallback available for non-emoji terminals

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)