### PR TITLE
fix(console): align player list field name with backend (#359)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
@@ -507,13 +507,13 @@ export function ServerDetail({ server, onSendCommand }: ServerDetailProps) {
                       value={`${server.players.online} / ${server.players.max}`}
                     />
 
-                    {server.players.list && server.players.list.length > 0 && (
+                    {server.players.players && server.players.players.length > 0 && (
                       <>
                         <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
                           Online Players
                         </Typography>
                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                          {server.players.list.map((player) => (
+                          {server.players.players.map((player) => (
                             <Chip key={player} label={player} size="small" />
                           ))}
                         </Box>

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -27,7 +27,7 @@ export interface ServerDetail extends ServerSummary {
   players?: {
     online: number;
     max: number;
-    list: string[];
+    players: string[];
   };
   stats?: ServerStats;
   worldName?: string;


### PR DESCRIPTION
## Summary
- Frontend `IMcctlApiClient.ts`의 `list` 필드명을 Backend의 `players`와 일치시켜 플레이어 목록이 Overview에 표시되도록 수정
- `ServerDetail.tsx`의 참조도 `players.list` → `players.players`로 변경

## Test plan
- [ ] 플레이어 접속 시 Overview에 플레이어 이름 Chip 표시 확인
- [ ] 서버 미실행 시 "Player information unavailable" 표시 유지

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)