### PR TITLE
feat(console): add online-mode and whitelist settings (#357, #358)

### DIFF
--- a/platform/servers/_template/config.env
+++ b/platform/servers/_template/config.env
@@ -102,6 +102,12 @@ MODRINTH_DOWNLOAD_DEPENDENCIES=required
 # CF_LOADER=forge (optional - auto-detected from modpack)
 
 # -----------------------------------------------------------------------------
+# Authentication
+# -----------------------------------------------------------------------------
+ONLINE_MODE=TRUE
+# Set to FALSE to allow cracked clients (not recommended)
+
+# -----------------------------------------------------------------------------
 # Whitelist (Secure by Default)
 # -----------------------------------------------------------------------------
 ENABLE_WHITELIST=TRUE

--- a/platform/services/mcctl-api/src/schemas/config.ts
+++ b/platform/services/mcctl-api/src/schemas/config.ts
@@ -37,6 +37,10 @@ export const ServerConfigSchema = Type.Object({
   viewDistance: Type.Optional(Type.Number({ minimum: 2, maximum: 32, description: 'View distance in chunks' })),
   spawnProtection: Type.Optional(Type.Number({ minimum: 0, maximum: 100, description: 'Spawn protection radius' })),
 
+  // Security Settings (restart required)
+  onlineMode: Type.Optional(Type.Boolean({ description: 'Require Mojang authentication (online-mode)' })),
+  enableWhitelist: Type.Optional(Type.Boolean({ description: 'Enable whitelist to restrict player access' })),
+
   // Performance Settings (restart required)
   memory: Type.Optional(Type.String({ pattern: '^\\d+[MG]$', description: 'JVM memory allocation (e.g., 4G)' })),
   useAikarFlags: Type.Optional(Type.Boolean({ description: 'Use Aikar JVM flags for optimization' })),
@@ -54,6 +58,10 @@ export const UpdateServerConfigRequestSchema = Type.Object({
   pvp: Type.Optional(Type.Boolean()),
   viewDistance: Type.Optional(Type.Number({ minimum: 2, maximum: 32 })),
   spawnProtection: Type.Optional(Type.Number({ minimum: 0, maximum: 100 })),
+
+  // Security Settings (restart required)
+  onlineMode: Type.Optional(Type.Boolean()),
+  enableWhitelist: Type.Optional(Type.Boolean()),
 
   // Performance Settings (restart required)
   memory: Type.Optional(Type.String({ pattern: '^\\d+[MG]$' })),

--- a/platform/services/mcctl-api/src/services/ConfigService.ts
+++ b/platform/services/mcctl-api/src/services/ConfigService.ts
@@ -13,6 +13,8 @@ const CONFIG_FIELD_MAP: Record<keyof ServerConfig, string> = {
   pvp: 'PVP',
   viewDistance: 'VIEW_DISTANCE',
   spawnProtection: 'SPAWN_PROTECTION',
+  onlineMode: 'ONLINE_MODE',
+  enableWhitelist: 'ENABLE_WHITELIST',
   memory: 'MEMORY',
   useAikarFlags: 'USE_AIKAR_FLAGS',
 };
@@ -23,6 +25,8 @@ const CONFIG_FIELD_MAP: Record<keyof ServerConfig, string> = {
 const RESTART_REQUIRED_FIELDS: (keyof ServerConfig)[] = [
   'memory',
   'useAikarFlags',
+  'onlineMode',
+  'enableWhitelist',
 ];
 
 /**
@@ -68,6 +72,8 @@ function parseEnvValue(key: keyof ServerConfig, value: string | undefined): Serv
 
     case 'pvp':
     case 'useAikarFlags':
+    case 'onlineMode':
+    case 'enableWhitelist':
       return value.toLowerCase() === 'true';
 
     case 'difficulty':
@@ -105,6 +111,10 @@ function formatEnvValue(key: keyof ServerConfig, value: ServerConfig[keyof Serve
     case 'pvp':
     case 'useAikarFlags':
       return value ? 'true' : 'false';
+
+    case 'onlineMode':
+    case 'enableWhitelist':
+      return value ? 'TRUE' : 'FALSE';
 
     case 'difficulty':
     case 'gameMode':

--- a/platform/services/mcctl-console/src/components/servers/ServerOptionsTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerOptionsTab.tsx
@@ -74,8 +74,8 @@ export function ServerOptionsTab({ serverName, isRunning }: ServerOptionsTabProp
     setFormData((prev) => ({ ...prev, [field]: value }));
     setHasChanges(true);
 
-    // Track if performance settings changed
-    if (field === 'memory' || field === 'useAikarFlags') {
+    // Track if restart-required settings changed
+    if (field === 'memory' || field === 'useAikarFlags' || field === 'onlineMode' || field === 'enableWhitelist') {
       setPerformanceChanged(true);
     }
   };
@@ -260,6 +260,53 @@ export function ServerOptionsTab({ serverName, isRunning }: ServerOptionsTabProp
                 onChange={(e) => handleChange('spawnProtection', parseInt(e.target.value, 10))}
                 inputProps={{ min: 0, max: 128 }}
               />
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
+      {/* Security Settings Section */}
+      <Card sx={{ mb: 3, borderRadius: 3 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom fontWeight={600}>
+            Security Settings
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            These settings require a server restart to take effect.
+          </Typography>
+          <Divider sx={{ mb: 3 }} />
+
+          <Grid container spacing={3}>
+            {/* Online Mode */}
+            <Grid item xs={12} sm={6}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={formData.onlineMode ?? true}
+                    onChange={(e) => handleChange('onlineMode', e.target.checked)}
+                  />
+                }
+                label="Online Mode (Mojang Auth)"
+              />
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ ml: 4 }}>
+                Disable to allow cracked clients (not recommended)
+              </Typography>
+            </Grid>
+
+            {/* Whitelist */}
+            <Grid item xs={12} sm={6}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={formData.enableWhitelist ?? true}
+                    onChange={(e) => handleChange('enableWhitelist', e.target.checked)}
+                  />
+                }
+                label="Enable Whitelist"
+              />
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ ml: 4 }}>
+                Only whitelisted players can join
+              </Typography>
             </Grid>
           </Grid>
         </CardContent>

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -169,6 +169,10 @@ export interface ServerConfig {
   viewDistance?: number;
   spawnProtection?: number;
 
+  // Security Settings (restart required)
+  onlineMode?: boolean;
+  enableWhitelist?: boolean;
+
   // Performance Settings (restart required)
   memory?: string;
   useAikarFlags?: boolean;
@@ -186,6 +190,8 @@ export interface UpdateServerConfigRequest {
   pvp?: boolean;
   viewDistance?: number;
   spawnProtection?: number;
+  onlineMode?: boolean;
+  enableWhitelist?: boolean;
   memory?: string;
   useAikarFlags?: boolean;
 }


### PR DESCRIPTION
## Summary
- 서버 설정 페이지에 **Security Settings** 섹션 추가
- **Online Mode** 토글: `ONLINE_MODE` 환경변수 제어 (Mojang 인증 on/off)
- **Enable Whitelist** 토글: `ENABLE_WHITELIST` 환경변수 제어
- API 스키마, ConfigService, Frontend 타입 모두 업데이트
- config.env 템플릿에 `ONLINE_MODE=TRUE` 기본값 추가

## Test plan
- [ ] 설정 탭에서 Online Mode 토글 표시 및 변경
- [ ] 설정 탭에서 Whitelist 토글 표시 및 변경
- [ ] 변경 시 restart required 경고 표시
- [ ] config.env에 값 저장 확인

Closes #357
Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)