### PR TITLE
refactor(console): remove Roboto Mono font, use MUI default

### DIFF
--- a/platform/services/mcctl-console/src/app/layout.tsx
+++ b/platform/services/mcctl-console/src/app/layout.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import { Roboto_Mono } from 'next/font/google';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 import { ThemeProvider } from '@/theme';
 import { QueryProvider } from '@/lib';
 import { LoadingProvider } from '@/components/providers';
 import './globals.css';
-
-const robotoMono = Roboto_Mono({
-  subsets: ['latin'],
-  variable: '--font-roboto-mono',
-});
 
 export const metadata: Metadata = {
   title: 'Minecraft Server Manager',
@@ -24,7 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${robotoMono.variable} ${robotoMono.className}`}>
+      <body>
         <div id="__next">
           <AppRouterCacheProvider>
             <ThemeProvider>

--- a/platform/services/mcctl-console/src/components/admin/UserDetailDialog.tsx
+++ b/platform/services/mcctl-console/src/components/admin/UserDetailDialog.tsx
@@ -94,7 +94,7 @@ export function UserDetailDialog({ user, open, onClose }: UserDetailDialogProps)
             <Typography variant="caption" color="text.secondary">
               User ID
             </Typography>
-            <Typography variant="body2" sx={{ fontFamily: '"Roboto Mono", monospace', fontSize: '0.875rem' }}>
+            <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
               {user.id}
             </Typography>
           </Box>

--- a/platform/services/mcctl-console/src/components/audit-logs/AuditLogDetail.tsx
+++ b/platform/services/mcctl-console/src/components/audit-logs/AuditLogDetail.tsx
@@ -159,7 +159,7 @@ export function AuditLogDetail({ log, open, onClose }: AuditLogDetailProps) {
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
                 ID
               </Typography>
-              <Typography variant="body2" sx={{ fontFamily: '"Roboto Mono", monospace', fontSize: '0.8rem', wordBreak: 'break-all' }}>
+              <Typography variant="body2" sx={{ fontSize: '0.8rem', wordBreak: 'break-all' }}>
                 {log.id}
               </Typography>
             </Box>

--- a/platform/services/mcctl-console/src/components/common/HostnameDisplay.tsx
+++ b/platform/services/mcctl-console/src/components/common/HostnameDisplay.tsx
@@ -119,7 +119,6 @@ export function HostnameDisplay({
               <Typography
                 variant="body2"
                 sx={{
-                  fontFamily: '"Roboto Mono", monospace',
                   fontSize: 12,
                 }}
               >

--- a/platform/services/mcctl-console/src/components/servers/ConnectionInfoCard.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ConnectionInfoCard.tsx
@@ -31,7 +31,6 @@ function InfoRow({ label, value, copyText }: { label: string; value: string; cop
         <Typography
           variant="body2"
           sx={{
-            fontFamily: copyText ? '"Roboto Mono", monospace' : 'inherit',
             color: copyText ? 'text.primary' : 'text.secondary',
             wordBreak: 'break-all',
           }}

--- a/platform/services/mcctl-console/src/components/servers/HostnameSection.tsx
+++ b/platform/services/mcctl-console/src/components/servers/HostnameSection.tsx
@@ -193,7 +193,7 @@ export function HostnameSection({ serverName }: HostnameSectionProps) {
                     bgcolor: 'action.hover',
                   }}
                 >
-                  <Typography variant="body2" fontFamily='"Roboto Mono", monospace'>
+                  <Typography variant="body2">
                     {domain}
                   </Typography>
                   <IconButton

--- a/platform/services/mcctl-console/src/components/servers/ResourceStatCard.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ResourceStatCard.tsx
@@ -50,7 +50,6 @@ export function ResourceStatCard({
             sx={{
               fontWeight: 700,
               color: 'text.primary',
-              fontFamily: '"Roboto Mono", monospace',
               letterSpacing: '-0.5px',
             }}
           >

--- a/platform/services/mcctl-console/src/components/servers/ServerConsole.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerConsole.tsx
@@ -383,7 +383,6 @@ export function ServerConsole({ serverName }: ServerConsoleProps) {
           overflow: 'auto',
           bgcolor: '#1a1a1a',
           p: 1,
-          fontFamily: '"Roboto Mono", monospace',
           fontSize: '0.85rem',
         }}
       >
@@ -435,9 +434,8 @@ export function ServerConsole({ serverName }: ServerConsoleProps) {
           onChange={(e) => setCommand(e.target.value)}
           onKeyDown={handleKeyDown}
           disabled={!isConnected || isExecuting}
-          InputProps={{
-            sx: { fontFamily: '"Roboto Mono", monospace' },
-          }}
+          InputProps={{}}
+
         />
         <Button
           variant="contained"

--- a/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
@@ -301,7 +301,6 @@ export function ServerDetail({ server, onSendCommand }: ServerDetailProps) {
               overflowY: 'auto',
               px: 2.5,
               py: 2,
-              fontFamily: '"Roboto Mono", monospace',
               fontSize: 13,
               lineHeight: 1.85,
               color: '#b4b6c4',
@@ -452,7 +451,6 @@ export function ServerDetail({ server, onSendCommand }: ServerDetailProps) {
               sx: {
                 bgcolor: '#13141c',
                 borderRadius: 2,
-                fontFamily: '"Roboto Mono", monospace',
                 fontSize: 14,
                 '& .MuiOutlinedInput-notchedOutline': {
                   borderColor: '#2a2d3e',

--- a/platform/services/mcctl-console/src/components/servers/settings/RestartConfirmDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/settings/RestartConfirmDialog.tsx
@@ -46,7 +46,7 @@ export function RestartConfirmDialog({
             <ListItem key={field} sx={{ py: 0 }}>
               <ListItemText
                 primary={field}
-                primaryTypographyProps={{ variant: 'body2', fontFamily: '"Roboto Mono", monospace' }}
+                primaryTypographyProps={{ variant: 'body2' }}
               />
             </ListItem>
           ))}

--- a/platform/services/mcctl-console/src/components/settings/AccountInfoSection.tsx
+++ b/platform/services/mcctl-console/src/components/settings/AccountInfoSection.tsx
@@ -47,7 +47,7 @@ export function AccountInfoSection() {
             <TableRow>
               <TableCell sx={cellLabelSx}>Account ID</TableCell>
               <TableCell sx={cellValueSx}>
-                <Typography variant="body2" sx={{ fontFamily: '"Roboto Mono", monospace', fontSize: '0.8rem' }}>
+                <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
                   {user.id}
                 </Typography>
               </TableCell>

--- a/platform/services/mcctl-console/src/components/settings/PlayitSection.tsx
+++ b/platform/services/mcctl-console/src/components/settings/PlayitSection.tsx
@@ -246,7 +246,7 @@ export function PlayitSection() {
                           </TableCell>
                           <TableCell sx={{ py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
                             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                              <Typography variant="body2" sx={{ fontFamily: '"Roboto Mono", monospace', wordBreak: 'break-all' }}>
+                              <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
                                 {server.playitDomain}
                               </Typography>
                               <CopyButton text={server.playitDomain!} />

--- a/platform/services/mcctl-console/src/components/settings/RouterStatus.tsx
+++ b/platform/services/mcctl-console/src/components/settings/RouterStatus.tsx
@@ -182,7 +182,7 @@ export function RouterStatus({ router }: RouterStatusProps) {
                       <Typography
                         key={hostname}
                         variant="body2"
-                        sx={{ fontFamily: '"Roboto Mono", monospace', fontSize: '0.85rem', color: 'text.secondary' }}
+                        sx={{ fontSize: '0.85rem', color: 'text.secondary' }}
                       >
                         {hostname}
                       </Typography>

--- a/platform/services/mcctl-console/src/theme/muiTheme.ts
+++ b/platform/services/mcctl-console/src/theme/muiTheme.ts
@@ -60,9 +60,7 @@ export const darkTheme = createTheme({
       selected: colors.bgSurface,
     },
   },
-  typography: {
-    fontFamily: 'var(--font-roboto-mono), "Roboto Mono", monospace',
-  },
+  typography: {},
   components: {
     MuiCard: {
       styleOverrides: {


### PR DESCRIPTION
## Summary
- Roboto Mono 폰트를 전체 제거하고 MUI 기본 폰트(Roboto)로 통일
- 마인크래프트 폰트(`"Minecraft", sans-serif`)는 그대로 유지

## Changes
| 파일 | 변경 |
|------|------|
| `layout.tsx` | `Roboto_Mono` import 및 CSS variable 제거, body className 정리 |
| `muiTheme.ts` | 글로벌 `fontFamily` 오버라이드 제거 → MUI 기본값 사용 |
| 14개 컴포넌트 | 인라인 `fontFamily: '"Roboto Mono", monospace'` 제거 |

## Test plan
- [x] `pnpm build` 성공
- [x] `pnpm test` 통과 (기존 2개 실패는 pre-existing)
- [x] `Roboto Mono` 문자열이 src/ 내에서 완전히 제거됨 확인
- [ ] 브라우저에서 모든 페이지 폰트가 MUI 기본 Roboto로 표시되는지 확인
- [ ] 마인크래프트 폰트(GNB 로고 등)가 유지되는지 확인

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)