### PR TITLE
feat(console): Phase 3 - Player Management Specialized Editors (#377)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/files/PlayerEditorDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/files/PlayerEditorDialog.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Slide from '@mui/material/Slide';
+import CloseIcon from '@mui/icons-material/Close';
+import CodeIcon from '@mui/icons-material/Code';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import PeopleIcon from '@mui/icons-material/People';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import BlockIcon from '@mui/icons-material/Block';
+import type { TransitionProps } from '@mui/material/transitions';
+import { forwardRef } from 'react';
+import { WhitelistManager } from '@/components/players/WhitelistManager';
+import { OpManager } from '@/components/players/OpManager';
+import { BanManager } from '@/components/players/BanManager';
+
+const SlideTransition = forwardRef(function SlideTransition(
+  props: TransitionProps & { children: React.ReactElement },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
+
+export type PlayerEditorType = 'whitelist' | 'ops' | 'bans';
+
+interface PlayerEditorDialogProps {
+  serverName: string;
+  editorType: PlayerEditorType | null;
+  filePath: string | null;
+  onClose: () => void;
+  onSwitchToRaw: (path: string) => void;
+}
+
+const editorConfig: Record<PlayerEditorType, { label: string; icon: React.ReactNode }> = {
+  whitelist: { label: 'Whitelist Manager', icon: <PeopleIcon sx={{ mx: 1 }} /> },
+  ops: { label: 'Operators Manager', icon: <AdminPanelSettingsIcon sx={{ mx: 1 }} /> },
+  bans: { label: 'Ban List Manager', icon: <BlockIcon sx={{ mx: 1 }} /> },
+};
+
+export function getPlayerEditorType(fileName: string): PlayerEditorType | null {
+  switch (fileName) {
+    case 'whitelist.json':
+      return 'whitelist';
+    case 'ops.json':
+      return 'ops';
+    case 'banned-players.json':
+      return 'bans';
+    default:
+      return null;
+  }
+}
+
+export function PlayerEditorDialog({
+  serverName,
+  editorType,
+  filePath,
+  onClose,
+  onSwitchToRaw,
+}: PlayerEditorDialogProps) {
+  const isOpen = editorType !== null;
+  const config = editorType ? editorConfig[editorType] : null;
+
+  return (
+    <Dialog
+      fullScreen
+      open={isOpen}
+      onClose={onClose}
+      TransitionComponent={SlideTransition}
+    >
+      <AppBar sx={{ position: 'relative' }} color="default" elevation={1}>
+        <Toolbar variant="dense">
+          <IconButton edge="start" color="inherit" onClick={onClose} aria-label="close">
+            <CloseIcon />
+          </IconButton>
+          {config?.icon}
+          <Typography sx={{ flex: 1 }} variant="subtitle1" noWrap>
+            {config?.label}
+          </Typography>
+          {filePath && (
+            <Button
+              size="small"
+              startIcon={<CodeIcon />}
+              onClick={() => {
+                onClose();
+                onSwitchToRaw(filePath);
+              }}
+            >
+              Raw View
+            </Button>
+          )}
+        </Toolbar>
+      </AppBar>
+
+      <Box sx={{ flex: 1, overflow: 'auto', p: { xs: 1, sm: 2 } }}>
+        {editorType === 'whitelist' && <WhitelistManager serverName={serverName} />}
+        {editorType === 'ops' && <OpManager serverName={serverName} />}
+        {editorType === 'bans' && <BanManager serverName={serverName} />}
+      </Box>
+    </Dialog>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/files/ServerFilesTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/files/ServerFilesTab.tsx
@@ -20,6 +20,8 @@ import { FileBreadcrumb } from './FileBreadcrumb';
 import { FileToolbar } from './FileToolbar';
 import { FileList } from './FileList';
 import { TextEditor } from './TextEditor';
+import { PlayerEditorDialog, getPlayerEditorType } from './PlayerEditorDialog';
+import type { PlayerEditorType } from './PlayerEditorDialog';
 import type { FileEntry } from '@/ports/api/IMcctlApiClient';
 
 interface ServerFilesTabProps {
@@ -46,6 +48,10 @@ export function ServerFilesTab({ serverName }: ServerFilesTabProps) {
 
   // Text editor
   const [editorFilePath, setEditorFilePath] = useState<string | null>(null);
+
+  // Player editor (Smart Routing)
+  const [playerEditorType, setPlayerEditorType] = useState<PlayerEditorType | null>(null);
+  const [playerEditorPath, setPlayerEditorPath] = useState<string | null>(null);
 
   const { data, isLoading, error, refetch } = useServerFiles(serverName, currentPath);
   const deleteFile = useDeleteFile(serverName);
@@ -80,7 +86,13 @@ export function ServerFilesTab({ serverName }: ServerFilesTabProps) {
         break;
       case 'open': {
         const path = currentPath === '/' ? `/${file.name}` : `${currentPath}/${file.name}`;
-        setEditorFilePath(path);
+        const specialEditor = getPlayerEditorType(file.name);
+        if (specialEditor) {
+          setPlayerEditorType(specialEditor);
+          setPlayerEditorPath(path);
+        } else {
+          setEditorFilePath(path);
+        }
         break;
       }
     }
@@ -217,6 +229,22 @@ export function ServerFilesTab({ serverName }: ServerFilesTabProps) {
         serverName={serverName}
         filePath={editorFilePath}
         onClose={() => setEditorFilePath(null)}
+      />
+
+      {/* Player Editor (Smart Routing) */}
+      <PlayerEditorDialog
+        serverName={serverName}
+        editorType={playerEditorType}
+        filePath={playerEditorPath}
+        onClose={() => {
+          setPlayerEditorType(null);
+          setPlayerEditorPath(null);
+        }}
+        onSwitchToRaw={(path) => {
+          setPlayerEditorType(null);
+          setPlayerEditorPath(null);
+          setEditorFilePath(path);
+        }}
       />
 
       <Snackbar


### PR DESCRIPTION
## Summary
- `whitelist.json`, `ops.json`, `banned-players.json` 클릭 시 전용 Player Editor로 자동 라우팅 (Smart Routing)
- 기존 `WhitelistManager`, `OpManager`, `BanManager` 컴포넌트를 fullscreen Dialog로 래핑하여 재활용
- Raw View 버튼으로 TextEditor 전환 지원

## Changes
- **New**: `PlayerEditorDialog.tsx` - Player editor wrapper (fullscreen Dialog + existing managers)
- **Modified**: `ServerFilesTab.tsx` - Smart routing: special files → PlayerEditorDialog, others → TextEditor

## Architecture
- 신규 백엔드 작업 없음: 기존 whitelist/ops/bans API 100% 재활용
- `getPlayerEditorType()` 유틸리티 함수로 파일명 → 에디터 타입 매핑

## Test plan
- [ ] File browser에서 `whitelist.json` 클릭 → WhitelistManager 열림
- [ ] File browser에서 `ops.json` 클릭 → OpManager 열림
- [ ] File browser에서 `banned-players.json` 클릭 → BanManager 열림
- [ ] Raw View 버튼 클릭 → TextEditor로 전환
- [ ] 일반 텍스트 파일 클릭 → TextEditor 열림 (기존 동작 유지)
- [ ] 빌드 성공 확인

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)