### PR TITLE
refactor(console): convert file editors from Dialog to inline view (#389)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/files/PlayerEditorDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/files/PlayerEditorDialog.tsx
@@ -1,47 +1,34 @@
 'use client';
 
-import { useState } from 'react';
-import Dialog from '@mui/material/Dialog';
-import AppBar from '@mui/material/AppBar';
-import Toolbar from '@mui/material/Toolbar';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import Slide from '@mui/material/Slide';
-import CloseIcon from '@mui/icons-material/Close';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CodeIcon from '@mui/icons-material/Code';
-import ListAltIcon from '@mui/icons-material/ListAlt';
 import PeopleIcon from '@mui/icons-material/People';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import BlockIcon from '@mui/icons-material/Block';
-import type { TransitionProps } from '@mui/material/transitions';
-import { forwardRef } from 'react';
 import { WhitelistManager } from '@/components/players/WhitelistManager';
 import { OpManager } from '@/components/players/OpManager';
 import { BanManager } from '@/components/players/BanManager';
 
-const SlideTransition = forwardRef(function SlideTransition(
-  props: TransitionProps & { children: React.ReactElement },
-  ref: React.Ref<unknown>,
-) {
-  return <Slide direction="up" ref={ref} {...props} />;
-});
-
 export type PlayerEditorType = 'whitelist' | 'ops' | 'bans';
 
-interface PlayerEditorDialogProps {
+interface PlayerEditorViewProps {
   serverName: string;
-  editorType: PlayerEditorType | null;
+  editorType: PlayerEditorType;
   filePath: string | null;
-  onClose: () => void;
+  onBack: () => void;
   onSwitchToRaw: (path: string) => void;
 }
 
 const editorConfig: Record<PlayerEditorType, { label: string; icon: React.ReactNode }> = {
-  whitelist: { label: 'Whitelist Manager', icon: <PeopleIcon sx={{ mx: 1 }} /> },
-  ops: { label: 'Operators Manager', icon: <AdminPanelSettingsIcon sx={{ mx: 1 }} /> },
-  bans: { label: 'Ban List Manager', icon: <BlockIcon sx={{ mx: 1 }} /> },
+  whitelist: { label: 'Whitelist Manager', icon: <PeopleIcon sx={{ color: 'primary.main' }} /> },
+  ops: { label: 'Operators Manager', icon: <AdminPanelSettingsIcon sx={{ color: 'primary.main' }} /> },
+  bans: { label: 'Ban List Manager', icon: <BlockIcon sx={{ color: 'primary.main' }} /> },
 };
 
 export function getPlayerEditorType(fileName: string): PlayerEditorType | null {
@@ -61,48 +48,52 @@ export function PlayerEditorDialog({
   serverName,
   editorType,
   filePath,
-  onClose,
+  onBack,
   onSwitchToRaw,
-}: PlayerEditorDialogProps) {
-  const isOpen = editorType !== null;
-  const config = editorType ? editorConfig[editorType] : null;
+}: PlayerEditorViewProps) {
+  const config = editorConfig[editorType];
 
   return (
-    <Dialog
-      fullScreen
-      open={isOpen}
-      onClose={onClose}
-      TransitionComponent={SlideTransition}
-    >
-      <AppBar sx={{ position: 'relative' }} color="default" elevation={1}>
-        <Toolbar variant="dense">
-          <IconButton edge="start" color="inherit" onClick={onClose} aria-label="close">
-            <CloseIcon />
-          </IconButton>
-          {config?.icon}
-          <Typography sx={{ flex: 1 }} variant="subtitle1" noWrap>
-            {config?.label}
-          </Typography>
-          {filePath && (
-            <Button
-              size="small"
-              startIcon={<CodeIcon />}
-              onClick={() => {
-                onClose();
-                onSwitchToRaw(filePath);
-              }}
-            >
-              Raw View
-            </Button>
-          )}
-        </Toolbar>
-      </AppBar>
+    <Card sx={{ borderRadius: 3, display: 'flex', flexDirection: 'column', minHeight: 600 }}>
+      {/* Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 2,
+          py: 1,
+          borderBottom: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <IconButton size="small" onClick={onBack} aria-label="back">
+          <ArrowBackIcon />
+        </IconButton>
+        {config.icon}
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: 1 }} noWrap>
+          {config.label}
+        </Typography>
+        {filePath && (
+          <Button
+            size="small"
+            startIcon={<CodeIcon />}
+            onClick={() => {
+              onBack();
+              onSwitchToRaw(filePath);
+            }}
+          >
+            Raw View
+          </Button>
+        )}
+      </Box>
 
-      <Box sx={{ flex: 1, overflow: 'auto', p: { xs: 1, sm: 2 } }}>
+      {/* Content */}
+      <CardContent sx={{ flex: 1, overflow: 'auto', p: { xs: 1, sm: 2 }, '&:last-child': { pb: 2 } }}>
         {editorType === 'whitelist' && <WhitelistManager serverName={serverName} />}
         {editorType === 'ops' && <OpManager serverName={serverName} />}
         {editorType === 'bans' && <BanManager serverName={serverName} />}
-      </Box>
-    </Dialog>
+      </CardContent>
+    </Card>
   );
 }

--- a/platform/services/mcctl-console/src/components/servers/files/ServerFilesTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/files/ServerFilesTab.tsx
@@ -189,6 +189,37 @@ export function ServerFilesTab({ serverName }: ServerFilesTabProps) {
     );
   }
 
+  // Inline text editor view (replaces file browser)
+  if (editorFilePath) {
+    return (
+      <TextEditor
+        serverName={serverName}
+        filePath={editorFilePath}
+        onBack={() => setEditorFilePath(null)}
+      />
+    );
+  }
+
+  // Inline player editor view (replaces file browser)
+  if (playerEditorType) {
+    return (
+      <PlayerEditorDialog
+        serverName={serverName}
+        editorType={playerEditorType}
+        filePath={playerEditorPath}
+        onBack={() => {
+          setPlayerEditorType(null);
+          setPlayerEditorPath(null);
+        }}
+        onSwitchToRaw={(path) => {
+          setPlayerEditorType(null);
+          setPlayerEditorPath(null);
+          setEditorFilePath(path);
+        }}
+      />
+    );
+  }
+
   return (
     <>
       <Card sx={{ borderRadius: 3 }}>
@@ -236,29 +267,6 @@ export function ServerFilesTab({ serverName }: ServerFilesTabProps) {
         isPending={uploadFiles.isPending}
         onUpload={handleUpload}
         onClose={() => setUploadDialogOpen(false)}
-      />
-
-      {/* Text Editor */}
-      <TextEditor
-        serverName={serverName}
-        filePath={editorFilePath}
-        onClose={() => setEditorFilePath(null)}
-      />
-
-      {/* Player Editor (Smart Routing) */}
-      <PlayerEditorDialog
-        serverName={serverName}
-        editorType={playerEditorType}
-        filePath={playerEditorPath}
-        onClose={() => {
-          setPlayerEditorType(null);
-          setPlayerEditorPath(null);
-        }}
-        onSwitchToRaw={(path) => {
-          setPlayerEditorType(null);
-          setPlayerEditorPath(null);
-          setEditorFilePath(path);
-        }}
       />
 
       <Snackbar


### PR DESCRIPTION
## Summary

- TextEditor를 fullScreen Dialog에서 인라인 Card 뷰로 변환
- PlayerEditorDialog를 fullScreen Dialog에서 인라인 Card 뷰로 변환
- ServerFilesTab의 라우팅 로직을 모든 에디터가 인라인 교체 방식으로 동작하도록 수정
- ServerPropertiesView와 동일한 헤더 패턴 (← 뒤로 | 아이콘 | 타이틀 | 액션 버튼) 적용

## Test plan

- [ ] 일반 텍스트 파일 클릭 시 인라인 뷰로 열리는지 확인
- [ ] server.properties 클릭 시 기존과 동일하게 인라인 뷰로 열리는지 확인
- [ ] whitelist.json / ops.json / banned-players.json 클릭 시 인라인 뷰로 열리는지 확인
- [ ] 뒤로가기 버튼으로 파일 브라우저로 정상 복귀하는지 확인
- [ ] TextEditor에서 수정 후 뒤로가기 시 Unsaved Changes 확인 다이얼로그 동작 확인
- [ ] CodeMirror 에디터 초기화/저장/Cmd-S 단축키 정상 동작 확인
- [ ] Player Editor의 Raw View 전환 정상 동작 확인
- [ ] TypeScript 빌드 에러 없음 확인

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)