### PR TITLE
feat(cli): add mcctl config-snapshot CLI commands (#401)

### DIFF
--- a/platform/services/cli/src/commands/config-snapshot/create.ts
+++ b/platform/services/cli/src/commands/config-snapshot/create.ts
@@ -1,0 +1,64 @@
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotCreateOptions {
+  root?: string;
+  serverName?: string;
+  description?: string;
+  json?: boolean;
+}
+
+/**
+ * Create a new config snapshot for a server
+ */
+export async function configSnapshotCreateCommand(
+  options: ConfigSnapshotCreateOptions
+): Promise<number> {
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotUseCase;
+
+  // Validate server name
+  if (!options.serverName) {
+    log.error('Server name is required. Usage: mcctl config-snapshot create <server>');
+    return 1;
+  }
+
+  try {
+    console.log('');
+    console.log(
+      colors.dim(
+        `Creating snapshot for server "${options.serverName}"...`
+      )
+    );
+
+    const snapshot = await useCase.create(
+      options.serverName,
+      options.description
+    );
+
+    if (options.json) {
+      console.log(JSON.stringify(snapshot.toJSON(), null, 2));
+      return 0;
+    }
+
+    console.log(colors.green('Snapshot created successfully!'));
+    console.log(`  ID:     ${colors.cyan(snapshot.id)}`);
+    console.log(`  Server: ${colors.bold(snapshot.serverName.value)}`);
+    console.log(
+      `  Files:  ${colors.yellow(String(snapshot.files.length))} files captured`
+    );
+    console.log(
+      `  Time:   ${colors.dim(snapshot.createdAt.toLocaleString())}`
+    );
+    if (snapshot.description) {
+      console.log(`  Note:   ${colors.dim(snapshot.description)}`);
+    }
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to create snapshot: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/delete.ts
+++ b/platform/services/cli/src/commands/config-snapshot/delete.ts
@@ -1,0 +1,62 @@
+import * as p from '@clack/prompts';
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotDeleteOptions {
+  root?: string;
+  id: string;
+  force?: boolean;
+}
+
+/**
+ * Delete a config snapshot
+ */
+export async function configSnapshotDeleteCommand(
+  options: ConfigSnapshotDeleteOptions
+): Promise<number> {
+  if (!options.id) {
+    log.error('Snapshot ID is required. Usage: mcctl config-snapshot delete <id>');
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotUseCase;
+
+  try {
+    const snapshot = await useCase.findById(options.id);
+
+    if (!snapshot) {
+      log.error(`Snapshot not found: ${options.id}`);
+      return 1;
+    }
+
+    // Confirmation prompt (unless --force)
+    if (!options.force) {
+      const confirmed = await p.confirm({
+        message: `Delete snapshot ${colors.cyan(snapshot.id.substring(0, 8))} for server "${colors.bold(snapshot.serverName.value)}" (${snapshot.files.length} files, created ${snapshot.createdAt.toLocaleDateString()})?`,
+        initialValue: false,
+      });
+
+      if (p.isCancel(confirmed) || !confirmed) {
+        console.log(colors.dim('\nDeletion cancelled.\n'));
+        return 0;
+      }
+    }
+
+    await useCase.delete(options.id);
+
+    console.log('');
+    console.log(
+      colors.green(
+        `Snapshot deleted: ${colors.bold(snapshot.id.substring(0, 8))}...`
+      )
+    );
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to delete snapshot: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/diff.ts
+++ b/platform/services/cli/src/commands/config-snapshot/diff.ts
@@ -1,0 +1,190 @@
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../infrastructure/di/container.js';
+import type { FileDiff } from '@minecraft-docker/shared';
+
+export interface ConfigSnapshotDiffOptions {
+  root?: string;
+  id1: string;
+  id2: string;
+  unified?: boolean;
+  sideBySide?: boolean;
+  filesOnly?: boolean;
+  json?: boolean;
+}
+
+/**
+ * Display diff between two config snapshots
+ */
+export async function configSnapshotDiffCommand(
+  options: ConfigSnapshotDiffOptions
+): Promise<number> {
+  if (!options.id1 || !options.id2) {
+    log.error(
+      'Two snapshot IDs are required. Usage: mcctl config-snapshot diff <id1> <id2>'
+    );
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotUseCase;
+
+  try {
+    const diff = await useCase.diff(options.id1, options.id2);
+
+    if (options.json) {
+      console.log(JSON.stringify(diff.toJSON(), null, 2));
+      return 0;
+    }
+
+    // Summary header
+    const { added, modified, deleted } = diff.summary;
+    console.log('');
+    console.log(colors.bold('Snapshot Diff'));
+    console.log(`  Base:    ${colors.dim(options.id1.substring(0, 8))}...`);
+    console.log(`  Compare: ${colors.dim(options.id2.substring(0, 8))}...`);
+    console.log('');
+
+    if (!diff.hasChanges) {
+      console.log(colors.dim('No differences found between snapshots.'));
+      console.log('');
+      return 0;
+    }
+
+    // Summary line
+    const summaryParts: string[] = [];
+    if (added > 0) summaryParts.push(colors.green(`+${added} added`));
+    if (modified > 0) summaryParts.push(colors.yellow(`~${modified} modified`));
+    if (deleted > 0) summaryParts.push(colors.red(`-${deleted} deleted`));
+    console.log(`  Changes: ${summaryParts.join(', ')}`);
+    console.log('');
+
+    if (options.filesOnly) {
+      // Show only file names with status indicators
+      console.log(colors.bold('Changed Files:'));
+      console.log('');
+
+      for (const change of diff.changes) {
+        const statusIcon = getStatusIcon(change.status);
+        const statusColor = getStatusColor(change.status);
+        console.log(`  ${statusIcon} ${statusColor(change.path)}`);
+      }
+
+      console.log('');
+      return 0;
+    }
+
+    // Full diff output
+    for (const change of diff.changes) {
+      printFileDiff(change);
+    }
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to compute diff: ${message}`);
+    return 1;
+  }
+}
+
+/**
+ * Get the status icon for a file change
+ */
+function getStatusIcon(status: string): string {
+  switch (status) {
+    case 'added':
+      return colors.green('+');
+    case 'deleted':
+      return colors.red('-');
+    case 'modified':
+      return colors.yellow('~');
+    default:
+      return ' ';
+  }
+}
+
+/**
+ * Get the color function for a file change status
+ */
+function getStatusColor(
+  status: string
+): (text: string) => string {
+  switch (status) {
+    case 'added':
+      return colors.green;
+    case 'deleted':
+      return colors.red;
+    case 'modified':
+      return colors.yellow;
+    default:
+      return (t: string) => t;
+  }
+}
+
+/**
+ * Print unified diff output for a single file
+ */
+function printFileDiff(change: FileDiff): void {
+  const statusLabel =
+    change.status === 'added'
+      ? colors.green('[ADDED]')
+      : change.status === 'deleted'
+        ? colors.red('[DELETED]')
+        : colors.yellow('[MODIFIED]');
+
+  console.log(`${statusLabel} ${colors.bold(change.path)}`);
+
+  if (change.status === 'added' && change.newContent !== undefined) {
+    // Show added file content (first 10 lines)
+    const lines = change.newContent.split('\n').slice(0, 10);
+    for (const line of lines) {
+      console.log(colors.green(`  + ${line}`));
+    }
+    if (change.newContent.split('\n').length > 10) {
+      console.log(colors.dim('  ... (truncated)'));
+    }
+  } else if (change.status === 'deleted' && change.oldContent !== undefined) {
+    // Show deleted file content (first 10 lines)
+    const lines = change.oldContent.split('\n').slice(0, 10);
+    for (const line of lines) {
+      console.log(colors.red(`  - ${line}`));
+    }
+    if (change.oldContent.split('\n').length > 10) {
+      console.log(colors.dim('  ... (truncated)'));
+    }
+  } else if (
+    change.status === 'modified' &&
+    change.oldContent !== undefined &&
+    change.newContent !== undefined
+  ) {
+    // Produce a simple line-by-line diff
+    const oldLines = change.oldContent.split('\n');
+    const newLines = change.newContent.split('\n');
+
+    const maxLines = Math.min(Math.max(oldLines.length, newLines.length), 20);
+
+    for (let i = 0; i < maxLines; i++) {
+      const oldLine = oldLines[i];
+      const newLine = newLines[i];
+
+      if (oldLine === undefined && newLine !== undefined) {
+        console.log(colors.green(`  + ${newLine}`));
+      } else if (newLine === undefined && oldLine !== undefined) {
+        console.log(colors.red(`  - ${oldLine}`));
+      } else if (oldLine !== newLine) {
+        if (oldLine !== undefined) {
+          console.log(colors.red(`  - ${oldLine}`));
+        }
+        if (newLine !== undefined) {
+          console.log(colors.green(`  + ${newLine}`));
+        }
+      }
+    }
+
+    const totalLines = Math.max(oldLines.length, newLines.length);
+    if (totalLines > 20) {
+      console.log(colors.dim(`  ... (${totalLines - 20} more lines)`));
+    }
+  }
+
+  console.log('');
+}

--- a/platform/services/cli/src/commands/config-snapshot/index.ts
+++ b/platform/services/cli/src/commands/config-snapshot/index.ts
@@ -1,0 +1,36 @@
+export {
+  configSnapshotListCommand,
+  type ConfigSnapshotListOptions,
+} from './list.js';
+export {
+  configSnapshotCreateCommand,
+  type ConfigSnapshotCreateOptions,
+} from './create.js';
+export {
+  configSnapshotShowCommand,
+  type ConfigSnapshotShowOptions,
+} from './show.js';
+export {
+  configSnapshotDeleteCommand,
+  type ConfigSnapshotDeleteOptions,
+} from './delete.js';
+export {
+  configSnapshotDiffCommand,
+  type ConfigSnapshotDiffOptions,
+} from './diff.js';
+export {
+  configSnapshotRestoreCommand,
+  type ConfigSnapshotRestoreOptions,
+} from './restore.js';
+
+// Schedule sub-commands
+export {
+  configSnapshotScheduleListCommand,
+  type ConfigSnapshotScheduleListOptions,
+  configSnapshotScheduleAddCommand,
+  type ConfigSnapshotScheduleAddOptions,
+  configSnapshotScheduleRemoveCommand,
+  type ConfigSnapshotScheduleRemoveOptions,
+  configSnapshotScheduleToggleCommand,
+  type ConfigSnapshotScheduleToggleOptions,
+} from './schedule/index.js';

--- a/platform/services/cli/src/commands/config-snapshot/list.ts
+++ b/platform/services/cli/src/commands/config-snapshot/list.ts
@@ -1,0 +1,85 @@
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotListOptions {
+  root?: string;
+  serverName?: string;
+  limit?: number;
+  offset?: number;
+  json?: boolean;
+}
+
+/**
+ * List config snapshots (all servers or specific server)
+ */
+export async function configSnapshotListCommand(
+  options: ConfigSnapshotListOptions
+): Promise<number> {
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotUseCase;
+  const limit = options.limit ?? 20;
+
+  try {
+    const snapshots = await useCase.list(options.serverName, limit, options.offset);
+
+    if (options.json) {
+      console.log(JSON.stringify(snapshots.map((s) => s.toJSON()), null, 2));
+      return 0;
+    }
+
+    if (snapshots.length === 0) {
+      console.log('');
+      if (options.serverName) {
+        console.log(
+          colors.dim(
+            `No snapshots found for server "${options.serverName}".`
+          )
+        );
+      } else {
+        console.log(colors.dim('No snapshots found.'));
+      }
+      console.log(
+        colors.dim(
+          '  Use: mcctl config-snapshot create <server> to create one.'
+        )
+      );
+      console.log('');
+      return 0;
+    }
+
+    console.log('');
+    if (options.serverName) {
+      console.log(
+        colors.bold(
+          `Config Snapshots for ${options.serverName} (${snapshots.length}):`
+        )
+      );
+    } else {
+      console.log(
+        colors.bold(`Config Snapshots (${snapshots.length}):`)
+      );
+    }
+    console.log('');
+
+    for (const snapshot of snapshots) {
+      const date = snapshot.createdAt.toLocaleString();
+      const server = colors.cyan(snapshot.serverName.value.padEnd(15));
+      const id = colors.dim(snapshot.id.substring(0, 8) + '...');
+      const fileCount = colors.yellow(`${snapshot.files.length} files`);
+      const desc = snapshot.description
+        ? colors.dim(`  "${snapshot.description}"`)
+        : '';
+
+      console.log(
+        `  ${server}  ${colors.dim(date)}  ${fileCount}  ${id}${desc}`
+      );
+    }
+
+    console.log('');
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to list snapshots: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/restore.ts
+++ b/platform/services/cli/src/commands/config-snapshot/restore.ts
@@ -1,0 +1,85 @@
+import * as p from '@clack/prompts';
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotRestoreOptions {
+  root?: string;
+  id: string;
+  force?: boolean;
+  noSafety?: boolean;
+}
+
+/**
+ * Restore server configuration from a config snapshot
+ */
+export async function configSnapshotRestoreCommand(
+  options: ConfigSnapshotRestoreOptions
+): Promise<number> {
+  if (!options.id) {
+    log.error(
+      'Snapshot ID is required. Usage: mcctl config-snapshot restore <id>'
+    );
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotUseCase;
+
+  try {
+    const snapshot = await useCase.findById(options.id);
+
+    if (!snapshot) {
+      log.error(`Snapshot not found: ${options.id}`);
+      return 1;
+    }
+
+    // Confirmation prompt (unless --force)
+    if (!options.force) {
+      console.log('');
+      console.log(colors.bold('Restore Configuration'));
+      console.log(`  Server:  ${colors.bold(snapshot.serverName.value)}`);
+      console.log(`  Snapshot: ${colors.cyan(snapshot.id.substring(0, 8))}...`);
+      console.log(
+        `  Created: ${colors.dim(snapshot.createdAt.toLocaleString())}`
+      );
+      console.log(
+        `  Files:   ${colors.yellow(String(snapshot.files.length))} files will be overwritten`
+      );
+      if (snapshot.description) {
+        console.log(`  Note:    ${colors.dim(snapshot.description)}`);
+      }
+      console.log('');
+
+      const confirmed = await p.confirm({
+        message: `Restore ${snapshot.files.length} files for server "${snapshot.serverName.value}"? This will overwrite current configuration.`,
+        initialValue: false,
+      });
+
+      if (p.isCancel(confirmed) || !confirmed) {
+        console.log(colors.dim('\nRestore cancelled.\n'));
+        return 0;
+      }
+    }
+
+    console.log(colors.dim('\nRestoring configuration files...'));
+
+    await useCase.restore(options.id, options.force ?? false);
+
+    console.log('');
+    console.log(
+      colors.green(
+        `Configuration restored from snapshot ${colors.bold(snapshot.id.substring(0, 8))}...`
+      )
+    );
+    console.log(
+      `  ${colors.yellow(String(snapshot.files.length))} files restored for server "${colors.bold(snapshot.serverName.value)}".`
+    );
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to restore snapshot: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/schedule/add.ts
+++ b/platform/services/cli/src/commands/config-snapshot/schedule/add.ts
@@ -1,0 +1,79 @@
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotScheduleAddOptions {
+  root?: string;
+  serverName?: string;
+  cron?: string;
+  name?: string;
+  retention?: number;
+  json?: boolean;
+}
+
+/**
+ * Add a new config snapshot schedule
+ */
+export async function configSnapshotScheduleAddCommand(
+  options: ConfigSnapshotScheduleAddOptions
+): Promise<number> {
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotScheduleUseCase;
+
+  // Validate required fields
+  if (!options.serverName) {
+    log.error(
+      '--server is required. Usage: mcctl config-snapshot schedule add --server <name> --cron "..." --name "..."'
+    );
+    return 1;
+  }
+
+  if (!options.cron) {
+    log.error(
+      '--cron is required. Example: --cron "0 3 * * *"'
+    );
+    return 1;
+  }
+
+  if (!options.name) {
+    log.error(
+      '--name is required. Example: --name "Daily Snapshot"'
+    );
+    return 1;
+  }
+
+  const retentionCount = options.retention ?? 10;
+
+  try {
+    const schedule = await useCase.create(
+      options.serverName,
+      options.name,
+      options.cron,
+      retentionCount
+    );
+
+    if (options.json) {
+      console.log(JSON.stringify(schedule.toJSON(), null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.green('Config snapshot schedule created!'));
+    console.log(`  Name:      ${colors.bold(schedule.name)}`);
+    console.log(`  Server:    ${colors.bold(schedule.serverName.value)}`);
+    console.log(`  Cron:      ${colors.cyan(schedule.cronExpression.expression)}`);
+    console.log(
+      `  Schedule:  ${schedule.cronExpression.toHumanReadable()}`
+    );
+    console.log(
+      `  Retention: max ${colors.yellow(String(schedule.retentionCount))} snapshots`
+    );
+    console.log(`  ID:        ${colors.dim(schedule.id)}`);
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to create schedule: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/schedule/index.ts
+++ b/platform/services/cli/src/commands/config-snapshot/schedule/index.ts
@@ -1,0 +1,16 @@
+export {
+  configSnapshotScheduleListCommand,
+  type ConfigSnapshotScheduleListOptions,
+} from './list.js';
+export {
+  configSnapshotScheduleAddCommand,
+  type ConfigSnapshotScheduleAddOptions,
+} from './add.js';
+export {
+  configSnapshotScheduleRemoveCommand,
+  type ConfigSnapshotScheduleRemoveOptions,
+} from './remove.js';
+export {
+  configSnapshotScheduleToggleCommand,
+  type ConfigSnapshotScheduleToggleOptions,
+} from './toggle.js';

--- a/platform/services/cli/src/commands/config-snapshot/schedule/list.ts
+++ b/platform/services/cli/src/commands/config-snapshot/schedule/list.ts
@@ -1,0 +1,90 @@
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotScheduleListOptions {
+  root?: string;
+  serverName?: string;
+  json?: boolean;
+}
+
+/**
+ * List config snapshot schedules
+ */
+export async function configSnapshotScheduleListCommand(
+  options: ConfigSnapshotScheduleListOptions
+): Promise<number> {
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotScheduleUseCase;
+
+  try {
+    const schedules = options.serverName
+      ? await useCase.findByServer(options.serverName)
+      : await useCase.findAll();
+
+    if (options.json) {
+      console.log(JSON.stringify(schedules.map((s) => s.toJSON()), null, 2));
+      return 0;
+    }
+
+    if (schedules.length === 0) {
+      console.log('');
+      if (options.serverName) {
+        console.log(
+          colors.dim(
+            `No schedules configured for server "${options.serverName}".`
+          )
+        );
+      } else {
+        console.log(colors.dim('No schedules configured.'));
+      }
+      console.log(
+        colors.dim(
+          '  Use: mcctl config-snapshot schedule add --server <name> --cron "0 3 * * *" --name "Daily"'
+        )
+      );
+      console.log('');
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.bold(`Config Snapshot Schedules (${schedules.length}):`));
+    console.log('');
+
+    for (const schedule of schedules) {
+      const status = schedule.enabled
+        ? colors.green('enabled')
+        : colors.dim('disabled');
+
+      const name = colors.bold(schedule.name);
+      const cron = colors.cyan(schedule.cronExpression.expression);
+      const humanReadable = colors.dim(
+        `(${schedule.cronExpression.toHumanReadable()})`
+      );
+
+      console.log(
+        `  ${name}  ${cron} ${humanReadable}  [${status}]`
+      );
+      console.log(`    ID:        ${colors.dim(schedule.id)}`);
+      console.log(`    Server:    ${colors.bold(schedule.serverName.value)}`);
+      console.log(
+        `    Retention: max ${colors.yellow(String(schedule.retentionCount))} snapshots`
+      );
+
+      if (schedule.lastRunAt) {
+        const statusColor =
+          schedule.lastRunStatus === 'success' ? colors.green : colors.red;
+        console.log(
+          `    Last run:  ${statusColor(schedule.lastRunStatus ?? 'unknown')} at ${schedule.lastRunAt.toLocaleString()}`
+        );
+      }
+
+      console.log('');
+    }
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to list schedules: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/schedule/remove.ts
+++ b/platform/services/cli/src/commands/config-snapshot/schedule/remove.ts
@@ -1,0 +1,57 @@
+import * as p from '@clack/prompts';
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotScheduleRemoveOptions {
+  root?: string;
+  id: string;
+  force?: boolean;
+}
+
+/**
+ * Remove a config snapshot schedule
+ */
+export async function configSnapshotScheduleRemoveCommand(
+  options: ConfigSnapshotScheduleRemoveOptions
+): Promise<number> {
+  if (!options.id) {
+    log.error(
+      'Schedule ID is required. Usage: mcctl config-snapshot schedule remove <id>'
+    );
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotScheduleUseCase;
+
+  try {
+    // Confirmation prompt (unless --force)
+    if (!options.force) {
+      const confirmed = await p.confirm({
+        message: `Remove schedule ${colors.cyan(options.id.substring(0, 8))}...?`,
+        initialValue: false,
+      });
+
+      if (p.isCancel(confirmed) || !confirmed) {
+        console.log(colors.dim('\nRemoval cancelled.\n'));
+        return 0;
+      }
+    }
+
+    await useCase.delete(options.id);
+
+    console.log('');
+    console.log(
+      colors.green(
+        `Schedule removed: ${colors.dim(options.id.substring(0, 8))}...`
+      )
+    );
+    console.log('');
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to remove schedule: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/schedule/toggle.ts
+++ b/platform/services/cli/src/commands/config-snapshot/schedule/toggle.ts
@@ -1,0 +1,55 @@
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotScheduleToggleOptions {
+  root?: string;
+  id: string;
+  action: 'enable' | 'disable';
+}
+
+/**
+ * Enable or disable a config snapshot schedule
+ */
+export async function configSnapshotScheduleToggleCommand(
+  options: ConfigSnapshotScheduleToggleOptions
+): Promise<number> {
+  if (!options.id) {
+    log.error(
+      `Schedule ID is required. Usage: mcctl config-snapshot schedule ${options.action} <id>`
+    );
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotScheduleUseCase;
+
+  try {
+    if (options.action === 'enable') {
+      await useCase.enable(options.id);
+
+      console.log('');
+      console.log(
+        colors.green(
+          `Schedule enabled: ${colors.dim(options.id.substring(0, 8))}...`
+        )
+      );
+      console.log('');
+    } else {
+      await useCase.disable(options.id);
+
+      console.log('');
+      console.log(
+        colors.yellow(
+          `Schedule disabled: ${colors.dim(options.id.substring(0, 8))}...`
+        )
+      );
+      console.log('');
+    }
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to ${options.action} schedule: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/config-snapshot/show.ts
+++ b/platform/services/cli/src/commands/config-snapshot/show.ts
@@ -1,0 +1,79 @@
+import { log, colors } from '@minecraft-docker/shared';
+import { getContainer } from '../../infrastructure/di/container.js';
+
+export interface ConfigSnapshotShowOptions {
+  root?: string;
+  id: string;
+  files?: boolean;
+  json?: boolean;
+}
+
+/**
+ * Show details of a specific config snapshot
+ */
+export async function configSnapshotShowCommand(
+  options: ConfigSnapshotShowOptions
+): Promise<number> {
+  if (!options.id) {
+    log.error('Snapshot ID is required. Usage: mcctl config-snapshot show <id>');
+    return 1;
+  }
+
+  const container = getContainer(options.root);
+  const useCase = container.configSnapshotUseCase;
+
+  try {
+    const snapshot = await useCase.findById(options.id);
+
+    if (!snapshot) {
+      log.error(`Snapshot not found: ${options.id}`);
+      return 1;
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(snapshot.toJSON(), null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log(colors.bold('Config Snapshot Details'));
+    console.log('');
+    console.log(`  ID:          ${colors.cyan(snapshot.id)}`);
+    console.log(`  Server:      ${colors.bold(snapshot.serverName.value)}`);
+    console.log(
+      `  Created:     ${colors.dim(snapshot.createdAt.toLocaleString())}`
+    );
+    console.log(
+      `  Files:       ${colors.yellow(String(snapshot.files.length))} files`
+    );
+
+    if (snapshot.description) {
+      console.log(`  Description: ${colors.dim(snapshot.description)}`);
+    }
+
+    if (snapshot.scheduleId) {
+      console.log(`  Schedule ID: ${colors.dim(snapshot.scheduleId)}`);
+    }
+
+    if (options.files && snapshot.files.length > 0) {
+      console.log('');
+      console.log(colors.bold('  Files:'));
+
+      for (const file of snapshot.files) {
+        const sizeKb = (file.size / 1024).toFixed(1);
+        console.log(
+          `    ${colors.cyan(file.path.padEnd(40))} ${colors.dim(
+            `${sizeKb} KB`
+          )} ${colors.dim(file.hash.substring(0, 8))}`
+        );
+      }
+    }
+
+    console.log('');
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to show snapshot: ${message}`);
+    return 1;
+  }
+}

--- a/platform/services/cli/src/commands/index.ts
+++ b/platform/services/cli/src/commands/index.ts
@@ -52,3 +52,27 @@ export {
   type AdminUserCommandOptions,
   type AdminApiCommandOptions,
 } from './console/index.js';
+
+// Config snapshot commands
+export {
+  configSnapshotListCommand,
+  type ConfigSnapshotListOptions,
+  configSnapshotCreateCommand,
+  type ConfigSnapshotCreateOptions,
+  configSnapshotShowCommand,
+  type ConfigSnapshotShowOptions,
+  configSnapshotDeleteCommand,
+  type ConfigSnapshotDeleteOptions,
+  configSnapshotDiffCommand,
+  type ConfigSnapshotDiffOptions,
+  configSnapshotRestoreCommand,
+  type ConfigSnapshotRestoreOptions,
+  configSnapshotScheduleListCommand,
+  type ConfigSnapshotScheduleListOptions,
+  configSnapshotScheduleAddCommand,
+  type ConfigSnapshotScheduleAddOptions,
+  configSnapshotScheduleRemoveCommand,
+  type ConfigSnapshotScheduleRemoveOptions,
+  configSnapshotScheduleToggleCommand,
+  type ConfigSnapshotScheduleToggleOptions,
+} from './config-snapshot/index.js';

--- a/platform/services/cli/tests/commands/config-snapshot-schedule.test.ts
+++ b/platform/services/cli/tests/commands/config-snapshot-schedule.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  configSnapshotScheduleListCommand,
+  configSnapshotScheduleAddCommand,
+  configSnapshotScheduleRemoveCommand,
+  configSnapshotScheduleToggleCommand,
+  type ConfigSnapshotScheduleListOptions,
+  type ConfigSnapshotScheduleAddOptions,
+  type ConfigSnapshotScheduleRemoveOptions,
+  type ConfigSnapshotScheduleToggleOptions,
+} from '../../src/commands/config-snapshot/index.js';
+import { getContainer } from '../../src/infrastructure/di/container.js';
+
+vi.mock('../../src/infrastructure/di/container.js');
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn().mockResolvedValue(true),
+  isCancel: vi.fn().mockReturnValue(false),
+  text: vi.fn().mockResolvedValue('Daily Snapshot'),
+  select: vi.fn().mockResolvedValue('myserver'),
+  intro: vi.fn(),
+  outro: vi.fn(),
+}));
+vi.mock('@minecraft-docker/shared', async () => {
+  const actual = await vi.importActual('@minecraft-docker/shared');
+  return {
+    ...actual,
+    Paths: vi.fn().mockImplementation(() => ({
+      isInitialized: vi.fn().mockReturnValue(true),
+      root: '/tmp/test',
+      servers: '/tmp/test/servers',
+    })),
+  };
+});
+
+/**
+ * Build a mock schedule object
+ */
+function buildMockSchedule(overrides = {}) {
+  return {
+    id: 'sched-id-001',
+    serverName: { value: 'myserver' },
+    name: 'Daily Snapshot',
+    cronExpression: {
+      expression: '0 3 * * *',
+      toHumanReadable: () => 'At 03:00 AM every day',
+    },
+    enabled: true,
+    retentionCount: 10,
+    lastRunAt: null,
+    lastRunStatus: null,
+    createdAt: new Date('2026-02-22T09:00:00Z'),
+    updatedAt: new Date('2026-02-22T09:00:00Z'),
+    toJSON: () => ({
+      id: 'sched-id-001',
+      serverName: 'myserver',
+      name: 'Daily Snapshot',
+      cronExpression: '0 3 * * *',
+      cronHumanReadable: 'At 03:00 AM every day',
+      enabled: true,
+      retentionCount: 10,
+      lastRunAt: null,
+      lastRunStatus: null,
+      createdAt: '2026-02-22T09:00:00.000Z',
+      updatedAt: '2026-02-22T09:00:00.000Z',
+    }),
+    ...overrides,
+  };
+}
+
+describe('config-snapshot schedule commands', () => {
+  let mockScheduleUseCase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockScheduleUseCase = {
+      create: vi.fn().mockResolvedValue(buildMockSchedule()),
+      findAll: vi.fn().mockResolvedValue([buildMockSchedule()]),
+      findByServer: vi.fn().mockResolvedValue([buildMockSchedule()]),
+      enable: vi.fn().mockResolvedValue(undefined),
+      disable: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(buildMockSchedule()),
+    };
+
+    vi.mocked(getContainer).mockReturnValue({
+      configSnapshotScheduleUseCase: mockScheduleUseCase,
+    } as any);
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // schedule list
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotScheduleListCommand', () => {
+    it('should list all schedules', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleListOptions = {
+        root: '/tmp/test',
+      };
+
+      const exitCode = await configSnapshotScheduleListCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.findAll).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should filter by server when --server option is given', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleListOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+      };
+
+      const exitCode = await configSnapshotScheduleListCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.findByServer).toHaveBeenCalledWith('myserver');
+      consoleSpy.mockRestore();
+    });
+
+    it('should output JSON when --json flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleListOptions = {
+        root: '/tmp/test',
+        json: true,
+      };
+
+      const exitCode = await configSnapshotScheduleListCommand(options);
+
+      expect(exitCode).toBe(0);
+      const jsonOutput = consoleSpy.mock.calls.find((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonOutput).toBeDefined();
+      consoleSpy.mockRestore();
+    });
+
+    it('should show empty message when no schedules found', async () => {
+      mockScheduleUseCase.findAll.mockResolvedValue([]);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleListOptions = {
+        root: '/tmp/test',
+      };
+
+      const exitCode = await configSnapshotScheduleListCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No schedules')
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // schedule add
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotScheduleAddCommand', () => {
+    it('should add a schedule with required args', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleAddOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        cron: '0 3 * * *',
+        name: 'Daily Snapshot',
+        retention: 10,
+      };
+
+      const exitCode = await configSnapshotScheduleAddCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.create).toHaveBeenCalledWith(
+        'myserver',
+        'Daily Snapshot',
+        '0 3 * * *',
+        10
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should use default retention when not specified', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleAddOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        cron: '0 3 * * *',
+        name: 'Daily Snapshot',
+      };
+
+      const exitCode = await configSnapshotScheduleAddCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.create).toHaveBeenCalledWith(
+        'myserver',
+        'Daily Snapshot',
+        '0 3 * * *',
+        10
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 when server name is missing', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleAddOptions = {
+        root: '/tmp/test',
+        cron: '0 3 * * *',
+        name: 'Daily Snapshot',
+      };
+
+      const exitCode = await configSnapshotScheduleAddCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should return 1 when cron expression is missing', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleAddOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        name: 'Daily Snapshot',
+      };
+
+      const exitCode = await configSnapshotScheduleAddCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should return 1 when name is missing', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleAddOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        cron: '0 3 * * *',
+      };
+
+      const exitCode = await configSnapshotScheduleAddCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should output JSON when --json flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleAddOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        cron: '0 3 * * *',
+        name: 'Daily Snapshot',
+        json: true,
+      };
+
+      const exitCode = await configSnapshotScheduleAddCommand(options);
+
+      expect(exitCode).toBe(0);
+      const jsonOutput = consoleSpy.mock.calls.find((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonOutput).toBeDefined();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // schedule remove
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotScheduleRemoveCommand', () => {
+    it('should remove schedule with confirmation', async () => {
+      const { confirm } = await import('@clack/prompts');
+      vi.mocked(confirm).mockResolvedValue(true);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleRemoveOptions = {
+        root: '/tmp/test',
+        id: 'sched-id-001',
+      };
+
+      const exitCode = await configSnapshotScheduleRemoveCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.delete).toHaveBeenCalledWith('sched-id-001');
+      consoleSpy.mockRestore();
+    });
+
+    it('should skip confirmation with --force flag', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleRemoveOptions = {
+        root: '/tmp/test',
+        id: 'sched-id-001',
+        force: true,
+      };
+
+      const exitCode = await configSnapshotScheduleRemoveCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.delete).toHaveBeenCalledWith('sched-id-001');
+      consoleSpy.mockRestore();
+    });
+
+    it('should cancel when user declines', async () => {
+      const { confirm, isCancel } = await import('@clack/prompts');
+      vi.mocked(confirm).mockResolvedValue(false);
+      vi.mocked(isCancel).mockReturnValue(false);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleRemoveOptions = {
+        root: '/tmp/test',
+        id: 'sched-id-001',
+      };
+
+      const exitCode = await configSnapshotScheduleRemoveCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.delete).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 when schedule ID is missing', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleRemoveOptions = {
+        root: '/tmp/test',
+        id: '',
+      };
+
+      const exitCode = await configSnapshotScheduleRemoveCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // schedule enable / disable
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotScheduleToggleCommand', () => {
+    it('should enable a schedule', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleToggleOptions = {
+        root: '/tmp/test',
+        id: 'sched-id-001',
+        action: 'enable',
+      };
+
+      const exitCode = await configSnapshotScheduleToggleCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.enable).toHaveBeenCalledWith('sched-id-001');
+      consoleSpy.mockRestore();
+    });
+
+    it('should disable a schedule', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleToggleOptions = {
+        root: '/tmp/test',
+        id: 'sched-id-001',
+        action: 'disable',
+      };
+
+      const exitCode = await configSnapshotScheduleToggleCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockScheduleUseCase.disable).toHaveBeenCalledWith('sched-id-001');
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 when schedule ID is missing', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleToggleOptions = {
+        root: '/tmp/test',
+        id: '',
+        action: 'enable',
+      };
+
+      const exitCode = await configSnapshotScheduleToggleCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should return 1 on error', async () => {
+      mockScheduleUseCase.enable.mockRejectedValue(new Error('Schedule not found'));
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotScheduleToggleOptions = {
+        root: '/tmp/test',
+        id: 'nonexistent',
+        action: 'enable',
+      };
+
+      const exitCode = await configSnapshotScheduleToggleCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/platform/services/cli/tests/commands/config-snapshot.test.ts
+++ b/platform/services/cli/tests/commands/config-snapshot.test.ts
@@ -1,0 +1,665 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  configSnapshotListCommand,
+  configSnapshotCreateCommand,
+  configSnapshotShowCommand,
+  configSnapshotDeleteCommand,
+  configSnapshotDiffCommand,
+  configSnapshotRestoreCommand,
+  type ConfigSnapshotListOptions,
+  type ConfigSnapshotCreateOptions,
+  type ConfigSnapshotShowOptions,
+  type ConfigSnapshotDeleteOptions,
+  type ConfigSnapshotDiffOptions,
+  type ConfigSnapshotRestoreOptions,
+} from '../../src/commands/config-snapshot/index.js';
+import { getContainer } from '../../src/infrastructure/di/container.js';
+
+vi.mock('../../src/infrastructure/di/container.js');
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn().mockResolvedValue(true),
+  isCancel: vi.fn().mockReturnValue(false),
+  text: vi.fn().mockResolvedValue('test description'),
+  select: vi.fn().mockResolvedValue('myserver'),
+  intro: vi.fn(),
+  outro: vi.fn(),
+}));
+vi.mock('@minecraft-docker/shared', async () => {
+  const actual = await vi.importActual('@minecraft-docker/shared');
+  return {
+    ...actual,
+    Paths: vi.fn().mockImplementation(() => ({
+      isInitialized: vi.fn().mockReturnValue(true),
+      root: '/tmp/test',
+      servers: '/tmp/test/servers',
+    })),
+  };
+});
+
+/**
+ * Build mock snapshot object
+ */
+function buildMockSnapshot(overrides = {}) {
+  return {
+    id: 'snap-id-001',
+    serverName: { value: 'myserver' },
+    createdAt: new Date('2026-02-22T10:00:00Z'),
+    description: 'Test snapshot',
+    files: [
+      { path: 'server.properties', hash: 'abc123', size: 1024 },
+      { path: 'ops.json', hash: 'def456', size: 512 },
+    ],
+    scheduleId: undefined,
+    toJSON: () => ({
+      id: 'snap-id-001',
+      serverName: 'myserver',
+      createdAt: '2026-02-22T10:00:00.000Z',
+      description: 'Test snapshot',
+      files: [
+        { path: 'server.properties', hash: 'abc123', size: 1024 },
+        { path: 'ops.json', hash: 'def456', size: 512 },
+      ],
+    }),
+    ...overrides,
+  };
+}
+
+/**
+ * Build mock schedule object
+ */
+function buildMockSchedule(overrides = {}) {
+  return {
+    id: 'sched-id-001',
+    serverName: { value: 'myserver' },
+    name: 'Daily Snapshot',
+    cronExpression: {
+      expression: '0 3 * * *',
+      toHumanReadable: () => 'At 03:00 AM every day',
+    },
+    enabled: true,
+    retentionCount: 10,
+    lastRunAt: null,
+    lastRunStatus: null,
+    createdAt: new Date('2026-02-22T09:00:00Z'),
+    updatedAt: new Date('2026-02-22T09:00:00Z'),
+    toJSON: () => ({
+      id: 'sched-id-001',
+      serverName: 'myserver',
+      name: 'Daily Snapshot',
+      cronExpression: '0 3 * * *',
+      cronHumanReadable: 'At 03:00 AM every day',
+      enabled: true,
+      retentionCount: 10,
+      lastRunAt: null,
+      lastRunStatus: null,
+      createdAt: '2026-02-22T09:00:00.000Z',
+      updatedAt: '2026-02-22T09:00:00.000Z',
+    }),
+    ...overrides,
+  };
+}
+
+/**
+ * Build mock SnapshotDiff object
+ */
+function buildMockDiff() {
+  return {
+    baseSnapshotId: 'snap-id-001',
+    compareSnapshotId: 'snap-id-002',
+    changes: [
+      {
+        path: 'server.properties',
+        status: 'modified',
+        oldContent: 'old content',
+        newContent: 'new content',
+        oldHash: 'abc',
+        newHash: 'xyz',
+        toJSON: () => ({
+          path: 'server.properties',
+          status: 'modified',
+          oldContent: 'old content',
+          newContent: 'new content',
+          oldHash: 'abc',
+          newHash: 'xyz',
+        }),
+      },
+      {
+        path: 'whitelist.json',
+        status: 'added',
+        newContent: '[]',
+        newHash: 'new-hash',
+        toJSON: () => ({
+          path: 'whitelist.json',
+          status: 'added',
+          newContent: '[]',
+          newHash: 'new-hash',
+        }),
+      },
+    ],
+    summary: { added: 1, modified: 1, deleted: 0 },
+    hasChanges: true,
+    toJSON: () => ({
+      baseSnapshotId: 'snap-id-001',
+      compareSnapshotId: 'snap-id-002',
+      changes: [],
+      summary: { added: 1, modified: 1, deleted: 0 },
+      hasChanges: true,
+    }),
+  };
+}
+
+describe('config-snapshot commands', () => {
+  let mockUseCase: any;
+  let mockScheduleUseCase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseCase = {
+      create: vi.fn().mockResolvedValue(buildMockSnapshot()),
+      list: vi.fn().mockResolvedValue([buildMockSnapshot()]),
+      findById: vi.fn().mockResolvedValue(buildMockSnapshot()),
+      diff: vi.fn().mockResolvedValue(buildMockDiff()),
+      restore: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      count: vi.fn().mockResolvedValue(1),
+    };
+
+    mockScheduleUseCase = {
+      create: vi.fn().mockResolvedValue(buildMockSchedule()),
+      findAll: vi.fn().mockResolvedValue([buildMockSchedule()]),
+      findByServer: vi.fn().mockResolvedValue([buildMockSchedule()]),
+      enable: vi.fn().mockResolvedValue(undefined),
+      disable: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(buildMockSchedule()),
+    };
+
+    vi.mocked(getContainer).mockReturnValue({
+      configSnapshotUseCase: mockUseCase,
+      configSnapshotScheduleUseCase: mockScheduleUseCase,
+    } as any);
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // config-snapshot list
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotListCommand', () => {
+    it('should list all snapshots (no server filter)', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotListOptions = {
+        root: '/tmp/test',
+        limit: 20,
+      };
+
+      const exitCode = await configSnapshotListCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.list).toHaveBeenCalledWith(undefined, 20, undefined);
+      consoleSpy.mockRestore();
+    });
+
+    it('should list snapshots filtered by server', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotListOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        limit: 10,
+      };
+
+      const exitCode = await configSnapshotListCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.list).toHaveBeenCalledWith('myserver', 10, undefined);
+      consoleSpy.mockRestore();
+    });
+
+    it('should output JSON when --json flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotListOptions = {
+        root: '/tmp/test',
+        json: true,
+      };
+
+      const exitCode = await configSnapshotListCommand(options);
+
+      expect(exitCode).toBe(0);
+      // Verify JSON was output
+      const jsonOutput = consoleSpy.mock.calls.find((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonOutput).toBeDefined();
+      consoleSpy.mockRestore();
+    });
+
+    it('should show empty message when no snapshots found', async () => {
+      mockUseCase.list.mockResolvedValue([]);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotListOptions = {
+        root: '/tmp/test',
+      };
+
+      const exitCode = await configSnapshotListCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No snapshots'));
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 on error', async () => {
+      mockUseCase.list.mockRejectedValue(new Error('DB error'));
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotListOptions = {
+        root: '/tmp/test',
+      };
+
+      const exitCode = await configSnapshotListCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // config-snapshot create
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotCreateCommand', () => {
+    it('should create a snapshot with server name and description', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotCreateOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        description: 'My snapshot',
+      };
+
+      const exitCode = await configSnapshotCreateCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.create).toHaveBeenCalledWith('myserver', 'My snapshot');
+      consoleSpy.mockRestore();
+    });
+
+    it('should create a snapshot without description', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotCreateOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+      };
+
+      const exitCode = await configSnapshotCreateCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.create).toHaveBeenCalledWith('myserver', undefined);
+      consoleSpy.mockRestore();
+    });
+
+    it('should output JSON when --json flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotCreateOptions = {
+        root: '/tmp/test',
+        serverName: 'myserver',
+        json: true,
+      };
+
+      const exitCode = await configSnapshotCreateCommand(options);
+
+      expect(exitCode).toBe(0);
+      const jsonOutput = consoleSpy.mock.calls.find((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonOutput).toBeDefined();
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 on error', async () => {
+      mockUseCase.create.mockRejectedValue(new Error('Server not found'));
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotCreateOptions = {
+        root: '/tmp/test',
+        serverName: 'nonexistent',
+      };
+
+      const exitCode = await configSnapshotCreateCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // config-snapshot show
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotShowCommand', () => {
+    it('should show snapshot details', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotShowOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+      };
+
+      const exitCode = await configSnapshotShowCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.findById).toHaveBeenCalledWith('snap-id-001');
+      consoleSpy.mockRestore();
+    });
+
+    it('should include file list when --files flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotShowOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+        files: true,
+      };
+
+      const exitCode = await configSnapshotShowCommand(options);
+
+      expect(exitCode).toBe(0);
+      // File paths should appear in output
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('server.properties')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should output JSON when --json flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotShowOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+        json: true,
+      };
+
+      const exitCode = await configSnapshotShowCommand(options);
+
+      expect(exitCode).toBe(0);
+      const jsonOutput = consoleSpy.mock.calls.find((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonOutput).toBeDefined();
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 when snapshot not found', async () => {
+      mockUseCase.findById.mockResolvedValue(null);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotShowOptions = {
+        root: '/tmp/test',
+        id: 'nonexistent-id',
+      };
+
+      const exitCode = await configSnapshotShowCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should require snapshot ID', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotShowOptions = {
+        root: '/tmp/test',
+        id: '',
+      };
+
+      const exitCode = await configSnapshotShowCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // config-snapshot delete
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotDeleteCommand', () => {
+    it('should delete snapshot with confirmation', async () => {
+      const { confirm } = await import('@clack/prompts');
+      vi.mocked(confirm).mockResolvedValue(true);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDeleteOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+      };
+
+      const exitCode = await configSnapshotDeleteCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.findById).toHaveBeenCalledWith('snap-id-001');
+      expect(mockUseCase.delete).toHaveBeenCalledWith('snap-id-001');
+      consoleSpy.mockRestore();
+    });
+
+    it('should skip confirmation with --force flag', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDeleteOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+        force: true,
+      };
+
+      const exitCode = await configSnapshotDeleteCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.delete).toHaveBeenCalledWith('snap-id-001');
+      consoleSpy.mockRestore();
+    });
+
+    it('should cancel when user declines confirmation', async () => {
+      const { confirm, isCancel } = await import('@clack/prompts');
+      vi.mocked(confirm).mockResolvedValue(false);
+      vi.mocked(isCancel).mockReturnValue(false);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDeleteOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+      };
+
+      const exitCode = await configSnapshotDeleteCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.delete).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 when snapshot not found', async () => {
+      mockUseCase.findById.mockResolvedValue(null);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDeleteOptions = {
+        root: '/tmp/test',
+        id: 'nonexistent',
+        force: true,
+      };
+
+      const exitCode = await configSnapshotDeleteCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // config-snapshot diff
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotDiffCommand', () => {
+    it('should diff two snapshots', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDiffOptions = {
+        root: '/tmp/test',
+        id1: 'snap-id-001',
+        id2: 'snap-id-002',
+      };
+
+      const exitCode = await configSnapshotDiffCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.diff).toHaveBeenCalledWith('snap-id-001', 'snap-id-002');
+      consoleSpy.mockRestore();
+    });
+
+    it('should show files-only when --files-only flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDiffOptions = {
+        root: '/tmp/test',
+        id1: 'snap-id-001',
+        id2: 'snap-id-002',
+        filesOnly: true,
+      };
+
+      const exitCode = await configSnapshotDiffCommand(options);
+
+      expect(exitCode).toBe(0);
+      // Should output file names only
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('server.properties')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should output JSON when --json flag is set', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDiffOptions = {
+        root: '/tmp/test',
+        id1: 'snap-id-001',
+        id2: 'snap-id-002',
+        json: true,
+      };
+
+      const exitCode = await configSnapshotDiffCommand(options);
+
+      expect(exitCode).toBe(0);
+      const jsonOutput = consoleSpy.mock.calls.find((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonOutput).toBeDefined();
+      consoleSpy.mockRestore();
+    });
+
+    it('should require both snapshot IDs', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotDiffOptions = {
+        root: '/tmp/test',
+        id1: 'snap-id-001',
+        id2: '',
+      };
+
+      const exitCode = await configSnapshotDiffCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // config-snapshot restore
+  // ─────────────────────────────────────────────────────────────
+  describe('configSnapshotRestoreCommand', () => {
+    it('should restore snapshot with confirmation', async () => {
+      const { confirm } = await import('@clack/prompts');
+      vi.mocked(confirm).mockResolvedValue(true);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotRestoreOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+      };
+
+      const exitCode = await configSnapshotRestoreCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.findById).toHaveBeenCalledWith('snap-id-001');
+      expect(mockUseCase.restore).toHaveBeenCalledWith('snap-id-001', false);
+      consoleSpy.mockRestore();
+    });
+
+    it('should skip confirmation with --force flag', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const options: ConfigSnapshotRestoreOptions = {
+        root: '/tmp/test',
+        id: 'snap-id-001',
+        force: true,
+      };
+
+      const exitCode = await configSnapshotRestoreCommand(options);
+
+      expect(exitCode).toBe(0);
+      expect(mockUseCase.restore).toHaveBeenCalledWith('snap-id-001', true);
+      consoleSpy.mockRestore();
+    });
+
+    it('should return 1 when snapshot not found', async () => {
+      mockUseCase.findById.mockResolvedValue(null);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const options: ConfigSnapshotRestoreOptions = {
+        root: '/tmp/test',
+        id: 'nonexistent',
+        force: true,
+      };
+
+      const exitCode = await configSnapshotRestoreCommand(options);
+
+      expect(exitCode).toBe(1);
+      consoleSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `mcctl config-snapshot` CLI 서브커맨드 구현 (list, create, show, diff, restore, delete)
- `mcctl config-snapshot schedule` 서브커맨드 구현 (list, add, remove, enable/disable)
- Hexagonal Architecture 패턴에 따른 DI 컨테이너 확장

## Changes
- `platform/services/cli/src/commands/config-snapshot/` — 6개 스냅샷 커맨드 + 4개 스케줄 커맨드
- `platform/services/cli/src/index.ts` — 커맨드 그룹 등록
- `platform/services/cli/src/infrastructure/di/container.ts` — DI 컨테이너 확장
- `platform/services/cli/tests/commands/config-snapshot.test.ts` — 단위 테스트 (665줄)
- `platform/services/cli/tests/commands/config-snapshot-schedule.test.ts` — 스케줄 테스트 (437줄)

## Test plan
- [ ] `pnpm --filter @minecraft-docker/mcctl test` 통과 확인
- [ ] `pnpm --filter @minecraft-docker/mcctl build` 성공 확인
- [ ] 타입 체크 통과 확인

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)