### PR TITLE
feat(console): add Config History tab to Server Detail page (#403)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
@@ -34,6 +34,7 @@ import { ConnectionInfoCard } from './ConnectionInfoCard';
 import { HostnameDisplay } from '@/components/common';
 import { ServerModsTab } from './ServerModsTab';
 import { ServerFilesTab } from './files/ServerFilesTab';
+import { ServerConfigHistoryTab } from './config-history';
 
 interface ServerDetailProps {
   server: ServerDetailType;
@@ -41,7 +42,7 @@ interface ServerDetailProps {
 }
 
 // Tab configuration
-const TABS = ['Overview', 'Activity', 'Mods', 'Files', 'Backups', 'Access', 'Options'] as const;
+const TABS = ['Overview', 'Activity', 'Mods', 'Files', 'Config History', 'Backups', 'Access', 'Options'] as const;
 type TabType = (typeof TABS)[number];
 
 // Icon size for stat cards
@@ -571,6 +572,15 @@ export function ServerDetail({ server, onSendCommand }: ServerDetailProps) {
       {activeTab === 'Files' && (
         <Box sx={{ mt: 3 }}>
           <ServerFilesTab serverName={server.name} />
+        </Box>
+      )}
+
+      {activeTab === 'Config History' && (
+        <Box sx={{ mt: 3 }}>
+          <ServerConfigHistoryTab
+            serverName={server.name}
+            isServerRunning={server.status === 'running'}
+          />
         </Box>
       )}
 

--- a/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotCompareBar.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotCompareBar.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { ConfigSnapshotCompareBar } from './ConfigSnapshotCompareBar';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+
+const renderWithTheme = (component: React.ReactNode) =>
+  render(<ThemeProvider>{component}</ThemeProvider>);
+
+const makeSnapshot = (id: string, createdAt: string): ConfigSnapshotItem => ({
+  id,
+  serverName: 'test-server',
+  createdAt,
+  description: `Snapshot ${id}`,
+  files: [],
+});
+
+describe('ConfigSnapshotCompareBar', () => {
+  const onCompare = vi.fn();
+  const onCancelCompare = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows instructions when no snapshots selected', () => {
+    renderWithTheme(
+      <ConfigSnapshotCompareBar
+        selectedSnapshots={[]}
+        onCompare={onCompare}
+        onCancelCompare={onCancelCompare}
+      />
+    );
+
+    expect(screen.getByText('Compare mode')).toBeInTheDocument();
+    expect(screen.getByText('Select two snapshots to compare')).toBeInTheDocument();
+  });
+
+  it('View Diff button is disabled when fewer than 2 snapshots selected', () => {
+    const snap = makeSnapshot('a', '2026-02-22T14:30:00.000Z');
+
+    renderWithTheme(
+      <ConfigSnapshotCompareBar
+        selectedSnapshots={[snap]}
+        onCompare={onCompare}
+        onCancelCompare={onCancelCompare}
+      />
+    );
+
+    const viewDiffButton = screen.getByRole('button', { name: /view diff/i });
+    expect(viewDiffButton).toBeDisabled();
+  });
+
+  it('View Diff button is enabled when 2 snapshots selected', () => {
+    const snapA = makeSnapshot('a', '2026-02-21T03:00:00.000Z');
+    const snapB = makeSnapshot('b', '2026-02-22T14:30:00.000Z');
+
+    renderWithTheme(
+      <ConfigSnapshotCompareBar
+        selectedSnapshots={[snapA, snapB]}
+        onCompare={onCompare}
+        onCancelCompare={onCancelCompare}
+      />
+    );
+
+    const viewDiffButton = screen.getByRole('button', { name: /view diff/i });
+    expect(viewDiffButton).not.toBeDisabled();
+  });
+
+  it('calls onCompare when View Diff clicked with 2 selected', () => {
+    const snapA = makeSnapshot('a', '2026-02-21T03:00:00.000Z');
+    const snapB = makeSnapshot('b', '2026-02-22T14:30:00.000Z');
+
+    renderWithTheme(
+      <ConfigSnapshotCompareBar
+        selectedSnapshots={[snapA, snapB]}
+        onCompare={onCompare}
+        onCancelCompare={onCancelCompare}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /view diff/i }));
+    expect(onCompare).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancelCompare when Cancel clicked', () => {
+    renderWithTheme(
+      <ConfigSnapshotCompareBar
+        selectedSnapshots={[]}
+        onCompare={onCompare}
+        onCancelCompare={onCancelCompare}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancelCompare).toHaveBeenCalledOnce();
+  });
+
+  it('shows IDs of both selected snapshots', () => {
+    const snapA = makeSnapshot('abcdefgh-1234', '2026-02-21T03:00:00.000Z');
+    const snapB = makeSnapshot('xyzwvuts-9876', '2026-02-22T14:30:00.000Z');
+
+    renderWithTheme(
+      <ConfigSnapshotCompareBar
+        selectedSnapshots={[snapA, snapB]}
+        onCompare={onCompare}
+        onCancelCompare={onCancelCompare}
+      />
+    );
+
+    // Short IDs (first 8 chars) should appear
+    expect(screen.getByText(/abcdefgh/)).toBeInTheDocument();
+    expect(screen.getByText(/xyzwvuts/)).toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotCompareBar.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotCompareBar.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import CloseIcon from '@mui/icons-material/Close';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+
+function shortId(id: string): string {
+  return id.substring(0, 8);
+}
+
+function formatDateTime(isoString: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(isoString));
+}
+
+interface ConfigSnapshotCompareBarProps {
+  /** Selected snapshots for comparison (max 2) */
+  selectedSnapshots: ConfigSnapshotItem[];
+  onCompare: () => void;
+  onCancelCompare: () => void;
+}
+
+/**
+ * Floating bar displayed during compare mode.
+ * Shows selected snapshots and triggers the diff dialog when two are selected.
+ */
+export function ConfigSnapshotCompareBar({
+  selectedSnapshots,
+  onCompare,
+  onCancelCompare,
+}: ConfigSnapshotCompareBarProps) {
+  const count = selectedSnapshots.length;
+  const canCompare = count === 2;
+
+  return (
+    <Paper
+      elevation={4}
+      sx={{
+        position: 'sticky',
+        top: 16,
+        zIndex: 10,
+        px: 2,
+        py: 1.5,
+        mb: 2,
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: 'primary.main',
+        bgcolor: 'background.paper',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        flexWrap: 'wrap',
+      }}
+    >
+      <CompareArrowsIcon color="primary" fontSize="small" />
+
+      <Box sx={{ flex: 1 }}>
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          Compare mode
+        </Typography>
+        {count === 0 && (
+          <Typography variant="caption" color="text.secondary">
+            Select two snapshots to compare
+          </Typography>
+        )}
+        {count === 1 && (
+          <Typography variant="caption" color="text.secondary">
+            {formatDateTime(selectedSnapshots[0].createdAt)} selected — select one more
+          </Typography>
+        )}
+        {count === 2 && (
+          <Typography variant="caption" color="text.secondary">
+            {formatDateTime(selectedSnapshots[0].createdAt)} ({shortId(selectedSnapshots[0].id)})
+            {' vs '}
+            {formatDateTime(selectedSnapshots[1].createdAt)} ({shortId(selectedSnapshots[1].id)})
+          </Typography>
+        )}
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <Button
+          size="small"
+          variant="contained"
+          startIcon={<CompareArrowsIcon />}
+          onClick={onCompare}
+          disabled={!canCompare}
+        >
+          View Diff
+        </Button>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<CloseIcon />}
+          onClick={onCancelCompare}
+          color="inherit"
+        >
+          Cancel
+        </Button>
+      </Box>
+    </Paper>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotQuickActions.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotQuickActions.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { ConfigSnapshotQuickActions } from './ConfigSnapshotQuickActions';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+
+const renderWithTheme = (component: React.ReactNode) =>
+  render(<ThemeProvider>{component}</ThemeProvider>);
+
+const snapshot: ConfigSnapshotItem = {
+  id: 'snap-1',
+  serverName: 'test-server',
+  createdAt: '2026-02-22T14:30:00.000Z',
+  description: 'Test snapshot',
+  files: [{ path: 'server.properties', hash: 'abc', size: 100 }],
+};
+
+describe('ConfigSnapshotQuickActions', () => {
+  const onViewDiff = vi.fn();
+  const onRestore = vi.fn();
+  const onDelete = vi.fn();
+  const onToggleCompareSelect = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('normal mode', () => {
+    it('shows View Diff button when has predecessor', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={false}
+          isSelectedForCompare={false}
+          hasPredecessor={true}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /view diff/i })).toBeInTheDocument();
+    });
+
+    it('does not show View Diff button when no predecessor', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={false}
+          isSelectedForCompare={false}
+          hasPredecessor={false}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /view diff/i })).not.toBeInTheDocument();
+    });
+
+    it('calls onViewDiff when View Diff clicked', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={false}
+          isSelectedForCompare={false}
+          hasPredecessor={true}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /view diff/i }));
+      expect(onViewDiff).toHaveBeenCalledWith(snapshot);
+    });
+
+    it('calls onRestore when Restore clicked', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={false}
+          isSelectedForCompare={false}
+          hasPredecessor={false}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /restore snapshot/i }));
+      expect(onRestore).toHaveBeenCalledWith(snapshot);
+    });
+
+    it('requires double click to delete (confirm pattern)', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={false}
+          isSelectedForCompare={false}
+          hasPredecessor={false}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button', { name: /delete snapshot/i });
+      // First click — should show confirm
+      fireEvent.click(deleteButton);
+      expect(onDelete).not.toHaveBeenCalled();
+
+      // Confirm button should now appear
+      const confirmButton = screen.getByRole('button', { name: /confirm delete/i });
+      fireEvent.click(confirmButton);
+      expect(onDelete).toHaveBeenCalledWith(snapshot);
+    });
+  });
+
+  describe('compare mode', () => {
+    it('shows checkbox icon in compare mode', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={true}
+          isSelectedForCompare={false}
+          hasPredecessor={true}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: /select for comparison/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows checked icon when selected for compare', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={true}
+          isSelectedForCompare={true}
+          hasPredecessor={true}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: /remove from comparison/i })
+      ).toBeInTheDocument();
+    });
+
+    it('calls onToggleCompareSelect in compare mode', () => {
+      renderWithTheme(
+        <ConfigSnapshotQuickActions
+          snapshot={snapshot}
+          compareMode={true}
+          isSelectedForCompare={false}
+          hasPredecessor={true}
+          onViewDiff={onViewDiff}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onToggleCompareSelect={onToggleCompareSelect}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /select for comparison/i }));
+      expect(onToggleCompareSelect).toHaveBeenCalledWith(snapshot);
+    });
+  });
+});

--- a/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotQuickActions.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotQuickActions.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import CircularProgress from '@mui/material/CircularProgress';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import RestoreIcon from '@mui/icons-material/Restore';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+
+interface ConfigSnapshotQuickActionsProps {
+  snapshot: ConfigSnapshotItem;
+  /** Whether compare mode is active */
+  compareMode: boolean;
+  /** Whether this snapshot is selected for compare */
+  isSelectedForCompare: boolean;
+  /** Whether this snapshot has a predecessor to diff against */
+  hasPredecessor: boolean;
+  /** Whether delete is in progress for this snapshot */
+  isDeleting?: boolean;
+  onViewDiff: (snapshot: ConfigSnapshotItem) => void;
+  onRestore: (snapshot: ConfigSnapshotItem) => void;
+  onDelete: (snapshot: ConfigSnapshotItem) => void;
+  onToggleCompareSelect: (snapshot: ConfigSnapshotItem) => void;
+}
+
+/**
+ * Quick action buttons for a config snapshot timeline item.
+ * Shows View Diff, Restore, Delete actions; or compare toggle in compare mode.
+ */
+export function ConfigSnapshotQuickActions({
+  snapshot,
+  compareMode,
+  isSelectedForCompare,
+  hasPredecessor,
+  isDeleting = false,
+  onViewDiff,
+  onRestore,
+  onDelete,
+  onToggleCompareSelect,
+}: ConfigSnapshotQuickActionsProps) {
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
+
+  const handleDeleteClick = () => {
+    if (!deleteConfirm) {
+      setDeleteConfirm(true);
+      // Auto-cancel confirm after 3s
+      setTimeout(() => setDeleteConfirm(false), 3000);
+      return;
+    }
+    onDelete(snapshot);
+    setDeleteConfirm(false);
+  };
+
+  if (compareMode) {
+    return (
+      <Tooltip
+        title={isSelectedForCompare ? 'Remove from comparison' : 'Select for comparison'}
+        placement="top"
+      >
+        <IconButton
+          size="small"
+          onClick={() => onToggleCompareSelect(snapshot)}
+          color={isSelectedForCompare ? 'primary' : 'default'}
+          aria-label={isSelectedForCompare ? 'Remove from comparison' : 'Select for comparison'}
+        >
+          {isSelectedForCompare ? (
+            <CheckBoxIcon fontSize="small" />
+          ) : (
+            <CheckBoxOutlineBlankIcon fontSize="small" />
+          )}
+        </IconButton>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+      {hasPredecessor && (
+        <Tooltip title="View diff from previous snapshot" placement="top">
+          <IconButton
+            size="small"
+            onClick={() => onViewDiff(snapshot)}
+            aria-label="View diff"
+          >
+            <CompareArrowsIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+
+      <Tooltip title="Restore to this snapshot" placement="top">
+        <IconButton
+          size="small"
+          onClick={() => onRestore(snapshot)}
+          aria-label="Restore snapshot"
+        >
+          <RestoreIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      <Tooltip
+        title={deleteConfirm ? 'Click again to confirm delete' : 'Delete snapshot'}
+        placement="top"
+      >
+        <span>
+          <Button
+            size="small"
+            variant={deleteConfirm ? 'contained' : 'text'}
+            color="error"
+            onClick={handleDeleteClick}
+            disabled={isDeleting}
+            startIcon={
+              isDeleting ? (
+                <CircularProgress size={14} color="inherit" />
+              ) : (
+                <DeleteOutlineIcon fontSize="small" />
+              )
+            }
+            sx={{
+              minWidth: 0,
+              px: deleteConfirm ? 1 : 0.5,
+              fontSize: 12,
+              lineHeight: 1,
+            }}
+            aria-label={deleteConfirm ? 'Confirm delete' : 'Delete snapshot'}
+          >
+            {deleteConfirm ? 'Confirm' : ''}
+          </Button>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotTimeline.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotTimeline.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+import { ConfigSnapshotTimelineItem } from './ConfigSnapshotTimelineItem';
+
+/** Group snapshots by date label (e.g. "Feb 22, 2026") */
+function groupByDate(snapshots: ConfigSnapshotItem[]): Array<{
+  label: string;
+  items: ConfigSnapshotItem[];
+}> {
+  const groups = new Map<string, ConfigSnapshotItem[]>();
+
+  for (const s of snapshots) {
+    const label = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }).format(new Date(s.createdAt));
+
+    if (!groups.has(label)) {
+      groups.set(label, []);
+    }
+    groups.get(label)!.push(s);
+  }
+
+  return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
+}
+
+interface ConfigSnapshotTimelineProps {
+  snapshots: ConfigSnapshotItem[];
+  /** Total count from API (for showing load-more) */
+  total: number;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  compareMode: boolean;
+  selectedForCompare: ConfigSnapshotItem[];
+  deletingIds: Set<string>;
+  onViewDiff: (snapshot: ConfigSnapshotItem) => void;
+  onRestore: (snapshot: ConfigSnapshotItem) => void;
+  onDelete: (snapshot: ConfigSnapshotItem) => void;
+  onToggleCompareSelect: (snapshot: ConfigSnapshotItem) => void;
+  onLoadMore: () => void;
+}
+
+/**
+ * Vertical timeline displaying config snapshots grouped by date.
+ * Supports Load More pagination and compare mode.
+ */
+export function ConfigSnapshotTimeline({
+  snapshots,
+  total,
+  hasNextPage,
+  isFetchingNextPage,
+  compareMode,
+  selectedForCompare,
+  deletingIds,
+  onViewDiff,
+  onRestore,
+  onDelete,
+  onToggleCompareSelect,
+  onLoadMore,
+}: ConfigSnapshotTimelineProps) {
+  const groups = groupByDate(snapshots);
+  const selectedIds = new Set(selectedForCompare.map((s) => s.id));
+
+  // Track global position to determine isFirst/isLast
+  let globalIndex = 0;
+
+  return (
+    <Box>
+      {groups.map((group, groupIndex) => (
+        <Box key={group.label}>
+          {/* Date separator */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              mb: 1.5,
+              mt: groupIndex > 0 ? 2 : 0,
+            }}
+          >
+            <Divider sx={{ flex: 1 }} />
+            <Typography
+              variant="caption"
+              sx={{
+                color: 'text.secondary',
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                flexShrink: 0,
+              }}
+            >
+              {group.label}
+            </Typography>
+            <Divider sx={{ flex: 1 }} />
+          </Box>
+
+          {/* Timeline items */}
+          {group.items.map((snapshot) => {
+            const currentIndex = globalIndex;
+            globalIndex++;
+            return (
+              <ConfigSnapshotTimelineItem
+                key={snapshot.id}
+                snapshot={snapshot}
+                isFirst={currentIndex === snapshots.length - 1}
+                isLast={currentIndex === 0}
+                compareMode={compareMode}
+                isSelectedForCompare={selectedIds.has(snapshot.id)}
+                isDeleting={deletingIds.has(snapshot.id)}
+                onViewDiff={onViewDiff}
+                onRestore={onRestore}
+                onDelete={onDelete}
+                onToggleCompareSelect={onToggleCompareSelect}
+              />
+            );
+          })}
+        </Box>
+      ))}
+
+      {/* Load More */}
+      {hasNextPage && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+          <Button
+            onClick={onLoadMore}
+            disabled={isFetchingNextPage}
+            startIcon={
+              isFetchingNextPage ? (
+                <CircularProgress size={16} color="inherit" />
+              ) : (
+                <ExpandMoreIcon />
+              )
+            }
+            variant="outlined"
+            size="small"
+          >
+            {isFetchingNextPage
+              ? 'Loading...'
+              : `Load More (${total - snapshots.length} remaining)`}
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotTimelineItem.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotTimelineItem.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import { alpha, useTheme } from '@mui/material/styles';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import CameraAltOutlinedIcon from '@mui/icons-material/CameraAltOutlined';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+import { ConfigSnapshotQuickActions } from './ConfigSnapshotQuickActions';
+
+function formatDateTime(isoString: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(isoString));
+}
+
+function formatFileCount(count: number): string {
+  if (count === 0) return 'No files';
+  return `${count} file${count !== 1 ? 's' : ''}`;
+}
+
+interface ConfigSnapshotTimelineItemProps {
+  snapshot: ConfigSnapshotItem;
+  /** True if this is the very first snapshot (no predecessor) */
+  isFirst: boolean;
+  /** True if this is the very last snapshot in the list */
+  isLast: boolean;
+  /** Whether compare mode is active */
+  compareMode: boolean;
+  /** Whether this snapshot is selected for comparison */
+  isSelectedForCompare: boolean;
+  /** Whether delete is in progress */
+  isDeleting?: boolean;
+  onViewDiff: (snapshot: ConfigSnapshotItem) => void;
+  onRestore: (snapshot: ConfigSnapshotItem) => void;
+  onDelete: (snapshot: ConfigSnapshotItem) => void;
+  onToggleCompareSelect: (snapshot: ConfigSnapshotItem) => void;
+}
+
+/**
+ * A single item in the config snapshot timeline.
+ * Shows snapshot metadata, file count, schedule badge, and action buttons.
+ */
+export function ConfigSnapshotTimelineItem({
+  snapshot,
+  isFirst,
+  isLast,
+  compareMode,
+  isSelectedForCompare,
+  isDeleting = false,
+  onViewDiff,
+  onRestore,
+  onDelete,
+  onToggleCompareSelect,
+}: ConfigSnapshotTimelineItemProps) {
+  const theme = useTheme();
+  const isScheduled = !!snapshot.scheduleId;
+  const hasPredecessor = !isFirst;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 2,
+        position: 'relative',
+        opacity: isDeleting ? 0.5 : 1,
+        transition: 'opacity 0.2s',
+      }}
+    >
+      {/* Timeline spine & dot */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          flexShrink: 0,
+          width: 20,
+        }}
+      >
+        {/* Top connector */}
+        <Box
+          sx={{
+            width: 2,
+            height: 12,
+            bgcolor: isFirst ? 'transparent' : alpha(theme.palette.primary.main, 0.3),
+          }}
+        />
+        {/* Dot */}
+        <Box
+          sx={{
+            width: 12,
+            height: 12,
+            borderRadius: '50%',
+            bgcolor: isSelectedForCompare
+              ? 'primary.main'
+              : alpha(theme.palette.primary.main, 0.5),
+            border: '2px solid',
+            borderColor: isSelectedForCompare ? 'primary.dark' : 'primary.main',
+            flexShrink: 0,
+            boxShadow: isSelectedForCompare
+              ? `0 0 8px ${alpha(theme.palette.primary.main, 0.6)}`
+              : 'none',
+            transition: 'all 0.2s',
+          }}
+        />
+        {/* Bottom connector */}
+        <Box
+          sx={{
+            width: 2,
+            flex: 1,
+            minHeight: 16,
+            bgcolor: isLast ? 'transparent' : alpha(theme.palette.primary.main, 0.3),
+          }}
+        />
+      </Box>
+
+      {/* Content card */}
+      <Box
+        sx={{
+          flex: 1,
+          mb: 1,
+          pb: 1,
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: isSelectedForCompare
+            ? alpha(theme.palette.primary.main, 0.5)
+            : 'divider',
+          bgcolor: isSelectedForCompare
+            ? alpha(theme.palette.primary.main, 0.05)
+            : 'background.paper',
+          px: 2,
+          py: 1.5,
+          transition: 'border-color 0.2s, background-color 0.2s',
+          cursor: compareMode ? 'pointer' : 'default',
+          '&:hover': compareMode
+            ? {
+                borderColor: alpha(theme.palette.primary.main, 0.4),
+                bgcolor: alpha(theme.palette.primary.main, 0.03),
+              }
+            : undefined,
+        }}
+        onClick={compareMode ? () => onToggleCompareSelect(snapshot) : undefined}
+      >
+        {/* Header row */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 1,
+            mb: 0.5,
+          }}
+        >
+          {/* Timestamp & description */}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+              <Typography
+                variant="caption"
+                sx={{ color: 'text.secondary', fontFamily: 'monospace', flexShrink: 0 }}
+              >
+                {formatDateTime(snapshot.createdAt)}
+              </Typography>
+
+              {isScheduled && (
+                <Chip
+                  icon={<ScheduleIcon />}
+                  label="Scheduled"
+                  size="small"
+                  variant="outlined"
+                  color="default"
+                  sx={{ height: 20, fontSize: 11, '& .MuiChip-icon': { fontSize: 12 } }}
+                />
+              )}
+            </Box>
+
+            <Typography
+              variant="body2"
+              sx={{
+                fontWeight: 500,
+                mt: 0.25,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {snapshot.description || (
+                <Box component="span" sx={{ color: 'text.disabled', fontStyle: 'italic' }}>
+                  No description
+                </Box>
+              )}
+            </Typography>
+          </Box>
+
+          {/* Actions */}
+          <Box onClick={(e) => e.stopPropagation()}>
+            <ConfigSnapshotQuickActions
+              snapshot={snapshot}
+              compareMode={compareMode}
+              isSelectedForCompare={isSelectedForCompare}
+              hasPredecessor={hasPredecessor}
+              isDeleting={isDeleting}
+              onViewDiff={onViewDiff}
+              onRestore={onRestore}
+              onDelete={onDelete}
+              onToggleCompareSelect={onToggleCompareSelect}
+            />
+          </Box>
+        </Box>
+
+        {/* File count */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+          <CameraAltOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+          <Typography variant="caption" color="text.secondary">
+            {formatFileCount(snapshot.files.length)}
+            {isFirst && snapshot.files.length > 0 && ' — initial snapshot'}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { ThemeProvider } from '@/theme';
+import { ServerConfigHistoryTab } from './ServerConfigHistoryTab';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+
+// Mock hooks
+vi.mock('@/hooks/useServerConfigSnapshots', () => ({
+  useServerConfigSnapshots: vi.fn(),
+}));
+
+vi.mock('@/hooks/useDeleteConfigSnapshot', () => ({
+  useDeleteConfigSnapshot: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+// Mock dialog components to simplify testing
+vi.mock('@/components/backups/CreateSnapshotDialog', () => ({
+  CreateSnapshotDialog: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? createElement('div', { 'data-testid': 'create-snapshot-dialog' }, createElement('button', { onClick: onClose }, 'Close')) : null,
+}));
+
+vi.mock('@/components/backups/diff', () => ({
+  ConfigDiffDialog: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? createElement('div', { 'data-testid': 'diff-dialog' }, createElement('button', { onClick: onClose }, 'Close')) : null,
+}));
+
+vi.mock('@/components/backups/restore', () => ({
+  ConfigRestoreDialog: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? createElement('div', { 'data-testid': 'restore-dialog' }, createElement('button', { onClick: onClose }, 'Close')) : null,
+}));
+
+import { useServerConfigSnapshots } from '@/hooks/useServerConfigSnapshots';
+const mockUseServerConfigSnapshots = vi.mocked(useServerConfigSnapshots);
+
+const snapshots: ConfigSnapshotItem[] = [
+  {
+    id: 'snap-1',
+    serverName: 'test-server',
+    createdAt: '2026-02-22T14:30:00.000Z',
+    description: 'Before mod update',
+    files: [{ path: 'server.properties', hash: 'abc', size: 100 }],
+  },
+  {
+    id: 'snap-2',
+    serverName: 'test-server',
+    createdAt: '2026-02-21T03:00:00.000Z',
+    description: 'Scheduled: Daily backup',
+    files: [{ path: 'server.properties', hash: 'abc', size: 100 }],
+    scheduleId: 'sched-1',
+  },
+];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ThemeProvider, null, children)
+    );
+  }
+  return Wrapper;
+}
+
+const renderComponent = (props = {}) =>
+  render(
+    <ServerConfigHistoryTab serverName="test-server" {...props} />,
+    { wrapper: createWrapper() }
+  );
+
+describe('ServerConfigHistoryTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: false,
+    } as never);
+
+    renderComponent();
+
+    expect(screen.getByText('Loading config history...')).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Network failure'),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: false,
+    } as never);
+
+    renderComponent();
+
+    expect(screen.getByText(/Failed to load config history/i)).toBeInTheDocument();
+    expect(screen.getByText(/Network failure/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no snapshots', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots: [], total: 0 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    expect(screen.getByText('No config snapshots yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create first snapshot/i })).toBeInTheDocument();
+  });
+
+  it('shows Config History heading and Create Snapshot button', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots, total: 2 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    expect(screen.getByText('Config History')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create snapshot/i })).toBeInTheDocument();
+  });
+
+  it('shows snapshot descriptions in timeline', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots, total: 2 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    expect(screen.getByText('Before mod update')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled: Daily backup')).toBeInTheDocument();
+  });
+
+  it('opens Create Snapshot dialog when button clicked', async () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots, total: 2 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: /create snapshot/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-snapshot-dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Compare button when at least 2 snapshots exist', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots, total: 2 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    expect(screen.getByRole('button', { name: /compare/i })).toBeInTheDocument();
+  });
+
+  it('hides Compare button when only 1 snapshot exists', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots: [snapshots[0]], total: 1 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    expect(screen.queryByRole('button', { name: /^compare$/i })).not.toBeInTheDocument();
+  });
+
+  it('enters compare mode when Compare button clicked', async () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots, total: 2 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: /compare/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Compare mode')).toBeInTheDocument();
+    });
+  });
+
+  it('exits compare mode when Cancel clicked', async () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: { pages: [{ snapshots, total: 2 }], pageParams: [0] },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: /compare/i }));
+    await waitFor(() => expect(screen.getByText('Compare mode')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    await waitFor(() => {
+      expect(screen.queryByText('Compare mode')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import CameraAltOutlinedIcon from '@mui/icons-material/CameraAltOutlined';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+import { useServerConfigSnapshots } from '@/hooks/useServerConfigSnapshots';
+import { useDeleteConfigSnapshot } from '@/hooks/useDeleteConfigSnapshot';
+import { CreateSnapshotDialog } from '@/components/backups/CreateSnapshotDialog';
+import { ConfigDiffDialog } from '@/components/backups/diff';
+import { ConfigRestoreDialog } from '@/components/backups/restore';
+import { ConfigSnapshotTimeline } from './ConfigSnapshotTimeline';
+import { ConfigSnapshotCompareBar } from './ConfigSnapshotCompareBar';
+
+interface ServerConfigHistoryTabProps {
+  serverName: string;
+  /** Whether the server is currently running (used for restore dialog) */
+  isServerRunning?: boolean;
+}
+
+/**
+ * Config History tab for the Server Detail page.
+ * Shows a timeline of config snapshots for a specific server.
+ *
+ * Features:
+ * - Timeline of snapshots in reverse chronological order
+ * - Create snapshot button
+ * - Compare mode: select two snapshots then diff them
+ * - View Diff / Restore / Delete actions per snapshot
+ * - Load More pagination
+ */
+export function ServerConfigHistoryTab({
+  serverName,
+  isServerRunning = false,
+}: ServerConfigHistoryTabProps) {
+  // Data
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useServerConfigSnapshots(serverName);
+
+  const deleteMutation = useDeleteConfigSnapshot();
+
+  // Flatten pages into a single list (newest first — API returns in reverse chronological order)
+  const snapshots: ConfigSnapshotItem[] = useMemo(
+    () => data?.pages.flatMap((p) => p.snapshots) ?? [],
+    [data]
+  );
+  const total = data?.pages[0]?.total ?? 0;
+
+  // Dialog state
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  // Diff dialog
+  const [diffDialogOpen, setDiffDialogOpen] = useState(false);
+  const [diffSnapshotA, setDiffSnapshotA] = useState<ConfigSnapshotItem | null>(null);
+  const [diffSnapshotB, setDiffSnapshotB] = useState<ConfigSnapshotItem | null>(null);
+
+  // Restore dialog
+  const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
+  const [restoreSnapshot, setRestoreSnapshot] = useState<ConfigSnapshotItem | null>(null);
+
+  // Compare mode
+  const [compareMode, setCompareMode] = useState(false);
+  const [selectedForCompare, setSelectedForCompare] = useState<ConfigSnapshotItem[]>([]);
+
+  // Tracking deleting IDs
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
+
+  // --- Handlers ---
+
+  const handleViewDiff = useCallback(
+    (snapshot: ConfigSnapshotItem) => {
+      // Diff against the next (older) snapshot in the list
+      const idx = snapshots.findIndex((s) => s.id === snapshot.id);
+      if (idx < 0 || idx >= snapshots.length - 1) return;
+      const predecessor = snapshots[idx + 1];
+      setDiffSnapshotA(predecessor); // older = base
+      setDiffSnapshotB(snapshot); // newer = compare
+      setDiffDialogOpen(true);
+    },
+    [snapshots]
+  );
+
+  const handleRestore = useCallback((snapshot: ConfigSnapshotItem) => {
+    setRestoreSnapshot(snapshot);
+    setRestoreDialogOpen(true);
+  }, []);
+
+  const handleDelete = useCallback(
+    (snapshot: ConfigSnapshotItem) => {
+      setDeletingIds((prev) => new Set(prev).add(snapshot.id));
+      deleteMutation.mutate(
+        { serverName, snapshotId: snapshot.id },
+        {
+          onSettled: () => {
+            setDeletingIds((prev) => {
+              const next = new Set(prev);
+              next.delete(snapshot.id);
+              return next;
+            });
+          },
+        }
+      );
+    },
+    [serverName, deleteMutation]
+  );
+
+  const handleToggleCompareSelect = useCallback((snapshot: ConfigSnapshotItem) => {
+    setSelectedForCompare((prev) => {
+      const alreadySelected = prev.find((s) => s.id === snapshot.id);
+      if (alreadySelected) {
+        return prev.filter((s) => s.id !== snapshot.id);
+      }
+      // Max 2 selected
+      if (prev.length >= 2) {
+        return [prev[1], snapshot];
+      }
+      return [...prev, snapshot];
+    });
+  }, []);
+
+  const handleCompare = useCallback(() => {
+    if (selectedForCompare.length !== 2) return;
+    // Sort by createdAt: older first = A, newer = B
+    const sorted = [...selectedForCompare].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+    setDiffSnapshotA(sorted[0]);
+    setDiffSnapshotB(sorted[1]);
+    setDiffDialogOpen(true);
+  }, [selectedForCompare]);
+
+  const handleCancelCompare = useCallback(() => {
+    setCompareMode(false);
+    setSelectedForCompare([]);
+  }, []);
+
+  const handleCloseDiff = useCallback(() => {
+    setDiffDialogOpen(false);
+    setDiffSnapshotA(null);
+    setDiffSnapshotB(null);
+    // If we came from compare mode, keep it active
+  }, []);
+
+  // Current snapshot ID (newest snapshot for restore diff reference)
+  const currentSnapshotId = snapshots.length > 0 ? snapshots[0].id : undefined;
+
+  // --- Render ---
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 8, gap: 2 }}>
+        <CircularProgress size={24} />
+        <Typography variant="body2" color="text.secondary">
+          Loading config history...
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert severity="error" sx={{ mt: 1 }}>
+        Failed to load config history: {error?.message ?? 'Unknown error'}
+      </Alert>
+    );
+  }
+
+  return (
+    <Box>
+      {/* Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 2,
+          gap: 1,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          Config History
+        </Typography>
+
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          {snapshots.length >= 2 && !compareMode && (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<CompareArrowsIcon />}
+              onClick={() => setCompareMode(true)}
+            >
+              Compare
+            </Button>
+          )}
+          <Button
+            size="small"
+            variant="contained"
+            startIcon={<AddCircleOutlineIcon />}
+            onClick={() => setCreateDialogOpen(true)}
+          >
+            Create Snapshot
+          </Button>
+        </Box>
+      </Box>
+
+      {/* Compare bar (shown in compare mode) */}
+      {compareMode && (
+        <ConfigSnapshotCompareBar
+          selectedSnapshots={selectedForCompare}
+          onCompare={handleCompare}
+          onCancelCompare={handleCancelCompare}
+        />
+      )}
+
+      {/* Empty state */}
+      {snapshots.length === 0 && (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            py: 8,
+            gap: 1.5,
+            color: 'text.secondary',
+          }}
+        >
+          <CameraAltOutlinedIcon sx={{ fontSize: 48, opacity: 0.3 }} />
+          <Typography variant="body1" sx={{ fontWeight: 500 }}>
+            No config snapshots yet
+          </Typography>
+          <Typography variant="body2" color="text.secondary" textAlign="center">
+            Create a snapshot to save the current server configuration.
+          </Typography>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AddCircleOutlineIcon />}
+            onClick={() => setCreateDialogOpen(true)}
+            sx={{ mt: 1 }}
+          >
+            Create First Snapshot
+          </Button>
+        </Box>
+      )}
+
+      {/* Timeline */}
+      {snapshots.length > 0 && (
+        <ConfigSnapshotTimeline
+          snapshots={snapshots}
+          total={total}
+          hasNextPage={!!hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          compareMode={compareMode}
+          selectedForCompare={selectedForCompare}
+          deletingIds={deletingIds}
+          onViewDiff={handleViewDiff}
+          onRestore={handleRestore}
+          onDelete={handleDelete}
+          onToggleCompareSelect={handleToggleCompareSelect}
+          onLoadMore={fetchNextPage}
+        />
+      )}
+
+      {/* Create Snapshot Dialog */}
+      <CreateSnapshotDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        serverNames={[serverName]}
+        defaultServer={serverName}
+      />
+
+      {/* Diff Dialog */}
+      {diffDialogOpen && diffSnapshotA && diffSnapshotB && (
+        <ConfigDiffDialog
+          open={diffDialogOpen}
+          onClose={handleCloseDiff}
+          snapshotA={diffSnapshotA}
+          snapshotB={diffSnapshotB}
+          onRestoreA={(snapshot) => {
+            handleCloseDiff();
+            setRestoreSnapshot(snapshot);
+            setRestoreDialogOpen(true);
+          }}
+        />
+      )}
+
+      {/* Restore Dialog */}
+      {restoreDialogOpen && restoreSnapshot && (
+        <ConfigRestoreDialog
+          open={restoreDialogOpen}
+          serverName={serverName}
+          snapshot={restoreSnapshot}
+          currentSnapshotId={currentSnapshotId}
+          isServerRunning={isServerRunning}
+          onClose={() => {
+            setRestoreDialogOpen(false);
+            setRestoreSnapshot(null);
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/config-history/index.ts
+++ b/platform/services/mcctl-console/src/components/servers/config-history/index.ts
@@ -1,0 +1,5 @@
+export { ServerConfigHistoryTab } from './ServerConfigHistoryTab';
+export { ConfigSnapshotTimeline } from './ConfigSnapshotTimeline';
+export { ConfigSnapshotTimelineItem } from './ConfigSnapshotTimelineItem';
+export { ConfigSnapshotCompareBar } from './ConfigSnapshotCompareBar';
+export { ConfigSnapshotQuickActions } from './ConfigSnapshotQuickActions';

--- a/platform/services/mcctl-console/src/hooks/useDeleteConfigSnapshot.test.ts
+++ b/platform/services/mcctl-console/src/hooks/useDeleteConfigSnapshot.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { useDeleteConfigSnapshot } from './useDeleteConfigSnapshot';
+
+// Mock apiFetch
+vi.mock('./useApi', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from './useApi';
+const mockApiFetch = vi.mocked(apiFetch);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return Wrapper;
+}
+
+describe('useDeleteConfigSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends DELETE request with correct URL', async () => {
+    mockApiFetch.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteConfigSnapshot(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        serverName: 'test-server',
+        snapshotId: 'snap-123',
+      });
+    });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/servers/test-server/config-snapshots/snap-123',
+      { method: 'DELETE' }
+    );
+  });
+
+  it('encodes serverName and snapshotId in URL', async () => {
+    mockApiFetch.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteConfigSnapshot(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        serverName: 'my server',
+        snapshotId: 'snap/with/slashes',
+      });
+    });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/servers/my%20server/config-snapshots/snap%2Fwith%2Fslashes',
+      { method: 'DELETE' }
+    );
+  });
+
+  it('is in pending state during mutation', async () => {
+    let resolve: () => void;
+    mockApiFetch.mockReturnValue(new Promise<void>((r) => (resolve = r)));
+
+    const { result } = renderHook(() => useDeleteConfigSnapshot(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ serverName: 'test-server', snapshotId: 'snap-1' });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    act(() => resolve!());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('reports error on API failure', async () => {
+    mockApiFetch.mockRejectedValue(new Error('Not found'));
+
+    const { result } = renderHook(() => useDeleteConfigSnapshot(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          serverName: 'test-server',
+          snapshotId: 'snap-999',
+        });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Not found');
+  });
+});

--- a/platform/services/mcctl-console/src/hooks/useDeleteConfigSnapshot.ts
+++ b/platform/services/mcctl-console/src/hooks/useDeleteConfigSnapshot.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from './useApi';
+
+interface DeleteConfigSnapshotInput {
+  serverName: string;
+  snapshotId: string;
+}
+
+/**
+ * Hook to delete a config snapshot.
+ *
+ * Sends DELETE /api/servers/:name/config-snapshots/:id
+ * Invalidates the snapshot list on success.
+ */
+export function useDeleteConfigSnapshot() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, DeleteConfigSnapshotInput>({
+    mutationFn: ({ serverName, snapshotId }) =>
+      apiFetch<void>(
+        `/api/servers/${encodeURIComponent(serverName)}/config-snapshots/${encodeURIComponent(snapshotId)}`,
+        { method: 'DELETE' }
+      ),
+    onSuccess: (_, { serverName }) => {
+      queryClient.invalidateQueries({ queryKey: ['config-snapshots', 'list', serverName] });
+      // Also invalidate the global config-snapshots summary
+      queryClient.invalidateQueries({ queryKey: ['config-snapshots'] });
+    },
+  });
+}

--- a/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.test.ts
+++ b/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { useServerConfigSnapshots } from './useServerConfigSnapshots';
+import type { ConfigSnapshotListResponse } from '@/ports/api/IMcctlApiClient';
+
+// Mock apiFetch
+vi.mock('./useApi', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from './useApi';
+const mockApiFetch = vi.mocked(apiFetch);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return Wrapper;
+}
+
+const mockPage1: ConfigSnapshotListResponse = {
+  snapshots: [
+    {
+      id: 'snap-1',
+      serverName: 'test-server',
+      createdAt: '2026-02-22T14:30:00.000Z',
+      description: 'Before mod update',
+      files: [
+        { path: 'server.properties', hash: 'abc123', size: 1024 },
+        { path: 'config.env', hash: 'def456', size: 512 },
+      ],
+    },
+    {
+      id: 'snap-2',
+      serverName: 'test-server',
+      createdAt: '2026-02-21T03:00:00.000Z',
+      description: 'Scheduled: Daily backup',
+      files: [{ path: 'server.properties', hash: 'abc123', size: 1024 }],
+      scheduleId: 'sched-1',
+    },
+  ],
+  total: 3,
+};
+
+describe('useServerConfigSnapshots', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches snapshots for a server', async () => {
+    mockApiFetch.mockResolvedValue(mockPage1);
+
+    const { result } = renderHook(() => useServerConfigSnapshots('test-server'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.pages[0].snapshots).toHaveLength(2);
+    expect(result.current.data?.pages[0].total).toBe(3);
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/servers/test-server/config-snapshots?limit=10&offset=0'
+    );
+  });
+
+  it('encodes server name in URL', async () => {
+    mockApiFetch.mockResolvedValue({ snapshots: [], total: 0 });
+
+    renderHook(() => useServerConfigSnapshots('my server/test'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/api/servers/my%20server%2Ftest/config-snapshots?limit=10&offset=0'
+      )
+    );
+  });
+
+  it('does not fetch when serverName is empty', () => {
+    mockApiFetch.mockResolvedValue({ snapshots: [], total: 0 });
+
+    const { result } = renderHook(() => useServerConfigSnapshots(''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetching).toBe(false);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when disabled via options', () => {
+    mockApiFetch.mockResolvedValue({ snapshots: [], total: 0 });
+
+    const { result } = renderHook(
+      () => useServerConfigSnapshots('test-server', { enabled: false }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetching).toBe(false);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it('hasNextPage is true when there are more snapshots', async () => {
+    mockApiFetch.mockResolvedValue(mockPage1); // 2 snapshots, total=3
+
+    const { result } = renderHook(() => useServerConfigSnapshots('test-server'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('hasNextPage is false when all snapshots are loaded', async () => {
+    const allLoaded: ConfigSnapshotListResponse = {
+      snapshots: mockPage1.snapshots,
+      total: 2, // total equals fetched count
+    };
+    mockApiFetch.mockResolvedValue(allLoaded);
+
+    const { result } = renderHook(() => useServerConfigSnapshots('test-server'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockApiFetch.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useServerConfigSnapshots('test-server'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Network error');
+  });
+});

--- a/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.ts
+++ b/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.ts
@@ -1,0 +1,35 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { apiFetch } from './useApi';
+import type { ConfigSnapshotListResponse } from '@/ports/api/IMcctlApiClient';
+
+const PAGE_SIZE = 10;
+
+/**
+ * Hook to fetch config snapshots for a specific server with infinite pagination.
+ *
+ * Uses React Query's useInfiniteQuery for "Load More" functionality.
+ *
+ * @param serverName - Name of the server to fetch snapshots for
+ * @param options - Optional configuration
+ */
+export function useServerConfigSnapshots(
+  serverName: string,
+  options?: { enabled?: boolean }
+) {
+  return useInfiniteQuery<ConfigSnapshotListResponse, Error>({
+    queryKey: ['config-snapshots', 'list', serverName],
+    queryFn: ({ pageParam = 0 }) =>
+      apiFetch<ConfigSnapshotListResponse>(
+        `/api/servers/${encodeURIComponent(serverName)}/config-snapshots?limit=${PAGE_SIZE}&offset=${pageParam as number}`
+      ),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      const fetched = allPages.reduce((acc, page) => acc + page.snapshots.length, 0);
+      if (fetched >= lastPage.total) return undefined;
+      return fetched;
+    },
+    enabled: options?.enabled !== false && !!serverName,
+    staleTime: 30000,
+    refetchInterval: 60000,
+  });
+}


### PR DESCRIPTION
## Summary

- `ServerConfigHistoryTab` 컴포넌트 추가: 수직 타임라인 UI로 서버별 Config Snapshot 이력 표시
- `ConfigSnapshotTimeline`, `ConfigSnapshotTimelineItem` 컴포넌트 구현
- `ConfigSnapshotCompareBar`: 두 스냅샷을 선택해 비교하는 Compare Mode 플로팅 바
- `ConfigSnapshotQuickActions`: 스냅샷 당 액션 버튼 (View Diff / Restore / Delete)
- `useServerConfigSnapshots` 훅: Infinite Query 기반 페이지네이션
- `useDeleteConfigSnapshot` 훅: 스냅샷 삭제 뮤테이션
- `ServerDetail.tsx`에 "Config History" 탭 추가 (Files와 Backups 사이)
- #402, #404의 `ConfigDiffDialog`, `ConfigRestoreDialog`, `CreateSnapshotDialog` 재사용

## Key Features

- 역 시간 순 타임라인, 날짜별 그룹핑
- 스케줄 실행 스냅샷에 Schedule 배지 표시
- Compare 모드: 두 스냅샷 선택 후 Diff Dialog 열기
- Delete 이중 확인 패턴 (실수 방지)
- Load More 페이지네이션 (무한 스크롤 대신 명시적 버튼)
- 빈 상태(Empty State) UI 포함

## Test plan

- [x] `useServerConfigSnapshots` 훅 테스트 (7개)
- [x] `useDeleteConfigSnapshot` 훅 테스트 (4개)
- [x] `ConfigSnapshotCompareBar` 컴포넌트 테스트 (6개)
- [x] `ConfigSnapshotQuickActions` 컴포넌트 테스트 (8개)
- [x] `ServerConfigHistoryTab` 컴포넌트 테스트 (10개)
- [x] `pnpm build` 성공
- [x] `pnpm lint` 통과

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)