### PR TITLE
feat(console): implement Backups tab in Server Detail page (#427)

### DIFF
--- a/platform/services/mcctl-console/src/components/backups/ConfigSnapshotSchedulePanel.tsx
+++ b/platform/services/mcctl-console/src/components/backups/ConfigSnapshotSchedulePanel.tsx
@@ -30,6 +30,8 @@ interface ConfigSnapshotSchedulePanelProps {
   open: boolean;
   onClose: () => void;
   serverNames: string[];
+  /** When provided, only show schedules for this server */
+  filterServerName?: string;
 }
 
 /**
@@ -40,8 +42,9 @@ export function ConfigSnapshotSchedulePanel({
   open,
   onClose,
   serverNames,
+  filterServerName,
 }: ConfigSnapshotSchedulePanelProps) {
-  const { data, isLoading, error } = useConfigSnapshotSchedules();
+  const { data, isLoading, error } = useConfigSnapshotSchedules(filterServerName);
   const createMutation = useCreateConfigSnapshotSchedule();
   const updateMutation = useUpdateConfigSnapshotSchedule();
   const toggleMutation = useToggleConfigSnapshotSchedule();

--- a/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import SettingsIcon from '@mui/icons-material/Settings';
+import {
+  BackupStatus,
+  BackupHistory,
+  BackupPushButton,
+  BackupScheduleList,
+  BackupPageTabs,
+  ConfigSnapshotServerCard,
+  CreateSnapshotDialog,
+  ConfigSnapshotSchedulePanel,
+  type BackupTabValue,
+} from '@/components/backups';
+import { ConfigDiffDialog } from '@/components/backups/diff';
+import { useBackupStatus } from '@/hooks/useMcctl';
+import { useConfigSnapshots } from '@/hooks/useConfigSnapshots';
+import { useConfigSnapshotSchedules } from '@/hooks/useConfigSnapshotSchedules';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+
+interface ServerBackupTabProps {
+  serverName: string;
+}
+
+export function ServerBackupTab({ serverName }: ServerBackupTabProps) {
+  const [activeSubTab, setActiveSubTab] = useState<BackupTabValue>('world-backups');
+  const { data: statusData } = useBackupStatus();
+  const configured = statusData?.configured ?? false;
+
+  return (
+    <Box>
+      <BackupPageTabs value={activeSubTab} onChange={setActiveSubTab} />
+
+      {activeSubTab === 'world-backups' && (
+        <WorldBackupsContent configured={configured} />
+      )}
+
+      {activeSubTab === 'config-snapshots' && (
+        <ConfigSnapshotsContent serverName={serverName} />
+      )}
+    </Box>
+  );
+}
+
+function WorldBackupsContent({ configured }: { configured: boolean }) {
+  return (
+    <Stack spacing={3}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <BackupPushButton disabled={!configured} />
+      </Box>
+      <BackupStatus />
+      <BackupScheduleList />
+      {configured && <BackupHistory />}
+    </Stack>
+  );
+}
+
+function ConfigSnapshotsContent({ serverName }: { serverName: string }) {
+  const { data: snapshotsData, isLoading: snapshotsLoading, error: snapshotsError } = useConfigSnapshots(serverName, 5, 0);
+  const { data: schedulesData } = useConfigSnapshotSchedules(serverName);
+  const schedules = schedulesData?.schedules ?? [];
+
+  const snapshots = snapshotsData?.snapshots ?? [];
+  const totalCount = snapshotsData?.total ?? 0;
+  const schedule = schedules.find((s) => s.serverName === serverName);
+
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [schedulePanelOpen, setSchedulePanelOpen] = useState(false);
+  const [diffDialogOpen, setDiffDialogOpen] = useState(false);
+
+  const diffSnapshots = useMemo(() => {
+    if (snapshots.length < 2) return { snapshotA: null, snapshotB: null };
+    return {
+      snapshotA: snapshots[1] as ConfigSnapshotItem,
+      snapshotB: snapshots[0] as ConfigSnapshotItem,
+    };
+  }, [snapshots]);
+
+  if (snapshotsLoading) {
+    return (
+      <Typography color="text.secondary">Loading config snapshots...</Typography>
+    );
+  }
+
+  if (snapshotsError) {
+    return (
+      <Typography color="error">Failed to load config snapshots</Typography>
+    );
+  }
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mb: 2 }}>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<SettingsIcon />}
+          onClick={() => setSchedulePanelOpen(true)}
+        >
+          Manage Schedules
+        </Button>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<AddCircleOutlineIcon />}
+          onClick={() => setCreateDialogOpen(true)}
+        >
+          Create Snapshot
+        </Button>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Config snapshots capture server configuration files (server.properties, config.env, etc.)
+        for versioning, comparison, and restore operations.
+      </Typography>
+
+      <ConfigSnapshotServerCard
+        serverName={serverName}
+        snapshots={snapshots}
+        totalCount={totalCount}
+        schedule={schedule}
+        onViewHistory={() => {
+          if (snapshots.length > 0) {
+            setDiffDialogOpen(true);
+          }
+        }}
+        onCreateSnapshot={() => setCreateDialogOpen(true)}
+        onViewDiff={() => setDiffDialogOpen(true)}
+      />
+
+      <CreateSnapshotDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        serverNames={[serverName]}
+        defaultServer={serverName}
+      />
+
+      <ConfigSnapshotSchedulePanel
+        open={schedulePanelOpen}
+        onClose={() => setSchedulePanelOpen(false)}
+        serverNames={[serverName]}
+      />
+
+      {diffDialogOpen && diffSnapshots.snapshotA && diffSnapshots.snapshotB && (
+        <ConfigDiffDialog
+          open={diffDialogOpen}
+          onClose={() => setDiffDialogOpen(false)}
+          snapshotA={diffSnapshots.snapshotA}
+          snapshotB={diffSnapshots.snapshotB}
+        />
+      )}
+    </>
+  );
+}

--- a/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
@@ -126,7 +126,7 @@ function ConfigSnapshotsContent({ serverName }: { serverName: string }) {
         totalCount={totalCount}
         schedule={schedule}
         onViewHistory={() => {
-          if (snapshots.length > 0) {
+          if (snapshots.length >= 2) {
             setDiffDialogOpen(true);
           }
         }}
@@ -145,6 +145,7 @@ function ConfigSnapshotsContent({ serverName }: { serverName: string }) {
         open={schedulePanelOpen}
         onClose={() => setSchedulePanelOpen(false)}
         serverNames={[serverName]}
+        filterServerName={serverName}
       />
 
       {diffDialogOpen && diffSnapshots.snapshotA && diffSnapshots.snapshotB && (

--- a/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerDetail.tsx
@@ -35,6 +35,7 @@ import { HostnameDisplay } from '@/components/common';
 import { ServerModsTab } from './ServerModsTab';
 import { ServerFilesTab } from './files/ServerFilesTab';
 import { ServerConfigHistoryTab } from './config-history';
+import { ServerBackupTab } from './ServerBackupTab';
 
 interface ServerDetailProps {
   server: ServerDetailType;
@@ -586,9 +587,7 @@ export function ServerDetail({ server, onSendCommand }: ServerDetailProps) {
 
       {activeTab === 'Backups' && (
         <Box sx={{ mt: 3 }}>
-          <Typography variant="body1" color="text.secondary">
-            Backup management coming soon
-          </Typography>
+          <ServerBackupTab serverName={server.name} />
         </Box>
       )}
 


### PR DESCRIPTION
## Summary
- 서버 상세 화면(`/servers/[name]`)의 Backups 탭 플레이스홀더를 실제 백업 관리 UI로 교체
- World Backups 서브탭: `BackupStatus`, `BackupPushButton`, `BackupScheduleList`, `BackupHistory` 재사용
- Config Snapshots 서브탭: 해당 서버에 스코프된 Config Snapshot 관리 (생성, 히스토리, Diff, 스케줄)

## Changes
| File | Change |
|------|--------|
| `ServerBackupTab.tsx` | **New** - 서버 상세용 백업 탭 컴포넌트 |
| `ServerDetail.tsx` | 플레이스홀더 → `ServerBackupTab` 교체 |

## Test plan
- [ ] 서버 상세 페이지에서 Backups 탭 클릭 시 World Backups / Config Snapshots 서브탭 표시 확인
- [ ] World Backups: 백업 상태, Push Backup 버튼, 스케줄 목록, 히스토리 테이블 동작 확인
- [ ] Config Snapshots: 해당 서버의 스냅샷 카드, Create Snapshot, View Diff 동작 확인
- [ ] 기존 `/backups` 글로벌 페이지 기능에 영향 없음 확인
- [ ] TypeScript 빌드 성공 확인

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)