### PR TITLE
fix(console): add null guards to useServerConfigSnapshots (#431)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.test.tsx
@@ -267,4 +267,49 @@ describe('ServerConfigHistoryTab', () => {
       expect(screen.queryByText('Compare mode')).not.toBeInTheDocument();
     });
   });
+
+  it('renders without crash when page.snapshots is undefined', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: {
+        pages: [{ total: 0 } as never],
+        pageParams: [0],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    // Should not throw TypeError
+    renderComponent();
+
+    expect(screen.getByText('No config snapshots yet')).toBeInTheDocument();
+  });
+
+  it('renders empty state when pages contain mixed undefined snapshots', () => {
+    mockUseServerConfigSnapshots.mockReturnValue({
+      data: {
+        pages: [
+          { snapshots: undefined, total: 0 } as never,
+          { total: 0 } as never,
+        ],
+        pageParams: [0, 10],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    // Should not throw TypeError from flatMap
+    renderComponent();
+
+    expect(screen.getByText('No config snapshots yet')).toBeInTheDocument();
+  });
 });

--- a/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ServerConfigHistoryTab.tsx
@@ -54,7 +54,7 @@ export function ServerConfigHistoryTab({
 
   // Flatten pages into a single list (newest first — API returns in reverse chronological order)
   const snapshots: ConfigSnapshotItem[] = useMemo(
-    () => data?.pages.flatMap((p) => p.snapshots) ?? [],
+    () => data?.pages.flatMap((p) => p?.snapshots ?? []) ?? [],
     [data]
   );
   const total = data?.pages[0]?.total ?? 0;

--- a/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.test.ts
+++ b/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.test.ts
@@ -146,4 +146,31 @@ describe('useServerConfigSnapshots', () => {
 
     expect(result.current.error?.message).toBe('Network error');
   });
+
+  it('handles page with undefined snapshots in getNextPageParam without TypeError', async () => {
+    // Simulate a response where snapshots is undefined (malformed API response)
+    const malformedResponse = { total: 0 } as ConfigSnapshotListResponse;
+    mockApiFetch.mockResolvedValue(malformedResponse);
+
+    const { result } = renderHook(() => useServerConfigSnapshots('test-server'), {
+      wrapper: createWrapper(),
+    });
+
+    // Should not throw TypeError, should resolve gracefully
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('handles lastPage with undefined total in getNextPageParam without TypeError', async () => {
+    // Simulate a response where total is undefined
+    const malformedResponse = { snapshots: [] } as unknown as ConfigSnapshotListResponse;
+    mockApiFetch.mockResolvedValue(malformedResponse);
+
+    const { result } = renderHook(() => useServerConfigSnapshots('test-server'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(false);
+  });
 });

--- a/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.ts
+++ b/platform/services/mcctl-console/src/hooks/useServerConfigSnapshots.ts
@@ -24,8 +24,11 @@ export function useServerConfigSnapshots(
       ),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
-      const fetched = allPages.reduce((acc, page) => acc + page.snapshots.length, 0);
-      if (fetched >= lastPage.total) return undefined;
+      const fetched = allPages.reduce(
+        (acc, page) => acc + (page?.snapshots?.length ?? 0),
+        0
+      );
+      if (fetched >= (lastPage?.total ?? 0)) return undefined;
       return fetched;
     },
     enabled: options?.enabled !== false && !!serverName,


### PR DESCRIPTION
## Summary

- `useServerConfigSnapshots.ts`의 `getNextPageParam`에 null guard 추가하여 `page.snapshots`가 undefined일 때 TypeError 방지
- `ServerConfigHistoryTab.tsx`의 `flatMap`에 null guard 추가하여 동일 이슈 방지
- edge case 테스트 4건 추가 (snapshots undefined 시나리오)

## Test plan

- [x] `getNextPageParam`에서 `page.snapshots` undefined 시 에러 없이 동작 확인
- [x] `flatMap`에서 `page.snapshots` undefined 시 빈 배열 반환 확인
- [x] 기존 테스트 17개 regression 없음
- [x] 신규 edge case 테스트 4건 통과

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>