### PR TITLE
docs(npm): add Q&A and Ideas discussion links to README (#433)

### DIFF
--- a/platform/services/cli/README.md
+++ b/platform/services/cli/README.md
@@ -122,6 +122,11 @@ mcctl logs myserver
 
 [Full Changelog](https://github.com/smallmiro/minecraft-server-manager/releases)
 
+## Community
+
+- **[Q&A / Support](https://github.com/smallmiro/minecraft-server-manager/discussions/categories/q-a)** - Ask questions and get help from the community
+- **[Ideas / Feature Requests](https://github.com/smallmiro/minecraft-server-manager/discussions/categories/ideas)** - Share your ideas and vote on feature requests
+
 ## AI Assistant
 
 Get help using mcctl with our AI-powered assistant:


### PR DESCRIPTION
## Summary
- npm 패키지 README에 Community 섹션 추가
- GitHub Discussions Q&A 및 Ideas 카테고리 링크 배치
- Changelog 섹션과 AI Assistant 섹션 사이에 위치

## Changes
- `platform/services/cli/README.md`: Community 섹션 추가 (Q&A / Support, Ideas / Feature Requests)

## Test plan
- [ ] README 마크다운 렌더링 확인
- [ ] Q&A 링크 클릭 시 올바른 GitHub Discussions 페이지로 이동
- [ ] Ideas 링크 클릭 시 올바른 GitHub Discussions 페이지로 이동

Closes #433

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>