### PR TITLE
fix(console): disable View History button when less than 2 snapshots (#432)

### DIFF
--- a/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.test.tsx
+++ b/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@/theme';
 import { ConfigSnapshotServerCard } from './ConfigSnapshotServerCard';
 import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
@@ -81,7 +81,7 @@ describe('ConfigSnapshotServerCard', () => {
       expect(button).not.toBeDisabled();
     });
 
-    it('should show tooltip on disabled View History button explaining minimum requirement', () => {
+    it('should show tooltip on disabled View History button explaining minimum requirement', async () => {
       const oneSnapshot = [createMockSnapshot('snap-1', new Date().toISOString())];
       renderWithTheme(
         <ConfigSnapshotServerCard
@@ -90,8 +90,12 @@ describe('ConfigSnapshotServerCard', () => {
           totalCount={1}
         />
       );
-      // The tooltip text should indicate need for at least 2 snapshots
-      expect(screen.getByLabelText(/at least 2 snapshots/i)).toBeInTheDocument();
+      // Hover over the disabled button's wrapper span to trigger MUI Tooltip
+      const button = screen.getByRole('button', { name: /View History/i });
+      fireEvent.mouseOver(button.parentElement!);
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toHaveTextContent(/at least 2 snapshots/i);
+      });
     });
 
     it('should call onViewHistory when View History button is clicked with sufficient snapshots', () => {

--- a/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.test.tsx
+++ b/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { ConfigSnapshotServerCard } from './ConfigSnapshotServerCard';
+import type { ConfigSnapshotItem } from '@/ports/api/IMcctlApiClient';
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+const createMockSnapshot = (id: string, createdAt: string): ConfigSnapshotItem => ({
+  id,
+  serverName: 'test-server',
+  createdAt,
+  trigger: 'manual' as const,
+  files: [
+    { path: 'server.properties', contentHash: 'abc123' },
+  ],
+});
+
+describe('ConfigSnapshotServerCard', () => {
+  const defaultProps = {
+    serverName: 'test-server',
+    snapshots: [] as ConfigSnapshotItem[],
+    totalCount: 0,
+    onViewHistory: vi.fn(),
+    onCreateSnapshot: vi.fn(),
+    onViewDiff: vi.fn(),
+  };
+
+  it('should render server name', () => {
+    renderWithTheme(<ConfigSnapshotServerCard {...defaultProps} />);
+    expect(screen.getByText('test-server')).toBeInTheDocument();
+  });
+
+  it('should render "No snapshots yet" when no snapshots exist', () => {
+    renderWithTheme(<ConfigSnapshotServerCard {...defaultProps} />);
+    expect(screen.getByText('No snapshots yet')).toBeInTheDocument();
+  });
+
+  it('should render total count chip', () => {
+    renderWithTheme(<ConfigSnapshotServerCard {...defaultProps} totalCount={3} />);
+    expect(screen.getByText('3 snapshots total')).toBeInTheDocument();
+  });
+
+  describe('View History button - disabled conditions (#432)', () => {
+    it('should disable View History button when totalCount is 0', () => {
+      renderWithTheme(
+        <ConfigSnapshotServerCard {...defaultProps} totalCount={0} />
+      );
+      const button = screen.getByRole('button', { name: /View History/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('should disable View History button when totalCount is 1 (less than 2)', () => {
+      const oneSnapshot = [createMockSnapshot('snap-1', new Date().toISOString())];
+      renderWithTheme(
+        <ConfigSnapshotServerCard
+          {...defaultProps}
+          snapshots={oneSnapshot}
+          totalCount={1}
+        />
+      );
+      const button = screen.getByRole('button', { name: /View History/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('should enable View History button when totalCount is 2 or more', () => {
+      const twoSnapshots = [
+        createMockSnapshot('snap-2', new Date().toISOString()),
+        createMockSnapshot('snap-1', new Date(Date.now() - 3600000).toISOString()),
+      ];
+      renderWithTheme(
+        <ConfigSnapshotServerCard
+          {...defaultProps}
+          snapshots={twoSnapshots}
+          totalCount={2}
+        />
+      );
+      const button = screen.getByRole('button', { name: /View History/i });
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should show tooltip on disabled View History button explaining minimum requirement', () => {
+      const oneSnapshot = [createMockSnapshot('snap-1', new Date().toISOString())];
+      renderWithTheme(
+        <ConfigSnapshotServerCard
+          {...defaultProps}
+          snapshots={oneSnapshot}
+          totalCount={1}
+        />
+      );
+      // The tooltip text should indicate need for at least 2 snapshots
+      expect(screen.getByLabelText(/at least 2 snapshots/i)).toBeInTheDocument();
+    });
+
+    it('should call onViewHistory when View History button is clicked with sufficient snapshots', () => {
+      const twoSnapshots = [
+        createMockSnapshot('snap-2', new Date().toISOString()),
+        createMockSnapshot('snap-1', new Date(Date.now() - 3600000).toISOString()),
+      ];
+      const onViewHistory = vi.fn();
+      renderWithTheme(
+        <ConfigSnapshotServerCard
+          {...defaultProps}
+          snapshots={twoSnapshots}
+          totalCount={2}
+          onViewHistory={onViewHistory}
+        />
+      );
+      const button = screen.getByRole('button', { name: /View History/i });
+      fireEvent.click(button);
+      expect(onViewHistory).toHaveBeenCalledWith('test-server');
+    });
+  });
+
+  it('should render Create Snapshot button always enabled', () => {
+    renderWithTheme(<ConfigSnapshotServerCard {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /Create Snapshot/i });
+    expect(button).not.toBeDisabled();
+  });
+
+  it('should show View Diff button only when 2+ snapshots available', () => {
+    const twoSnapshots = [
+      createMockSnapshot('snap-2', new Date().toISOString()),
+      createMockSnapshot('snap-1', new Date(Date.now() - 3600000).toISOString()),
+    ];
+    renderWithTheme(
+      <ConfigSnapshotServerCard
+        {...defaultProps}
+        snapshots={twoSnapshots}
+        totalCount={2}
+      />
+    );
+    expect(screen.getByRole('button', { name: /View Diff/i })).toBeInTheDocument();
+  });
+
+  it('should not show View Diff button when less than 2 snapshots', () => {
+    renderWithTheme(<ConfigSnapshotServerCard {...defaultProps} totalCount={1} />);
+    expect(screen.queryByRole('button', { name: /View Diff/i })).not.toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.tsx
+++ b/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.tsx
@@ -134,7 +134,7 @@ export function ConfigSnapshotServerCard({
             title={totalCount < 2 ? 'Need at least 2 snapshots to compare history' : ''}
             arrow
           >
-            <span aria-label={totalCount < 2 ? 'Need at least 2 snapshots to compare history' : undefined}>
+            <span>
               <Button
                 size="small"
                 variant="outlined"

--- a/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.tsx
+++ b/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.tsx
@@ -130,15 +130,22 @@ export function ConfigSnapshotServerCard({
 
         {/* Action buttons */}
         <Stack direction="row" spacing={1}>
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<HistoryIcon />}
-            onClick={() => onViewHistory(serverName)}
-            disabled={totalCount === 0}
+          <Tooltip
+            title={totalCount < 2 ? 'Need at least 2 snapshots to compare history' : ''}
+            arrow
           >
-            View History
-          </Button>
+            <span aria-label={totalCount < 2 ? 'Need at least 2 snapshots to compare history' : undefined}>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<HistoryIcon />}
+                onClick={() => onViewHistory(serverName)}
+                disabled={totalCount < 2}
+              >
+                View History
+              </Button>
+            </span>
+          </Tooltip>
           <Button
             size="small"
             variant="outlined"

--- a/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
@@ -150,9 +150,8 @@ function ConfigSnapshotsContent({ serverName }: { serverName: string }) {
         totalCount={totalCount}
         schedule={schedule}
         onViewHistory={() => {
-          // Button is disabled in ConfigSnapshotServerCard when totalCount < 2,
-          // but keep this guard as defensive code
-          if (snapshots.length >= 2) {
+          // Guard aligned with ConfigSnapshotServerCard disabled={totalCount < 2}
+          if (totalCount >= 2 && snapshots.length >= 2) {
             setDiffDialogOpen(true);
           }
         }}

--- a/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerBackupTab.tsx
@@ -150,6 +150,8 @@ function ConfigSnapshotsContent({ serverName }: { serverName: string }) {
         totalCount={totalCount}
         schedule={schedule}
         onViewHistory={() => {
+          // Button is disabled in ConfigSnapshotServerCard when totalCount < 2,
+          // but keep this guard as defensive code
           if (snapshots.length >= 2) {
             setDiffDialogOpen(true);
           }


### PR DESCRIPTION
## Summary
- ConfigSnapshotServerCard의 View History 버튼 disabled 조건을 `totalCount === 0`에서 `totalCount < 2`로 변경
- 비활성 시 Tooltip으로 "Need at least 2 snapshots to compare history" 메시지 표시
- ServerBackupTab의 onViewHistory 핸들러에 방어적 코드 주석 추가

## Root Cause
`disabled={totalCount === 0}`으로만 체크하여, totalCount가 1인 경우에도 버튼이 활성화되지만 `onViewHistory` 핸들러에서 `snapshots.length >= 2`를 요구하여 클릭 시 아무 일도 일어나지 않았습니다.

## Changes
- `ConfigSnapshotServerCard.tsx`: disabled 조건 `totalCount < 2`로 변경 + Tooltip 추가
- `ServerBackupTab.tsx`: 방어적 코드 주석 추가
- `ConfigSnapshotServerCard.test.tsx`: 11개 테스트 추가 (TDD)

## Test plan
- [x] 스냅샷 0개: View History 버튼 비활성화 확인
- [x] 스냅샷 1개: View History 버튼 비활성화 + Tooltip 사유 표시 확인
- [x] 스냅샷 2개 이상: View History 버튼 클릭 시 정상 동작 확인
- [x] 기존 테스트 통과 (828/832 - 기존 실패 4건은 무관)

Closes #432

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>