### PR TITLE
feat(console): add Q&A and Ideas community links to Footer (#434)

### DIFF
--- a/platform/services/mcctl-console/src/components/layout/Footer.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Footer.test.tsx
@@ -38,32 +38,28 @@ describe('Footer', () => {
 
     expect(screen.getByText('GitHub')).toBeInTheDocument();
     expect(screen.getByText('Issues')).toBeInTheDocument();
+    expect(screen.getByText('Q&A / Support')).toBeInTheDocument();
+    expect(screen.getByText('Ideas / Feature Requests')).toBeInTheDocument();
   });
 
-  it('should render Q&A support link in community section', () => {
+  it('should render community discussion links with correct attributes', () => {
     renderWithTheme(<Footer />);
 
-    const qaLink = screen.getByText('Q&A / Support');
-    expect(qaLink).toBeInTheDocument();
-    expect(qaLink.closest('a')).toHaveAttribute(
+    const qaLink = screen.getByText('Q&A / Support').closest('a');
+    expect(qaLink).toHaveAttribute(
       'href',
       'https://github.com/smallmiro/minecraft-server-manager/discussions/categories/q-a'
     );
-    expect(qaLink.closest('a')).toHaveAttribute('target', '_blank');
-    expect(qaLink.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
-  });
+    expect(qaLink).toHaveAttribute('target', '_blank');
+    expect(qaLink).toHaveAttribute('rel', 'noopener noreferrer');
 
-  it('should render Ideas link in community section', () => {
-    renderWithTheme(<Footer />);
-
-    const ideasLink = screen.getByText('Ideas / Feature Requests');
-    expect(ideasLink).toBeInTheDocument();
-    expect(ideasLink.closest('a')).toHaveAttribute(
+    const ideasLink = screen.getByText('Ideas / Feature Requests').closest('a');
+    expect(ideasLink).toHaveAttribute(
       'href',
       'https://github.com/smallmiro/minecraft-server-manager/discussions/categories/ideas'
     );
-    expect(ideasLink.closest('a')).toHaveAttribute('target', '_blank');
-    expect(ideasLink.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(ideasLink).toHaveAttribute('target', '_blank');
+    expect(ideasLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('should render about links', () => {

--- a/platform/services/mcctl-console/src/components/layout/Footer.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Footer.test.tsx
@@ -40,6 +40,32 @@ describe('Footer', () => {
     expect(screen.getByText('Issues')).toBeInTheDocument();
   });
 
+  it('should render Q&A support link in community section', () => {
+    renderWithTheme(<Footer />);
+
+    const qaLink = screen.getByText('Q&A / Support');
+    expect(qaLink).toBeInTheDocument();
+    expect(qaLink.closest('a')).toHaveAttribute(
+      'href',
+      'https://github.com/smallmiro/minecraft-server-manager/discussions/categories/q-a'
+    );
+    expect(qaLink.closest('a')).toHaveAttribute('target', '_blank');
+    expect(qaLink.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should render Ideas link in community section', () => {
+    renderWithTheme(<Footer />);
+
+    const ideasLink = screen.getByText('Ideas / Feature Requests');
+    expect(ideasLink).toBeInTheDocument();
+    expect(ideasLink.closest('a')).toHaveAttribute(
+      'href',
+      'https://github.com/smallmiro/minecraft-server-manager/discussions/categories/ideas'
+    );
+    expect(ideasLink.closest('a')).toHaveAttribute('target', '_blank');
+    expect(ideasLink.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   it('should render about links', () => {
     renderWithTheme(<Footer />);
 

--- a/platform/services/mcctl-console/src/components/layout/Footer.tsx
+++ b/platform/services/mcctl-console/src/components/layout/Footer.tsx
@@ -59,6 +59,16 @@ const footerSections: FooterSection[] = [
         href: 'https://github.com/smallmiro/minecraft-server-manager/issues',
         external: true,
       },
+      {
+        label: 'Q&A / Support',
+        href: 'https://github.com/smallmiro/minecraft-server-manager/discussions/categories/q-a',
+        external: true,
+      },
+      {
+        label: 'Ideas / Feature Requests',
+        href: 'https://github.com/smallmiro/minecraft-server-manager/discussions/categories/ideas',
+        external: true,
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Footer Community 섹션에 Q&A / Support 및 Ideas / Feature Requests 링크 추가
- GitHub Discussions 카테고리로 연결되며 새 탭에서 열림
- MUI 디자인 시스템과 일관된 기존 Footer 스타일 유지

## Changes
- `Footer.tsx`: Community 섹션 footerSections 배열에 2개 링크 추가
- `Footer.test.tsx`: 2개 테스트 추가 (링크 존재 여부, href/target/rel 속성 검증)

## Test plan
- [x] Q&A / Support 링크가 Community 섹션에 표시
- [x] Ideas / Feature Requests 링크가 Community 섹션에 표시
- [x] 링크 클릭 시 새 탭에서 올바른 URL로 이동
- [x] MUI 디자인 시스템과 일관된 스타일 (기존 footerSections 구조 활용)
- [x] 기존 Footer 테스트 10개 모두 통과

Closes #434

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>