### PR TITLE
docs: add WebSocket Console, SSH Console, and Autoscale documentation (#443)

### DIFF
--- a/docs/itzg-reference/10-commands.md
+++ b/docs/itzg-reference/10-commands.md
@@ -86,86 +86,75 @@ services:
 
 ---
 
-## SSH Access
+## SSH Console
 
-Remote SSH console:
+Access server console via SSH connection.
 
-### Configuration
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_SSH` | `false` | Enable SSH console |
 
-```yaml
-environment:
-  ENABLE_SSH: "true"
-  RCON_PASSWORD: "secure_password"  # Used as SSH password
-```
+- Port: 2222 (inside container)
+- Password: Same as RCON password
+- Password-based authentication only
 
-### Port Mapping
-
-```yaml
-ports:
-  - "25565:25565"
-  - "2222:2222"
-```
-
-### Connection
-
-```bash
-ssh anyuser@server-ip -p 2222
-# Password: RCON_PASSWORD value
-```
-
-### Security Recommendations
+### Docker Compose Example
 
 ```yaml
-ports:
-  - "25565:25565"
-  - "127.0.0.1:2222:2222"  # Allow local access only
+services:
+  mc:
+    image: itzg/minecraft-server
+    ports:
+      - "25565:25565"
+      - "2222:2222"   # SSH console
+    environment:
+      EULA: "TRUE"
+      ENABLE_SSH: "true"
+      RCON_PASSWORD: "your_password"
 ```
 
 ---
 
 ## WebSocket Console
 
-Web-based console access:
+Stream server logs and send commands via WebSocket connection.
 
-### Configuration
+### Enable
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `WEBSOCKET_CONSOLE` | `false` | Enable WebSocket |
+| `WEBSOCKET_CONSOLE` | `false` | Enable WebSocket console |
 | `WEBSOCKET_ADDRESS` | `0.0.0.0:80` | Bind address |
-| `WEBSOCKET_PASSWORD` | - | Access password |
-| `WEBSOCKET_LOG_BUFFER_SIZE` | `50` | Log buffer size |
+| `WEBSOCKET_DISABLE_ORIGIN_CHECK` | `false` | Disable origin check |
+| `WEBSOCKET_ALLOWED_ORIGINS` | - | Allowed origins (comma-separated) |
+| `WEBSOCKET_PASSWORD` | - | WebSocket password (uses RCON_PASSWORD if unset) |
+| `WEBSOCKET_DISABLE_AUTHENTICATION` | `false` | Disable authentication |
+| `WEBSOCKET_LOG_BUFFER_SIZE` | `50` | Number of log history lines |
+
+### Docker Compose Example
 
 ```yaml
-environment:
-  WEBSOCKET_CONSOLE: "true"
-  WEBSOCKET_ADDRESS: "0.0.0.0:8080"
-  WEBSOCKET_PASSWORD: "secure_password"
+services:
+  mc:
+    image: itzg/minecraft-server
+    ports:
+      - "25565:25565"
+      - "8080:80"     # WebSocket console
+    environment:
+      EULA: "TRUE"
+      WEBSOCKET_CONSOLE: "true"
+      WEBSOCKET_PASSWORD: "your_password"
 ```
 
-### Port Mapping
+### Message Types
 
-```yaml
-ports:
-  - "25565:25565"
-  - "8080:8080"
-```
-
-### Authentication
-
-Use `Sec-WebSocket-Protocol` header when connecting via WebSocket:
-- First: `mc-server-runner-ws-v1`
-- Second: password
-
-### Security Settings
-
-```yaml
-environment:
-  WEBSOCKET_CONSOLE: "true"
-  WEBSOCKET_PASSWORD: "secure_password"
-  WEBSOCKET_ALLOWED_ORIGINS: "https://admin.example.com"
-  WEBSOCKET_DISABLE_ORIGIN_CHECK: "false"
-```
+| Type | Direction | Description |
+|------|-----------|-------------|
+| `StdinMessage` | Client → Server | Send command |
+| `StdoutMessage` | Server → Client | Standard output |
+| `StderrMessage` | Server → Client | Error output |
+| `LogHistoryMessage` | Server → Client | Log history on connect |
+| `AuthFailureMessage` | Server → Client | Authentication failed |
 
 ---
 

--- a/docs/itzg-reference/11-autopause-autostop.md
+++ b/docs/itzg-reference/11-autopause-autostop.md
@@ -253,3 +253,20 @@ services:
     volumes:
       - ./data:/data
 ```
+
+---
+
+## Autoscale (Scale to Zero)
+
+Stop servers when idle and automatically start them when players connect.
+
+### mc-router
+Hostname-based routing with automatic container start/stop. Used by this project for multi-server management.
+
+### Lazymc (via lazymc-docker-proxy)
+Proxy that manages server container lifecycle. Requires custom network with fixed IPs.
+
+### Lazytainer
+Network traffic-based container start/stop. Not Minecraft-aware (no hostname routing).
+
+For details, see: https://docker-minecraft-server.readthedocs.io/en/latest/misc/autoscale/autoscale/

--- a/docs/itzg-reference/doc-list.md
+++ b/docs/itzg-reference/doc-list.md
@@ -65,6 +65,9 @@
 - https://docker-minecraft-server.readthedocs.io/en/latest/misc/autopause-autostop/autopause/
 - https://docker-minecraft-server.readthedocs.io/en/latest/misc/autopause-autostop/autostop/
 
+### Autoscale
+- https://docker-minecraft-server.readthedocs.io/en/latest/misc/autoscale/autoscale/
+
 ### Contributing
 - https://docker-minecraft-server.readthedocs.io/en/latest/misc/contributing/development/
 - https://docker-minecraft-server.readthedocs.io/en/latest/misc/contributing/docs/


### PR DESCRIPTION
## Summary
- Updated WebSocket Console section in `docs/itzg-reference/10-commands.md` with full environment variables (`WEBSOCKET_DISABLE_ORIGIN_CHECK`, `WEBSOCKET_ALLOWED_ORIGINS`, `WEBSOCKET_DISABLE_AUTHENTICATION`) and WebSocket message types table
- Replaced SSH Access section with simplified SSH Console format including env var table
- Added Autoscale (Scale to Zero) section to `docs/itzg-reference/11-autopause-autostop.md` covering mc-router, Lazymc, and Lazytainer
- Added Autoscale link to `docs/itzg-reference/doc-list.md`

## Test plan
- [ ] Verify MkDocs builds without errors (`mkdocs build`)
- [ ] Confirm WebSocket Console section renders correctly with tables and code blocks
- [ ] Confirm SSH Console section renders correctly
- [ ] Confirm Autoscale section appears at end of autopause-autostop page
- [ ] Verify doc-list.md Autoscale link is valid

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)