### PR TITLE
chore: unify @types/node to ^22.x across all packages (#451)

### DIFF
--- a/platform/services/cli/package.json
+++ b/platform/services/cli/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.13.1",
     "@types/tar": "^6.1.13",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",

--- a/platform/services/mcctl-api/package.json
+++ b/platform/services/mcctl-api/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.13.1",
     "@types/node-cron": "^3.0.11",
     "tsx": "^4.19.2",
     "typescript": "^5.3.0",

--- a/platform/services/mod-source-modrinth/package.json
+++ b/platform/services/mod-source-modrinth/package.json
@@ -29,7 +29,7 @@
     "@minecraft-docker/shared": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.13.1",
     "typescript": "^5.3.0"
   },
   "keywords": [

--- a/platform/services/shared/package.json
+++ b/platform/services/shared/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.13.1",
     "tsx": "^4.21.0",
     "typescript": "^5.3.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.30
+        specifier: ^22.13.1
+        version: 22.19.7
       '@types/tar':
         specifier: ^6.1.13
         version: 6.1.13
@@ -70,7 +70,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@20.19.30)(jsdom@26.1.0)
+        version: 2.1.9(@types/node@22.19.7)(jsdom@26.1.0)
 
   platform/services/mcctl-api:
     dependencies:
@@ -121,8 +121,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.30
+        specifier: ^22.13.1
+        version: 22.19.7
       '@types/node-cron':
         specifier: ^3.0.11
         version: 3.0.11
@@ -134,7 +134,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.19.30)(jsdom@26.1.0)
+        version: 2.1.9(@types/node@22.19.7)(jsdom@26.1.0)
 
   platform/services/mcctl-console:
     dependencies:
@@ -279,8 +279,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.30
+        specifier: ^22.13.1
+        version: 22.19.7
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -304,8 +304,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.30
+        specifier: ^22.13.1
+        version: 22.19.7
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -5900,11 +5900,11 @@ snapshots:
 
   '@types/bcrypt@6.0.0':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
 
   '@types/estree@1.0.8': {}
 
@@ -5943,7 +5943,7 @@ snapshots:
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
       minipass: 4.2.8
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
@@ -6116,14 +6116,6 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
-
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.30))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@20.19.30)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.7))':
     dependencies:
@@ -8970,24 +8962,6 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  vite-node@2.1.9(@types/node@20.19.30):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.21(@types/node@20.19.30)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@2.1.9(@types/node@22.19.7):
     dependencies:
       cac: 6.7.14
@@ -9006,15 +8980,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@20.19.30):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.56.0
-    optionalDependencies:
-      '@types/node': 20.19.30
-      fsevents: 2.3.3
-
   vite@5.4.21(@types/node@22.19.7):
     dependencies:
       esbuild: 0.21.5
@@ -9023,42 +8988,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.7
       fsevents: 2.3.3
-
-  vitest@2.1.9(@types/node@20.19.30)(jsdom@26.1.0):
-    dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.30))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@20.19.30)
-      vite-node: 2.1.9(@types/node@20.19.30)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.30
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@2.1.9(@types/node@22.19.7)(jsdom@26.1.0):
     dependencies:


### PR DESCRIPTION
## Summary

- `@types/node` 버전을 모든 패키지에서 `^22.13.1`로 통일
- 기존 4개 패키지가 `^20.10.0`을 사용하고 있었으나 `mcctl-console`은 이미 `^22.13.1` 사용 중
- pnpm lockfile 업데이트 및 전체 빌드 검증 완료

## Changed Packages

| Package | Before | After |
|---------|--------|-------|
| `@minecraft-docker/shared` | `^20.10.0` | `^22.13.1` |
| `@minecraft-docker/mcctl` | `^20.10.0` | `^22.13.1` |
| `@minecraft-docker/mcctl-api` | `^20.10.0` | `^22.13.1` |
| `@minecraft-docker/mod-source-modrinth` | `^20.10.0` | `^22.13.1` |
| `@minecraft-docker/mcctl-console` | `^22.13.1` | (unchanged) |

## Test plan

- [x] All `package.json` files updated to `^22.13.1`
- [x] `pnpm install` completed successfully (lockfile updated, 4 duplicate packages removed)
- [x] `pnpm -r run build` passed with no type errors across all 6 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)