### PR TITLE
feat(api,console): add Configuration Repository settings support (#448)

### DIFF
--- a/platform/services/mcctl-api/src/schemas/config.ts
+++ b/platform/services/mcctl-api/src/schemas/config.ts
@@ -111,6 +111,12 @@ export const ServerConfigSchema = Type.Object({
   stopDuration: Type.Optional(Type.Number({ minimum: 0, description: 'Graceful stop timeout in seconds' })),
   uid: Type.Optional(Type.Number({ minimum: 0, description: 'Container user ID' })),
   gid: Type.Optional(Type.Number({ minimum: 0, description: 'Container group ID' })),
+
+  // ── Configuration Repositories ──
+  paperConfigRepo: Type.Optional(Type.String({ description: 'Paper optimized config repository URL' })),
+  pufferfishConfigRepo: Type.Optional(Type.String({ description: 'Pufferfish config repository URL' })),
+  purpurConfigRepo: Type.Optional(Type.String({ description: 'Purpur config repository URL' })),
+  serverPropertiesRepoUrl: Type.Optional(Type.String({ description: 'Base server.properties repository URL' })),
 });
 
 /**

--- a/platform/services/mcctl-api/src/services/ConfigService.ts
+++ b/platform/services/mcctl-api/src/services/ConfigService.ts
@@ -66,6 +66,12 @@ const CONFIG_FIELD_MAP: Record<keyof ServerConfig, string> = {
   stopDuration: 'STOP_DURATION',
   uid: 'UID',
   gid: 'GID',
+
+  // Configuration Repositories
+  paperConfigRepo: 'PAPER_CONFIG_REPO',
+  pufferfishConfigRepo: 'PUFFERFISH_CONFIG_REPO',
+  purpurConfigRepo: 'PURPUR_CONFIG_REPO',
+  serverPropertiesRepoUrl: 'SERVER_PROPERTIES_REPO_URL',
 };
 
 /**
@@ -99,6 +105,11 @@ const RESTART_REQUIRED_FIELDS: (keyof ServerConfig)[] = [
   'uid',
   'gid',
   'stopDuration',
+  // Configuration Repositories (applied at container startup)
+  'paperConfigRepo',
+  'pufferfishConfigRepo',
+  'purpurConfigRepo',
+  'serverPropertiesRepoUrl',
 ];
 
 /**

--- a/platform/services/mcctl-console/src/components/servers/settings/fieldConfigs.ts
+++ b/platform/services/mcctl-console/src/components/servers/settings/fieldConfigs.ts
@@ -364,6 +364,42 @@ export const systemEssentialFields: FieldConfig[] = [
   },
 ];
 
+// ── Configuration Repositories ──
+export const configRepoFields: FieldConfig[] = [
+  {
+    key: 'serverPropertiesRepoUrl',
+    label: 'server.properties Repository URL',
+    type: 'string',
+    helperText: 'Git repository URL for base server.properties template',
+    restartRequired: true,
+    columns: 12,
+  },
+  {
+    key: 'paperConfigRepo',
+    label: 'Paper Config Repository URL',
+    type: 'string',
+    helperText: 'Git repository URL for Paper optimized configuration',
+    restartRequired: true,
+    columns: 12,
+  },
+  {
+    key: 'pufferfishConfigRepo',
+    label: 'Pufferfish Config Repository URL',
+    type: 'string',
+    helperText: 'Git repository URL for Pufferfish configuration',
+    restartRequired: true,
+    columns: 12,
+  },
+  {
+    key: 'purpurConfigRepo',
+    label: 'Purpur Config Repository URL',
+    type: 'string',
+    helperText: 'Git repository URL for Purpur configuration',
+    restartRequired: true,
+    columns: 12,
+  },
+];
+
 // ── System: Advanced ──
 export const systemAdvancedFields: FieldConfig[] = [
   {

--- a/platform/services/mcctl-console/src/components/servers/settings/sectionConfigs.ts
+++ b/platform/services/mcctl-console/src/components/servers/settings/sectionConfigs.ts
@@ -4,6 +4,7 @@ import ShieldIcon from '@mui/icons-material/Shield';
 import SpeedIcon from '@mui/icons-material/Speed';
 import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline';
 import SettingsIcon from '@mui/icons-material/Settings';
+import FolderSpecialIcon from '@mui/icons-material/FolderSpecial';
 import type { FieldConfig } from './fieldConfigs';
 import {
   gameplayEssentialFields,
@@ -18,6 +19,7 @@ import {
   autopauseAdvancedFields,
   systemEssentialFields,
   systemAdvancedFields,
+  configRepoFields,
 } from './fieldConfigs';
 
 export interface SectionConfig {
@@ -77,5 +79,13 @@ export const sectionConfigs: SectionConfig[] = [
     description: 'Timezone, resource pack, RCON, and container settings.',
     essentialFields: systemEssentialFields,
     advancedFields: systemAdvancedFields,
+  },
+  {
+    id: 'config-repos',
+    icon: FolderSpecialIcon,
+    title: 'Configuration Repositories',
+    description: 'Git repository URLs for server configuration templates (applied at startup).',
+    essentialFields: configRepoFields,
+    advancedFields: [],
   },
 ];


### PR DESCRIPTION
## Summary

- API 스키마(`config.ts`)에 4개 Configuration Repository 필드 추가
- `ConfigService.ts`의 `CONFIG_FIELD_MAP`과 `RESTART_REQUIRED_FIELDS`에 매핑 추가
- 프론트엔드 `fieldConfigs.ts`에 `configRepoFields` 배열 추가 (URL 입력 필드)
- `sectionConfigs.ts`에 "Configuration Repositories" 섹션 추가

## Changes

### API (`mcctl-api`)

**`src/schemas/config.ts`**
- `paperConfigRepo` — Paper 최적화 설정 저장소 URL
- `pufferfishConfigRepo` — Pufferfish 설정 저장소 URL
- `purpurConfigRepo` — Purpur 설정 저장소 URL
- `serverPropertiesRepoUrl` — 기본 server.properties 저장소 URL

**`src/services/ConfigService.ts`**
- `CONFIG_FIELD_MAP`에 4개 필드 → 환경변수 매핑 추가
  - `PAPER_CONFIG_REPO`, `PUFFERFISH_CONFIG_REPO`, `PURPUR_CONFIG_REPO`, `SERVER_PROPERTIES_REPO_URL`
- `RESTART_REQUIRED_FIELDS`에 4개 필드 추가 (컨테이너 시작 시 적용)

### Frontend (`mcctl-console`)

**`src/components/servers/settings/fieldConfigs.ts`**
- `configRepoFields` 배열 추가 — 4개 URL 입력 필드 (`columns: 12`, `restartRequired: true`)

**`src/components/servers/settings/sectionConfigs.ts`**
- `FolderSpecialIcon` 아이콘으로 "Configuration Repositories" 섹션 추가
- `essentialFields: configRepoFields`, `advancedFields: []` 구성

## Test plan

- [ ] API: `GET /api/servers/:name/config` 응답에 새 필드 포함 확인
- [ ] API: `PATCH /api/servers/:name/config`로 repo URL 업데이트 시 `restartRequired: true` 반환 확인
- [ ] API: config.env 파일에 `PAPER_CONFIG_REPO=...` 형식으로 저장되는지 확인
- [ ] Console: Settings 페이지에 "Configuration Repositories" 섹션 표시 확인
- [ ] Console: 각 URL 필드에 restart 뱃지가 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)