### PR TITLE
feat(api,console): add native AutoPause (PAUSE_WHEN_EMPTY_SECONDS) support (#446)

### DIFF
--- a/platform/services/mcctl-api/src/schemas/config.ts
+++ b/platform/services/mcctl-api/src/schemas/config.ts
@@ -97,6 +97,9 @@ export const ServerConfigSchema = Type.Object({
   enableAutostop: Type.Optional(Type.Boolean({ description: 'Stop container when no players connected' })),
   autostopTimeoutEst: Type.Optional(Type.Number({ minimum: 0, description: 'Seconds to wait before autostop' })),
 
+  // ── Native Auto-pause (MC 1.21.2+) ──
+  pauseWhenEmptySeconds: Type.Optional(Type.Number({ minimum: 0, description: 'Native pause: seconds to wait before pausing when empty (MC 1.21.2+)' })),
+
   // ── System (Essential) ──
   tz: Type.Optional(Type.String({ description: 'Timezone (e.g., Asia/Seoul)' })),
   resourcePack: Type.Optional(Type.String({ description: 'Resource pack download URL' })),

--- a/platform/services/mcctl-api/src/services/ConfigService.ts
+++ b/platform/services/mcctl-api/src/services/ConfigService.ts
@@ -54,6 +54,9 @@ const CONFIG_FIELD_MAP: Record<keyof ServerConfig, string> = {
   enableAutostop: 'ENABLE_AUTOSTOP',
   autostopTimeoutEst: 'AUTOSTOP_TIMEOUT_EST',
 
+  // Native Auto-pause (MC 1.21.2+)
+  pauseWhenEmptySeconds: 'PAUSE_WHEN_EMPTY_SECONDS',
+
   // System
   tz: 'TZ',
   resourcePack: 'RESOURCE_PACK',
@@ -90,6 +93,8 @@ const RESTART_REQUIRED_FIELDS: (keyof ServerConfig)[] = [
   // Auto-pause / Auto-stop
   'enableAutopause',
   'enableAutostop',
+  // Native Auto-pause (MC 1.21.2+)
+  'pauseWhenEmptySeconds',
   // RCON
   'enableRcon',
   'rconPassword',
@@ -143,6 +148,7 @@ const NUMBER_FIELDS: (keyof ServerConfig)[] = [
   'autopauseTimeoutInit',
   'autopausePeriod',
   'autostopTimeoutEst',
+  'pauseWhenEmptySeconds',
   'rconPort',
   'stopDuration',
   'uid',

--- a/platform/services/mcctl-api/tests/config-service.test.ts
+++ b/platform/services/mcctl-api/tests/config-service.test.ts
@@ -888,6 +888,69 @@ GID=1000
     });
   });
 
+  describe('Native Auto-pause (#446)', () => {
+    beforeEach(() => {
+      mockedExistsSync.mockReturnValue(true);
+    });
+
+    it('should parse PAUSE_WHEN_EMPTY_SECONDS as a number field', () => {
+      mockedReadFileSync.mockReturnValue(`PAUSE_WHEN_EMPTY_SECONDS=60\n`);
+
+      const config = configService.getConfig('testserver');
+
+      expect(config.pauseWhenEmptySeconds).toBe(60);
+    });
+
+    it('should parse PAUSE_WHEN_EMPTY_SECONDS=0 (disable native pause)', () => {
+      mockedReadFileSync.mockReturnValue(`PAUSE_WHEN_EMPTY_SECONDS=0\n`);
+
+      const config = configService.getConfig('testserver');
+
+      expect(config.pauseWhenEmptySeconds).toBe(0);
+    });
+
+    it('should return undefined when PAUSE_WHEN_EMPTY_SECONDS is not set', () => {
+      mockedReadFileSync.mockReturnValue(`MOTD=Test\n`);
+
+      const config = configService.getConfig('testserver');
+
+      expect(config.pauseWhenEmptySeconds).toBeUndefined();
+    });
+
+    it('should write PAUSE_WHEN_EMPTY_SECONDS to env file', () => {
+      let writtenContent = '';
+      let callCount = 0;
+      mockedReadFileSync.mockImplementation(() => {
+        callCount++;
+        return callCount <= 2 ? 'MOTD=Test\n' : writtenContent;
+      });
+      mockedWriteFileSync.mockImplementation((_path, content) => {
+        writtenContent = content as string;
+      });
+
+      configService.updateConfig('testserver', { pauseWhenEmptySeconds: 120 });
+
+      expect(writtenContent).toContain('PAUSE_WHEN_EMPTY_SECONDS=120');
+    });
+
+    it('should require restart when pauseWhenEmptySeconds changes', () => {
+      let writtenContent = '';
+      let callCount = 0;
+      mockedReadFileSync.mockImplementation(() => {
+        callCount++;
+        return callCount <= 2 ? 'PAUSE_WHEN_EMPTY_SECONDS=60\n' : writtenContent;
+      });
+      mockedWriteFileSync.mockImplementation((_path, content) => {
+        writtenContent = content as string;
+      });
+
+      const result = configService.updateConfig('testserver', { pauseWhenEmptySeconds: 120 });
+
+      expect(result.restartRequired).toBe(true);
+      expect(result.changedFields).toContain('pauseWhenEmptySeconds');
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should handle config file with no equals signs', () => {
       mockedExistsSync.mockReturnValue(true);

--- a/platform/services/mcctl-console/src/components/servers/settings/fieldConfigs.ts
+++ b/platform/services/mcctl-console/src/components/servers/settings/fieldConfigs.ts
@@ -337,6 +337,15 @@ export const autopauseAdvancedFields: FieldConfig[] = [
     helperText: 'Wait time before stopping container',
     validation: { min: 0 },
   },
+  {
+    key: 'pauseWhenEmptySeconds',
+    label: 'Native Pause Delay (MC 1.21.2+)',
+    type: 'number',
+    unit: 'seconds',
+    helperText: 'Seconds to wait before native pause when empty (0 = disable). Requires MC 1.21.2+.',
+    restartRequired: true,
+    validation: { min: 0 },
+  },
 ];
 
 // ── System: Essential ──


### PR DESCRIPTION
## Summary

- Add `pauseWhenEmptySeconds` field to `ServerConfigSchema` (TypeBox schema, `src/schemas/config.ts`)
- Map API field to env variable `PAUSE_WHEN_EMPTY_SECONDS` in `CONFIG_FIELD_MAP` (`ConfigService.ts`)
- Add to `RESTART_REQUIRED_FIELDS` and `NUMBER_FIELDS` so it serializes correctly and triggers restart notification
- Add UI field config in `autopauseAdvancedFields` (`fieldConfigs.ts`) — shown in the Auto-pause / Auto-stop section with a note that MC 1.21.2+ is required

## Test plan

- [x] `config-service.test.ts` — 5 new tests added (TDD: RED → GREEN)
  - Parse `PAUSE_WHEN_EMPTY_SECONDS` as a number
  - Parse value `0` (disable native pause)
  - Returns `undefined` when key is absent
  - Writes `PAUSE_WHEN_EMPTY_SECONDS=<n>` to env file
  - Sets `restartRequired=true` when field changes
- [x] All 59 config-service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)