### PR TITLE
feat(cli): add Docker image auto-pull to mcctl update (#465)

### DIFF
--- a/platform/services/cli/src/commands/update.ts
+++ b/platform/services/cli/src/commands/update.ts
@@ -8,12 +8,88 @@ import {
 } from '../lib/update-checker.js';
 import { checkServiceAvailability, PM2_SERVICE_NAMES } from '../lib/pm2-utils.js';
 import { Pm2ServiceManagerAdapter } from '../infrastructure/adapters/Pm2ServiceManagerAdapter.js';
+import { ShellExecutor } from '../lib/shell.js';
 import { spawnSync } from 'child_process';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import * as prompts from '@clack/prompts';
 
 const PACKAGE_NAME = '@minecraft-docker/mcctl';
+
+/**
+ * Scan platform/servers docker-compose.yml files and return unique Docker image names.
+ * Skips the _template directory.
+ */
+export function scanDockerImages(serversDir: string): string[] {
+  if (!existsSync(serversDir)) {
+    return [];
+  }
+
+  const entries = readdirSync(serversDir);
+  const images = new Set<string>();
+
+  for (const entry of entries) {
+    if (entry === '_template') {
+      continue;
+    }
+
+    const composePath = join(serversDir, entry, 'docker-compose.yml');
+    if (!existsSync(composePath)) {
+      continue;
+    }
+
+    const content = readFileSync(composePath, 'utf-8');
+    const imageRegex = /^\s+image:\s+(.+)$/gm;
+    let match: RegExpExecArray | null;
+
+    while ((match = imageRegex.exec(content)) !== null) {
+      const imageName = match[1]!.trim();
+      if (imageName) {
+        images.add(imageName);
+      }
+    }
+  }
+
+  return Array.from(images);
+}
+
+/**
+ * Pull all unique Docker images found in server docker-compose files.
+ */
+export async function updateDockerImages(serversDir: string, rootDir: string): Promise<number> {
+  const images = scanDockerImages(serversDir);
+
+  if (images.length === 0) {
+    console.log(colors.dim('  No Docker images found in server configurations.'));
+    console.log('');
+    return 0;
+  }
+
+  console.log(colors.bold('Updating Docker images...'));
+  console.log('');
+
+  const shell = new ShellExecutor(new Paths(rootDir));
+  const spinner = prompts.spinner();
+  let hasErrors = false;
+
+  for (const image of images) {
+    spinner.start(`Pulling ${image}...`);
+    // Stop spinner before pull so the docker progress output is visible
+    spinner.stop(`Pulling ${image}`);
+
+    const code = await shell.dockerPull(image);
+
+    if (code === 0) {
+      console.log(`  ${colors.green('✓')} ${image}`);
+    } else {
+      console.log(`  ${colors.red('✗')} ${image} ${colors.dim('(pull failed)')}`);
+      hasErrors = true;
+    }
+  }
+
+  console.log('');
+  return hasErrors ? 1 : 0;
+}
 
 const SERVICE_PACKAGES = {
   [PM2_SERVICE_NAMES.API]: '@minecraft-docker/mcctl-api',
@@ -430,6 +506,18 @@ export async function updateServices(
 
   // Print results summary
   printServiceResults(results, options.check);
+
+  // Update Docker images (skip in check-only mode)
+  if (!options.check) {
+    const paths = new Paths(rootDir);
+    const dockerResult = await updateDockerImages(paths.servers, rootDir);
+    if (dockerResult !== 0) {
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      console.log(colors.dim(`  Completed in ${elapsed}s`));
+      console.log('');
+      return 1;
+    }
+  }
 
   // Print elapsed time
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);

--- a/platform/services/cli/src/lib/shell.ts
+++ b/platform/services/cli/src/lib/shell.ts
@@ -138,6 +138,28 @@ export class ShellExecutor {
   }
 
   /**
+   * Pull a Docker image
+   */
+  async dockerPull(image: string): Promise<number> {
+    return new Promise((resolve) => {
+      const child = spawn('docker', ['pull', image], {
+        cwd: this.paths.root,
+        stdio: 'inherit',
+        env: { ...process.env, ...this.env },
+      });
+
+      child.on('close', (code) => {
+        resolve(code ?? 0);
+      });
+
+      child.on('error', (err) => {
+        log.error(`Failed to pull Docker image ${image}: ${err.message}`);
+        resolve(1);
+      });
+    });
+  }
+
+  /**
    * Execute docker compose command
    */
   async dockerCompose(args: string[]): Promise<number> {

--- a/platform/services/cli/tests/unit/commands/docker-image-pull.test.ts
+++ b/platform/services/cli/tests/unit/commands/docker-image-pull.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock node:fs
+const mockExistsSync = vi.fn().mockReturnValue(false);
+const mockReaddirSync = vi.fn().mockReturnValue([]);
+const mockReadFileSync = vi.fn().mockReturnValue('');
+vi.mock('node:fs', () => ({
+  existsSync: (...args: any[]) => mockExistsSync(...args),
+  readdirSync: (...args: any[]) => mockReaddirSync(...args),
+  readFileSync: (...args: any[]) => mockReadFileSync(...args),
+}));
+
+// Mock node:path
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path');
+  return {
+    ...actual,
+    join: (...args: string[]) => actual.join(...args),
+  };
+});
+
+// Mock @minecraft-docker/shared
+vi.mock('@minecraft-docker/shared', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+  colors: {
+    bold: (s: string) => s,
+    cyan: (s: string) => s,
+    yellow: (s: string) => s,
+    green: (s: string) => s,
+    dim: (s: string) => s,
+    red: (s: string) => s,
+  },
+  Paths: vi.fn().mockImplementation((root?: string) => ({
+    root: root ?? '/tmp/test-root',
+    servers: (root ?? '/tmp/test-root') + '/servers',
+  })),
+}));
+
+import { scanDockerImages } from '../../../src/commands/update.js';
+
+describe('scanDockerImages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty array when servers directory does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const images = scanDockerImages('/tmp/no-such-dir/servers');
+
+    expect(images).toEqual([]);
+  });
+
+  it('should return empty array when there are no server subdirectories', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue([]);
+
+    const images = scanDockerImages('/tmp/servers');
+
+    expect(images).toEqual([]);
+  });
+
+  it('should extract image from a docker-compose.yml file', () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === '/tmp/servers') return true;
+      if (p === '/tmp/servers/myserver/docker-compose.yml') return true;
+      return false;
+    });
+    mockReaddirSync.mockReturnValue(['myserver'] as any);
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p === '/tmp/servers/myserver/docker-compose.yml') {
+        return 'services:\n  mc-myserver:\n    image: itzg/minecraft-server:java21\n';
+      }
+      return '';
+    });
+
+    const images = scanDockerImages('/tmp/servers');
+
+    expect(images).toEqual(['itzg/minecraft-server:java21']);
+  });
+
+  it('should skip directories without docker-compose.yml', () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === '/tmp/servers') return true;
+      if (p === '/tmp/servers/myserver/docker-compose.yml') return false;
+      return true;
+    });
+    mockReaddirSync.mockReturnValue(['myserver'] as any);
+
+    const images = scanDockerImages('/tmp/servers');
+
+    expect(images).toEqual([]);
+  });
+
+  it('should deduplicate identical images across multiple servers', () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === '/tmp/servers') return true;
+      if (
+        p === '/tmp/servers/server1/docker-compose.yml' ||
+        p === '/tmp/servers/server2/docker-compose.yml'
+      ) return true;
+      return false;
+    });
+    mockReaddirSync.mockReturnValue(['server1', 'server2'] as any);
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.includes('docker-compose.yml')) {
+        return 'services:\n  mc-server:\n    image: itzg/minecraft-server:java21\n';
+      }
+      return '';
+    });
+
+    const images = scanDockerImages('/tmp/servers');
+
+    expect(images).toEqual(['itzg/minecraft-server:java21']);
+    expect(images.length).toBe(1);
+  });
+
+  it('should collect different images from multiple servers', () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === '/tmp/servers') return true;
+      if (
+        p === '/tmp/servers/server1/docker-compose.yml' ||
+        p === '/tmp/servers/server2/docker-compose.yml'
+      ) return true;
+      return false;
+    });
+    mockReaddirSync.mockReturnValue(['server1', 'server2'] as any);
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.includes('server1/docker-compose.yml')) {
+        return 'services:\n  mc-server1:\n    image: itzg/minecraft-server:java21\n';
+      }
+      if (p.includes('server2/docker-compose.yml')) {
+        return 'services:\n  mc-server2:\n    image: itzg/minecraft-server:java17\n';
+      }
+      return '';
+    });
+
+    const images = scanDockerImages('/tmp/servers');
+
+    expect(images).toContain('itzg/minecraft-server:java21');
+    expect(images).toContain('itzg/minecraft-server:java17');
+    expect(images.length).toBe(2);
+  });
+
+  it('should skip the _template directory', () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === '/tmp/servers') return true;
+      if (p === '/tmp/servers/_template/docker-compose.yml') return true;
+      if (p === '/tmp/servers/realserver/docker-compose.yml') return true;
+      return false;
+    });
+    mockReaddirSync.mockReturnValue(['_template', 'realserver'] as any);
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.includes('docker-compose.yml')) {
+        return 'services:\n  mc-server:\n    image: itzg/minecraft-server:java21\n';
+      }
+      return '';
+    });
+
+    const images = scanDockerImages('/tmp/servers');
+
+    expect(images).toEqual(['itzg/minecraft-server:java21']);
+    expect(images.length).toBe(1);
+  });
+});

--- a/platform/services/cli/tests/unit/lib/shell-docker-pull.test.ts
+++ b/platform/services/cli/tests/unit/lib/shell-docker-pull.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// Mock child_process spawn
+const mockSpawn = vi.fn();
+vi.mock('node:child_process', () => ({
+  spawn: (...args: any[]) => mockSpawn(...args),
+}));
+
+// Mock node:fs
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(''),
+  writeFileSync: vi.fn(),
+}));
+
+// Mock @minecraft-docker/shared
+vi.mock('@minecraft-docker/shared', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+  colors: {
+    bold: (s: string) => s,
+    cyan: (s: string) => s,
+    yellow: (s: string) => s,
+    green: (s: string) => s,
+    dim: (s: string) => s,
+    red: (s: string) => s,
+  },
+  Paths: vi.fn().mockImplementation((root?: string) => ({
+    root: root ?? '/tmp/test-root',
+    servers: (root ?? '/tmp/test-root') + '/servers',
+    scripts: (root ?? '/tmp/test-root') + '/scripts',
+    templates: (root ?? '/tmp/test-root') + '/templates',
+  })),
+  execScript: vi.fn(),
+  execScriptInteractive: vi.fn(),
+}));
+
+import { ShellExecutor } from '../../../src/lib/shell.js';
+
+function createMockProcess(exitCode: number) {
+  const emitter = new EventEmitter() as NodeJS.EventEmitter & {
+    on: (event: string, listener: (...args: any[]) => void) => any;
+  };
+  // Emit close asynchronously
+  setTimeout(() => emitter.emit('close', exitCode), 0);
+  return emitter;
+}
+
+describe('ShellExecutor.dockerPull', () => {
+  let shell: ShellExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shell = new ShellExecutor();
+  });
+
+  it('should run docker pull with the given image name', async () => {
+    const mockProcess = createMockProcess(0);
+    mockSpawn.mockReturnValue(mockProcess);
+
+    const code = await shell.dockerPull('itzg/minecraft-server:java21');
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'docker',
+      ['pull', 'itzg/minecraft-server:java21'],
+      expect.objectContaining({ stdio: 'inherit' })
+    );
+    expect(code).toBe(0);
+  });
+
+  it('should return exit code from docker pull', async () => {
+    const mockProcess = createMockProcess(1);
+    mockSpawn.mockReturnValue(mockProcess);
+
+    const code = await shell.dockerPull('itzg/minecraft-server:java21');
+
+    expect(code).toBe(1);
+  });
+
+  it('should return 1 on spawn error', async () => {
+    const emitter = new EventEmitter();
+    mockSpawn.mockReturnValue(emitter);
+
+    const pullPromise = shell.dockerPull('itzg/minecraft-server:java21');
+    emitter.emit('error', new Error('docker not found'));
+    const code = await pullPromise;
+
+    expect(code).toBe(1);
+  });
+
+  it('should inherit stdio so user sees pull progress', async () => {
+    const mockProcess = createMockProcess(0);
+    mockSpawn.mockReturnValue(mockProcess);
+
+    await shell.dockerPull('itzg/minecraft-server:java21');
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'docker',
+      expect.any(Array),
+      expect.objectContaining({ stdio: 'inherit' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `ShellExecutor.dockerPull(image)` 메서드를 `shell.ts`에 추가하여 `docker pull <image>`를 실행합니다. `stdio: 'inherit'`으로 사용자가 pull 진행 상황을 직접 확인할 수 있습니다.
- `scanDockerImages(serversDir)` 함수를 `update.ts`에 추가하여 `platform/servers/` 하위의 `docker-compose.yml` 파일들을 스캔하고 `image:` 항목을 추출합니다. `_template` 디렉토리는 건너뜁니다.
- `updateDockerImages(serversDir, rootDir)` 함수로 고유한 이미지들을 순서대로 pull하고 결과를 출력합니다.
- `updateServices` 흐름에 Docker 이미지 업데이트 단계를 통합합니다. npm 패키지 업데이트 이후 실행되며 `--check` 모드에서는 건너뜁니다.

## Test plan

- [x] TDD RED → GREEN → 빌드 확인 순서로 개발
- [x] `tests/unit/commands/docker-image-pull.test.ts` (7 tests): `scanDockerImages` 함수 단위 테스트
  - 서버 디렉토리가 없는 경우
  - 서버가 없는 경우
  - 단일 서버에서 이미지 추출
  - `docker-compose.yml`이 없는 디렉토리 건너뜀
  - 동일 이미지 중복 제거
  - 여러 서버의 서로 다른 이미지 수집
  - `_template` 디렉토리 건너뜀
- [x] `tests/unit/lib/shell-docker-pull.test.ts` (4 tests): `ShellExecutor.dockerPull` 단위 테스트
  - 올바른 docker 명령어 인자 전달
  - 종료 코드 반환
  - spawn 오류 시 1 반환
  - `stdio: 'inherit'` 사용 확인
- [x] 기존 `update.test.ts` 11개 테스트 전부 통과
- [x] TypeScript 빌드 성공 (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)