### PR TITLE
feat(platform): pin mc-router image to v1.42.0 (#472)

### DIFF
--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -55,7 +55,9 @@ services:
   # No MAPPING environment variable needed with --in-docker mode
   # ===========================================================================
   router:
-    image: itzg/mc-router
+    # Pinned to v1.42.0 for production stability.
+    # Check releases: https://github.com/itzg/mc-router/releases
+    image: itzg/mc-router:1.42.0
     container_name: mc-router
     restart: unless-stopped
     environment:
@@ -63,7 +65,7 @@ services:
       AUTO_SCALE_UP: "true"
       AUTO_SCALE_DOWN: "true"
       AUTO_SCALE_DOWN_AFTER: "10m"
-      # Bug fixed in v1.39.1: https://github.com/itzg/mc-router/issues/507
+      # Go time.Duration format required (e.g., "120s", "2m"). Bare integers fail to parse.
       DOCKER_TIMEOUT: "120s"
       AUTO_SCALE_ASLEEP_MOTD: "§e§lServer is sleeping§r\n§7Connect to wake up!"
     ports:


### PR DESCRIPTION
## Summary

- `itzg/mc-router` 이미지를 명시적 버전 `1.42.0`으로 핀하여 운영 안정성 확보
- `DOCKER_TIMEOUT` 주변 코멘트를 원인(Go `time.Duration` 형식) 중심으로 갱신

Closes #472

## Why v1.42.0

| 항목 | 내용 |
|------|------|
| 릴리즈 | 2026-04-04 (latest) |
| 주요 변경 | Routes API에 `ScalingTarget` 추가, `--log-level` 옵션 |
| 호환성 | v1.39.1 → v1.42.0 사이 Docker 환경 breaking change 없음 |
| 우리가 의존하는 픽스 | v1.39.1의 Docker timeout 파싱 버그 (#507) 포함 |

v1.40.0 ~ v1.41.0의 새 기능은 대부분 k8s 한정이라 Docker compose 환경에는 영향 없습니다.

## Test plan

- [x] `docker compose config` 파싱 검증 (image: itzg/mc-router:1.42.0 정상)
- [ ] 운영 환경에서 `mcctl up` 후 `docker inspect mc-router` 로 이미지 태그 확인
- [ ] 기존 서버들의 라우팅 정상 동작 확인 (auto-scale up/down 포함)

## Rollback Plan

문제 발생 시 이전 latest 또는 직전 안정 버전으로 변경 후 재기동:
```yaml
image: itzg/mc-router:1.41.0
```
```bash
docker compose up -d router
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)