### PR TITLE
feat(console): apply approved compact, information-rich StatCard to Dashboard (#474)

### DIFF
--- a/platform/services/mcctl-console/src/app/(main)/dashboard/page.tsx
+++ b/platform/services/mcctl-console/src/app/(main)/dashboard/page.tsx
@@ -36,6 +36,12 @@ export default function DashboardPage() {
   // TODO: Calculate total players from server details (requires player data)
   const totalPlayers = 0;
 
+  // Derived metrics for the compact stat cards (computed values only — no history)
+  const stoppedServers = totalServers - onlineServers;
+  const onlinePercent = totalServers > 0 ? Math.round((onlineServers / totalServers) * 100) : 0;
+  const assignedWorlds = worldsData?.worlds.filter((world) => world.isLocked).length || 0;
+  const freeWorlds = totalWorlds - assignedWorlds;
+
   if (isLoading) {
     return (
       <>
@@ -82,13 +88,14 @@ export default function DashboardPage() {
           {[0, 1, 2, 3].map((i) => (
             <Grid item xs={12} sm={6} md={3} key={i}>
               <Card sx={{ height: '100%', position: 'relative', overflow: 'hidden', '&::before': { content: '""', position: 'absolute', top: 0, left: 0, right: 0, height: '4px', background: 'grey.300' } }}>
-                <CardContent>
-                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-                    <Skeleton variant="text" width="60%" />
-                    <Skeleton variant="circular" width={32} height={32} />
+                <CardContent sx={{ p: 1.75, '&:last-child': { pb: 1.75 } }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                    <Skeleton variant="text" width="55%" />
+                    <Skeleton variant="circular" width={20} height={20} />
                   </Box>
-                  <Skeleton variant="text" width="40%" height={48} />
-                  <Skeleton variant="text" width="70%" />
+                  <Skeleton variant="text" width="35%" height={30} />
+                  <Skeleton variant="rounded" width="100%" height={4} sx={{ mt: 1 }} />
+                  <Skeleton variant="text" width="70%" sx={{ mt: 0.75 }} />
                 </CardContent>
               </Card>
             </Grid>
@@ -191,25 +198,28 @@ export default function DashboardPage() {
           <StatCard
             title="Total Servers"
             value={totalServers}
-            icon={<ServerIcon fontSize="large" />}
+            icon={<ServerIcon fontSize="small" />}
             color="primary"
-            description="All configured servers"
+            progress={totalServers > 0 ? (onlineServers / totalServers) * 100 : undefined}
+            description={`${onlineServers} running · ${stoppedServers} stopped`}
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
           <StatCard
             title="Online Servers"
             value={onlineServers}
-            icon={<OnlineIcon fontSize="large" />}
+            unit={totalServers > 0 ? `/ ${totalServers}` : undefined}
+            icon={<OnlineIcon fontSize="small" />}
             color="success"
-            description="Currently running"
+            progress={totalServers > 0 ? onlinePercent : undefined}
+            description={`${onlinePercent}% running`}
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
           <StatCard
             title="Total Players"
             value={totalPlayers}
-            icon={<PlayersIcon fontSize="large" />}
+            icon={<PlayersIcon fontSize="small" />}
             color="info"
             description="Across all servers"
           />
@@ -218,9 +228,10 @@ export default function DashboardPage() {
           <StatCard
             title="Total Worlds"
             value={totalWorlds}
-            icon={<WorldIcon fontSize="large" />}
+            icon={<WorldIcon fontSize="small" />}
             color="secondary"
-            description="Available worlds"
+            progress={totalWorlds > 0 ? (assignedWorlds / totalWorlds) * 100 : undefined}
+            description={`${assignedWorlds} assigned · ${freeWorlds} free`}
           />
         </Grid>
       </Grid>

--- a/platform/services/mcctl-console/src/components/dashboard/StatCard.test.tsx
+++ b/platform/services/mcctl-console/src/components/dashboard/StatCard.test.tsx
@@ -85,4 +85,47 @@ describe('StatCard', () => {
 
     expect(screen.getByText('All configured servers')).toBeInTheDocument();
   });
+
+  it('should render a unit suffix next to the value when provided', () => {
+    renderWithTheme(
+      <StatCard title="Online Servers" value={3} unit="/ 8" />
+    );
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('/ 8')).toBeInTheDocument();
+  });
+
+  it('should render a progress bar when progress is provided', () => {
+    renderWithTheme(
+      <StatCard title="Online Servers" value={3} progress={40} color="success" />
+    );
+
+    const fill = screen.getByTestId('stat-card-progress-fill');
+    expect(fill).toBeInTheDocument();
+    expect(fill).toHaveStyle({ width: '40%' });
+  });
+
+  it('should not render a progress bar when progress is omitted', () => {
+    renderWithTheme(
+      <StatCard title="Total Players" value={0} />
+    );
+
+    expect(screen.queryByTestId('stat-card-progress-fill')).not.toBeInTheDocument();
+  });
+
+  it('should clamp progress above 100 to 100%', () => {
+    renderWithTheme(
+      <StatCard title="Online Servers" value={9} progress={150} />
+    );
+
+    expect(screen.getByTestId('stat-card-progress-fill')).toHaveStyle({ width: '100%' });
+  });
+
+  it('should clamp negative progress to 0%', () => {
+    renderWithTheme(
+      <StatCard title="Online Servers" value={0} progress={-20} />
+    );
+
+    expect(screen.getByTestId('stat-card-progress-fill')).toHaveStyle({ width: '0%' });
+  });
 });

--- a/platform/services/mcctl-console/src/components/dashboard/StatCard.tsx
+++ b/platform/services/mcctl-console/src/components/dashboard/StatCard.tsx
@@ -9,15 +9,31 @@ export interface StatCardProps {
   icon?: ReactNode;
   color?: 'primary' | 'success' | 'info' | 'secondary';
   description?: string;
+  /** Optional unit/suffix rendered next to the value (e.g. "/ 8"). */
+  unit?: string;
+  /** Optional 0-100 ratio; renders an accent progress bar. Omit when no data. */
+  progress?: number;
 }
 
-export function StatCard({ title, value, icon, color = 'primary', description }: StatCardProps) {
-  const colorMap = {
-    primary: '#1bd96a',
-    success: '#22c55e',
-    info: '#3b82f6',
-    secondary: '#7c3aed',
-  };
+const colorMap = {
+  primary: '#1bd96a',
+  success: '#22c55e',
+  info: '#3b82f6',
+  secondary: '#7c3aed',
+} as const;
+
+export function StatCard({
+  title,
+  value,
+  icon,
+  color = 'primary',
+  description,
+  unit,
+  progress,
+}: StatCardProps) {
+  const accent = colorMap[color];
+  const clampedProgress =
+    progress === undefined ? null : Math.max(0, Math.min(100, progress));
 
   return (
     <Card
@@ -33,36 +49,68 @@ export function StatCard({ title, value, icon, color = 'primary', description }:
           left: 0,
           right: 0,
           height: '4px',
-          background: colorMap[color],
+          background: accent,
         },
       }}
     >
-      <CardContent>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-          <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+      <CardContent sx={{ p: 1.75, '&:last-child': { pb: 1.75 } }}>
+        {/* Title row */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 1 }}>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ fontWeight: 600, fontSize: '0.75rem', letterSpacing: '0.02em' }}
+          >
             {title}
           </Typography>
           {icon && (
-            <Box sx={{ color: colorMap[color], opacity: 0.8 }}>
+            <Box sx={{ ml: 'auto', display: 'inline-flex', color: accent, opacity: 0.8 }}>
               {icon}
             </Box>
           )}
         </Box>
 
-        <Typography
-          variant="h3"
-          component="div"
-          sx={{
-            fontWeight: 700,
-            color: 'text.primary',
-            mb: description ? 1 : 0,
-          }}
-        >
-          {value}
-        </Typography>
+        {/* Figure row */}
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
+          <Typography
+            component="div"
+            sx={{ fontWeight: 700, fontSize: '1.9rem', lineHeight: 1, color: 'text.primary' }}
+          >
+            {value}
+          </Typography>
+          {unit && (
+            <Typography component="span" sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
+              {unit}
+            </Typography>
+          )}
+        </Box>
 
+        {/* Progress bar (computed ratios only) */}
+        {clampedProgress !== null && (
+          <Box
+            sx={{
+              height: 4,
+              borderRadius: 2,
+              mt: 1,
+              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+              overflow: 'hidden',
+            }}
+          >
+            <Box
+              data-testid="stat-card-progress-fill"
+              sx={{ height: '100%', borderRadius: 2, background: accent }}
+              style={{ width: `${clampedProgress}%` }}
+            />
+          </Box>
+        )}
+
+        {/* Subline */}
         {description && (
-          <Typography variant="caption" color="text.secondary">
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mt: 0.75, fontSize: '0.72rem' }}
+          >
             {description}
           </Typography>
         )}


### PR DESCRIPTION
## Summary

Claude Design 핸드오프 번들에서 사용자가 새로 디자인·승인한 **콤팩트 + 정보 풍부한 StatCard**를 production Dashboard에 적용합니다.

디자인 번들 전체를 코드와 대조한 결과, 색상/타이포/카드/GNB/Footer 등 토큰·컴포넌트는 이미 콘솔에서 추출되어 일치했고, **유일한 신규 승인 디자인이 이 StatCard**였습니다.

Closes #474

## What changed

**`StatCard` (구조 리팩터, Tidy First)**
- 콤팩트 레이아웃: 패딩 축소, 0.75rem title, 1.9rem figure
- 선택적 `unit` 접미사(예: `/ 8`)
- accent **progress bar** — `progress` 비율이 있을 때만 렌더(0–100 clamp)
- 0.72rem subline (`description`)
- 기존 `title/value/icon/color/description` props 하위호환 유지

**Dashboard (동작 변경)** — 데이터 정책: **계산 가능한 값만** (가짜 delta/peak 없음)

| 카드 | progress | subline |
|---|---|---|
| Total Servers | running/total | `N running · M stopped` |
| Online Servers | online/total (`/ total` unit) | `P% running` |
| Total Players | — (데이터 소스 없음) | `Across all servers` |
| Total Worlds | assigned/total | `N assigned · M free` (`World.isLocked`) |

로딩 스켈레톤도 콤팩트 카드 높이에 맞춰 조정.

## Test plan

- [x] TDD: StatCard 테스트 선작성(Red) → 구현(Green). progress 렌더/미렌더, clamp(>100, <0), unit, 하위호환 — **StatCard 14 tests** 통과
- [x] Dashboard **page.test 5 tests** 통과
- [x] `pnpm lint` 통과 (신규 경고 없음; 기존 무관 경고만)
- [x] 변경 파일 3개 `tsc --noEmit` 클린

## Caveats

- `pnpm build`는 이 환경에서 **better-sqlite3 네이티브 모듈 ABI 불일치**(로컬 Node 18 ↔ 모듈은 Node 22로 빌드)로 런타임 page-data 수집 단계에서 실패합니다. **webpack 컴파일 자체는 성공**하며 본 변경(순수 프레젠테이션)과 무관합니다. 샌드박스 권한(EACCES)으로 `pnpm rebuild`도 불가. CI/정상 환경에서 재확인 필요.
- `type-check`에 기존 2건 에러(`ConfigSnapshotServerCard.test.tsx`, `ConfigSnapshotCompareBar.test.tsx`)가 있으나 develop 선재 이슈로 본 PR과 무관.

## Out of scope

- Minecraft 픽셀 폰트 오프라인 임베딩
- ResourceStatCard(서버 상세) 콤팩트화
- delta/peak 등 히스토리 기반 지표

🤖 Generated with [Claude Code](https://claude.com/claude-code)
