### PR TITLE
fix(console): prevent mobile drawer backdrop from lingering after navigation (#476)

### DIFF
--- a/e2e/tests/mobile-nav.spec.ts
+++ b/e2e/tests/mobile-nav.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { TEST_CREDENTIALS, performLogin } from '../fixtures/auth';
+
+/**
+ * Regression test for #476.
+ *
+ * On mobile, the navigation drawer is a temporary MUI Drawer (Modal + Backdrop).
+ * Tapping a nav item closes the drawer and triggers a route change at the same
+ * time. With `keepMounted` the closed Modal + full-screen Backdrop stayed in the
+ * DOM and, when the close transition was interrupted by the navigation, lingered
+ * over the page and intercepted taps. After the fix the closed drawer unmounts,
+ * so no backdrop remains and the page stays interactive.
+ */
+test.describe('Mobile navigation drawer', () => {
+  test('does not leave a backdrop overlay blocking taps after navigation (#476)', async ({
+    browser,
+  }) => {
+    // iPhone-sized viewport (< md breakpoint, so the mobile drawer is used)
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+    });
+    const page = await context.newPage();
+
+    await performLogin(
+      page,
+      TEST_CREDENTIALS.valid.username,
+      TEST_CREDENTIALS.valid.password
+    );
+    await expect(page).not.toHaveURL(/\/login/);
+
+    await page.goto('/');
+
+    // Open the hamburger drawer; its backdrop scrim should be visible.
+    await page.getByLabel('open menu').click();
+    await expect(page.locator('.MuiBackdrop-root')).toBeVisible();
+
+    // Tap a nav item: this closes the drawer and navigates simultaneously.
+    await page.locator('a[href="/servers"]').click();
+    await expect(page).toHaveURL(/\/servers/);
+
+    // No modal backdrop must remain in the DOM after navigating.
+    await expect(page.locator('.MuiBackdrop-root')).toHaveCount(0);
+
+    // The page must stay interactive: the menu button is tappable again and
+    // reopening the drawer works (would fail if a transparent layer intercepted taps).
+    await page.getByLabel('open menu').click();
+    await expect(
+      page.locator('.MuiDrawer-root a[href="/dashboard"]').first()
+    ).toBeVisible();
+
+    await context.close();
+  });
+});

--- a/e2e/tests/mobile-nav.spec.ts
+++ b/e2e/tests/mobile-nav.spec.ts
@@ -35,7 +35,9 @@ test.describe('Mobile navigation drawer', () => {
     await expect(page.locator('.MuiBackdrop-root')).toBeVisible();
 
     // Tap a nav item: this closes the drawer and navigates simultaneously.
-    await page.locator('a[href="/servers"]').click();
+    // Scope to the drawer — the desktop nav also renders this href (CSS-hidden
+    // but present in the DOM), which would trip Playwright's strict mode.
+    await page.locator('.MuiDrawer-root a[href="/servers"]').click();
     await expect(page).toHaveURL(/\/servers/);
 
     // No modal backdrop must remain in the DOM after navigating.

--- a/platform/services/mcctl-console/src/components/layout/GNB.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/GNB.test.tsx
@@ -92,6 +92,17 @@ describe('GNB', () => {
     expect(onMenuToggle).toHaveBeenCalledTimes(1);
   });
 
+  it('should not keep the mobile drawer mounted in the DOM when closed', () => {
+    // The mobile drawer is a temporary MUI Drawer (Modal + Backdrop). With
+    // `keepMounted`, the closed drawer and its full-screen backdrop stay in the
+    // DOM; on mobile an interrupted close transition leaves that layer over the
+    // page, intercepting taps (#476). The "close menu" button lives only inside
+    // the mobile drawer, so its absence proves the closed drawer unmounts.
+    renderWithTheme(<GNB mobileOpen={false} onMenuToggle={vi.fn()} />);
+
+    expect(screen.queryByLabelText('close menu')).not.toBeInTheDocument();
+  });
+
   it('should render navigation links with correct hrefs', () => {
     renderWithTheme(<GNB mobileOpen={false} onMenuToggle={vi.fn()} />);
 

--- a/platform/services/mcctl-console/src/components/layout/GNB.tsx
+++ b/platform/services/mcctl-console/src/components/layout/GNB.tsx
@@ -195,9 +195,11 @@ export function GNB({ mobileOpen, onMenuToggle }: GNBProps) {
         anchor="left"
         open={mobileOpen}
         onClose={onMenuToggle}
-        ModalProps={{
-          keepMounted: true,
-        }}
+        // keepMounted is intentionally omitted: it kept the closed Drawer's
+        // Modal + Backdrop in the DOM, and on mobile an interrupted close
+        // transition (drawer closes while a route change re-renders) left that
+        // full-screen layer over the page, intercepting taps (#476). Letting the
+        // closed temporary Drawer unmount avoids the lingering overlay.
         sx={{
           display: { xs: 'block', md: 'none' },
           '& .MuiDrawer-paper': {


### PR DESCRIPTION
## Summary

아이폰/아이패드(모바일 뷰)에서 햄버거 메뉴로 페이지를 이동할 때마다 **화면을 덮는 레이어가 잔류하여 터치를 가로채는** 버그를 수정합니다.

Closes #476

## Root Cause

모바일 네비게이션은 MUI `variant="temporary"` Drawer(= Modal + Backdrop)이며 `ModalProps={{ keepMounted: true }}`로 설정돼 있었습니다. 메뉴 항목 탭 시 `onMenuToggle()`(드로어 닫기)과 Next `<Link>` 라우트 전환이 동시 실행되는데, `keepMounted`면 닫힌 Modal/Backdrop이 DOM에 남고 닫힘 정리(`visibility: hidden`)가 fade-out 트랜지션의 `onExited`에서 일어납니다. 라우트 전환으로 트랜지션이 중단되면 `onExited`가 발생하지 않아 **전체화면 Backdrop이 잔류**하여 탭을 가로챕니다. (iOS Safari에서 빈번)

## Fix

`keepMounted: true` 제거. 클라이언트 nav 드로어에는 불필요한 최적화이며, 제거하면 닫힌 temporary Drawer가 언마운트되어 잔류 오버레이가 사라집니다. (공유 레이아웃이라 GNB 자체는 리마운트되지 않으므로 닫힘 트랜지션은 정상 완료)

## Changes

- `GNB.tsx` — 모바일 Drawer의 `ModalProps={{ keepMounted: true }}` 제거 (사유 주석 추가)
- `GNB.test.tsx` — 닫힌 상태에서 드로어(=`close menu` 버튼)가 DOM에 잔류하지 않음 검증 (TDD Red→Green)
- `e2e/tests/mobile-nav.spec.ts` — 모바일 뷰포트 회귀 테스트: 드로어로 이동 후 Backdrop 미잔류 + 화면 상호작용 정상

## Test plan

- [x] TDD: `GNB.test.tsx` 신규 테스트 Red→Green, GNB **9 tests** 통과
- [x] `pnpm lint` GNB 관련 경고 없음
- [x] 변경 파일 type-check 클린 (e2e tsc 포함)
- [ ] E2E (CI): `e2e/tests/mobile-nav.spec.ts` — 실행에는 console+api+docker 구동 필요

## Caveats

- 콘솔 전체 `pnpm test`에 **선재 실패 4건**(ServerDetail 탭 3건, players routes 1건, UserServerRepository)이 있으나 develop 베이스라인에서도 동일하게 실패 → **본 PR과 무관**. (확인 완료)
- 이 환경의 `pnpm build`는 better-sqlite3 네이티브 ABI 불일치로 실패(코드 무관). E2E도 동일 사유로 로컬 실행 불가 → CI 검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
