### PR TITLE
feat(console): make web console an installable standalone PWA (#478)

### DIFF
--- a/platform/services/mcctl-console/public/icons/icon.svg
+++ b/platform/services/mcctl-console/public/icons/icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="512" height="512">
+  <!-- Creeper Face - Minecraft Style (PWA icon, "any" purpose) -->
+  <rect width="32" height="32" fill="#5DA840"/>
+  <!-- Eyes -->
+  <rect x="4" y="8" width="8" height="8" fill="#000"/>
+  <rect x="20" y="8" width="8" height="8" fill="#000"/>
+  <!-- Mouth -->
+  <rect x="12" y="16" width="8" height="4" fill="#000"/>
+  <rect x="8" y="20" width="16" height="8" fill="#000"/>
+  <rect x="8" y="28" width="4" height="4" fill="#000"/>
+  <rect x="20" y="28" width="4" height="4" fill="#000"/>
+  <!-- Texture -->
+  <rect x="0" y="0" width="4" height="4" fill="#4A9030" opacity="0.5"/>
+  <rect x="8" y="4" width="4" height="4" fill="#4A9030" opacity="0.5"/>
+  <rect x="24" y="0" width="4" height="4" fill="#4A9030" opacity="0.5"/>
+  <rect x="28" y="8" width="4" height="4" fill="#4A9030" opacity="0.5"/>
+  <rect x="0" y="24" width="4" height="4" fill="#4A9030" opacity="0.5"/>
+</svg>

--- a/platform/services/mcctl-console/public/icons/maskable.svg
+++ b/platform/services/mcctl-console/public/icons/maskable.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="512" height="512">
+  <!-- Maskable PWA icon: full-bleed green background with the Creeper face
+       scaled into the central ~64% safe zone so adaptive masks don't clip it. -->
+  <rect width="32" height="32" fill="#5DA840"/>
+  <g transform="translate(6 6) scale(0.625)">
+    <!-- Eyes -->
+    <rect x="4" y="8" width="8" height="8" fill="#000"/>
+    <rect x="20" y="8" width="8" height="8" fill="#000"/>
+    <!-- Mouth -->
+    <rect x="12" y="16" width="8" height="4" fill="#000"/>
+    <rect x="8" y="20" width="16" height="8" fill="#000"/>
+    <rect x="8" y="28" width="4" height="4" fill="#000"/>
+    <rect x="20" y="28" width="4" height="4" fill="#000"/>
+  </g>
+</svg>

--- a/platform/services/mcctl-console/public/icons/maskable.svg
+++ b/platform/services/mcctl-console/public/icons/maskable.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="512" height="512">
   <!-- Maskable PWA icon: full-bleed green background with the Creeper face
-       scaled into the central ~64% safe zone so adaptive masks don't clip it. -->
+       scaled into the central ~62.5% safe zone so adaptive masks don't clip it. -->
   <rect width="32" height="32" fill="#5DA840"/>
   <g transform="translate(6 6) scale(0.625)">
     <!-- Eyes -->

--- a/platform/services/mcctl-console/src/app/apple-icon.tsx
+++ b/platform/services/mcctl-console/src/app/apple-icon.tsx
@@ -1,0 +1,45 @@
+import { ImageResponse } from 'next/og';
+import type { CSSProperties } from 'react';
+
+// iOS apple-touch-icon. Next.js auto-injects <link rel="apple-touch-icon"> from
+// this file, and iOS uses it as the home-screen icon for the standalone PWA
+// (#478). Generated as a PNG at build time via ImageResponse (Satori — no native
+// image tooling required), so it works in build environments without a rasterizer.
+export const size = { width: 180, height: 180 };
+export const contentType = 'image/png';
+
+// Creeper face pixel rects, scaled from the 32-unit source grid to 180px (x5.625).
+const pixel = (left: number, top: number, width: number, height: number): CSSProperties => ({
+  position: 'absolute',
+  left,
+  top,
+  width,
+  height,
+  backgroundColor: '#000',
+});
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          position: 'relative',
+          backgroundColor: '#5DA840',
+        }}
+      >
+        {/* Eyes */}
+        <div style={pixel(23, 45, 45, 45)} />
+        <div style={pixel(113, 45, 45, 45)} />
+        {/* Mouth */}
+        <div style={pixel(68, 90, 45, 23)} />
+        <div style={pixel(45, 113, 90, 45)} />
+        <div style={pixel(45, 158, 23, 23)} />
+        <div style={pixel(113, 158, 23, 23)} />
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/platform/services/mcctl-console/src/app/apple-icon.tsx
+++ b/platform/services/mcctl-console/src/app/apple-icon.tsx
@@ -36,8 +36,9 @@ export default function AppleIcon() {
         {/* Mouth */}
         <div style={pixel(68, 90, 45, 23)} />
         <div style={pixel(45, 113, 90, 45)} />
-        <div style={pixel(45, 158, 23, 23)} />
-        <div style={pixel(113, 158, 23, 23)} />
+        {/* Bottom teeth: top 157 so top+height stays within the 180px canvas (no clip). */}
+        <div style={pixel(45, 157, 23, 23)} />
+        <div style={pixel(113, 157, 23, 23)} />
       </div>
     ),
     { ...size }

--- a/platform/services/mcctl-console/src/app/layout.tsx
+++ b/platform/services/mcctl-console/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 import { ThemeProvider } from '@/theme';
@@ -6,10 +5,7 @@ import { QueryProvider } from '@/lib';
 import { LoadingProvider } from '@/components/providers';
 import './globals.css';
 
-export const metadata: Metadata = {
-  title: 'Minecraft Server Manager',
-  description: 'Web-based management console for Minecraft server infrastructure',
-};
+export { metadata, viewport } from './metadata';
 
 export default function RootLayout({
   children,

--- a/platform/services/mcctl-console/src/app/manifest.test.ts
+++ b/platform/services/mcctl-console/src/app/manifest.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import manifest from './manifest';
+
+describe('PWA web app manifest', () => {
+  const m = manifest();
+
+  it('declares a standalone, root-scoped installable app', () => {
+    expect(m.display).toBe('standalone');
+    expect(m.start_url).toBe('/');
+    expect(m.scope).toBe('/');
+  });
+
+  it('provides a name and a short_name that fits a home-screen label', () => {
+    expect(m.name).toMatch(/minecraft/i);
+    expect(m.short_name).toBeTruthy();
+    expect((m.short_name as string).length).toBeLessThanOrEqual(12);
+  });
+
+  it('uses the dark theme background colors', () => {
+    expect(m.background_color).toBe('#16181c');
+    expect(m.theme_color).toBe('#16181c');
+  });
+
+  it('declares a scalable icon and a maskable icon', () => {
+    const icons = m.icons ?? [];
+    expect(icons.length).toBeGreaterThan(0);
+    expect(icons.some((i) => i.type === 'image/svg+xml' && i.sizes === 'any')).toBe(true);
+    expect(icons.some((i) => (i.purpose ?? '').includes('maskable'))).toBe(true);
+  });
+});

--- a/platform/services/mcctl-console/src/app/manifest.ts
+++ b/platform/services/mcctl-console/src/app/manifest.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * Web App Manifest — makes the console an installable, standalone PWA so a
+ * home-screen shortcut launches full-screen instead of inside the iOS Safari
+ * overlay chrome (the close button + URL bar). See #478.
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Minecraft Server Manager',
+    short_name: 'MC Console',
+    description: 'Web-based management console for Minecraft server infrastructure',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    background_color: '#16181c',
+    theme_color: '#16181c',
+    icons: [
+      // Scalable icon — covers all sizes for browsers that accept SVG.
+      { src: '/icons/icon.svg', type: 'image/svg+xml', sizes: 'any', purpose: 'any' },
+      // Padded variant for Android adaptive (maskable) icons.
+      { src: '/icons/maskable.svg', type: 'image/svg+xml', sizes: 'any', purpose: 'maskable' },
+    ],
+  };
+}

--- a/platform/services/mcctl-console/src/app/metadata.test.ts
+++ b/platform/services/mcctl-console/src/app/metadata.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { metadata, viewport } from './metadata';
+
+describe('root layout PWA metadata', () => {
+  it('marks the app as iOS web-app-capable so home-screen launch is full-screen', () => {
+    const appleWebApp = metadata.appleWebApp as { capable?: boolean; title?: string };
+    expect(appleWebApp).toBeTruthy();
+    expect(appleWebApp.capable).toBe(true);
+    expect(appleWebApp.title).toBeTruthy();
+  });
+
+  it('exposes a dark theme color and edge-to-edge viewport for standalone display', () => {
+    expect(viewport.themeColor).toBe('#16181c');
+    expect(viewport.viewportFit).toBe('cover');
+  });
+});

--- a/platform/services/mcctl-console/src/app/metadata.ts
+++ b/platform/services/mcctl-console/src/app/metadata.ts
@@ -1,0 +1,28 @@
+import type { Metadata, Viewport } from 'next';
+
+/**
+ * Root metadata + viewport, kept in their own module so they can be unit-tested
+ * without importing the full layout (which pulls in the DB/provider tree).
+ *
+ * `appleWebApp.capable` is the key to #478: it emits
+ * `<meta name="apple-mobile-web-app-capable" content="yes">`, so a home-screen
+ * shortcut launches full-screen instead of inside the iOS Safari overlay chrome.
+ */
+export const metadata: Metadata = {
+  title: 'Minecraft Server Manager',
+  description: 'Web-based management console for Minecraft server infrastructure',
+  applicationName: 'MC Console',
+  appleWebApp: {
+    capable: true,
+    title: 'Minecraft Console',
+    statusBarStyle: 'black-translucent',
+  },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: '#16181c',
+  // Extend under the notch / home indicator for a native standalone feel.
+  viewportFit: 'cover',
+};


### PR DESCRIPTION
## Summary

iOS 홈화면 바로가기로 mcctl-console을 열면 전체화면이 아니라 **Safari 오버레이 크롬(상단 ✕ 닫기 버튼 + "보안 안 됨 — IP" URL 바)** 안에서 떠서, 사용자가 "메뉴 옮길 때마다 레이어처럼 ✕가 뜬다"고 보고했습니다. 원인은 console이 **설치형 PWA(standalone)로 설정돼 있지 않았기 때문**입니다. (이전 #477 keepMounted 수정과 무관한 별개 원인)

console을 standalone PWA로 구성해 홈화면 바로가기가 ✕/URL 바 없이 전체화면으로 열리도록 합니다.

Closes #478

## What changed

- **`src/app/metadata.ts`** (신규) — `metadata`/`viewport`를 별도 모듈로 분리(DB/provider 트리 import 없이 단위 테스트 가능). 핵심: `appleWebApp.capable = true` → `<meta name="apple-mobile-web-app-capable" content="yes">`, `statusBarStyle: 'black-translucent'`, `viewport.themeColor '#16181c'`, `viewportFit: 'cover'`.
- **`src/app/layout.tsx`** — 인라인 metadata 제거, `export { metadata, viewport } from './metadata'`로 재노출.
- **`src/app/manifest.ts`** (신규) — Web App Manifest: `display: 'standalone'`, name/short_name, dark theme/background `#16181c`, icons.
- **`public/icons/icon.svg`, `maskable.svg`** (신규) — Creeper 스케일러블 아이콘(any + maskable).
- **`src/app/apple-icon.tsx`** (신규) — 180×180 iOS apple-touch-icon을 `ImageResponse`(next/og, Satori)로 **빌드 시 PNG 생성** (로컬 래스터라이저 불필요).
- 테스트: `manifest.test.ts`(4), `metadata.test.ts`(2) — TDD Red→Green.

## Test plan

- [x] `manifest.test.ts` + `metadata.test.ts` — **6 tests 통과**
- [x] `pnpm lint` PWA 파일 경고 없음
- [x] PWA 변경 파일 `tsc --noEmit` 클린 (총 에러 수 2 = develop 선재 이슈 그대로)
- [ ] 빌드/ImageResponse(apple-icon) 렌더는 이 환경의 better-sqlite3 ABI 제약으로 로컬 실행 불가 → **CI 검증 필요**

## 사용자 적용 방법 (중요)

배포(`mcctl update --all`) 후, **기존 iOS 홈화면 바로가기를 삭제하고 다시 추가**해야 iOS가 standalone 설정을 인식합니다. 그러면 ✕/URL 크롬 없이 전체화면으로 열립니다.

## Caveats / out of scope

- "보안 안 됨"(HTTP, Tailscale IP)은 별개 사안 — standalone 동작엔 무관하나 완전한 PWA(서비스워커/오프라인)는 HTTPS 필요 → 후속 이슈.
- 서비스워커/오프라인 캐싱 범위 외.
- manifest 아이콘은 스케일러블 SVG(sizes any) + maskable로 제공. iOS는 apple-icon PNG를 사용. 별도 raster 192/512 PNG가 필요하면 후속에서 추가 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
