### PR TITLE
fix(console): apply safe-area-inset-top so PWA AppBar clears the status bar (#480)

### DIFF
--- a/platform/services/mcctl-console/src/components/layout/GNB.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/GNB.test.tsx
@@ -139,6 +139,22 @@ describe('GNB', () => {
     expect(emotionStylesFor(appBar as Element)).toContain('env(safe-area-inset-top)');
   });
 
+  it('should offset the open mobile drawer below the safe-area inset (close button stays tappable)', () => {
+    // The temporary Drawer renders full-height from top:0, so its header (with
+    // the close button and first nav item) overlaps the status bar / notch in
+    // PWA standalone mode just like the AppBar did (#480). The drawer paper must
+    // also reserve env(safe-area-inset-top).
+    renderWithTheme(<GNB mobileOpen={true} onMenuToggle={vi.fn()} />);
+
+    // The drawer paper styles are emitted as a nested rule on the Drawer root
+    // (`.css-root .MuiDrawer-paper { ... }`), so assert against the injected
+    // stylesheet rule that targets .MuiDrawer-paper directly.
+    const styleText = Array.from(document.querySelectorAll('style'))
+      .map((s) => s.textContent ?? '')
+      .join('\n');
+    expect(styleText).toMatch(/\.MuiDrawer-paper\s*\{[^}]*env\(safe-area-inset-top\)/);
+  });
+
   it('should render navigation links with correct hrefs', () => {
     renderWithTheme(<GNB mobileOpen={false} onMenuToggle={vi.fn()} />);
 

--- a/platform/services/mcctl-console/src/components/layout/GNB.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/GNB.test.tsx
@@ -30,6 +30,28 @@ const renderWithTheme = (component: React.ReactNode) => {
   return render(<ThemeProvider>{component}</ThemeProvider>);
 };
 
+// Collects the emotion CSS rule bodies that apply to the given element by
+// matching its `css-*` classes against the injected <style> tags. Used to
+// assert on generated styles (e.g. safe-area insets) that jsdom's
+// getComputedStyle cannot resolve from class-based stylesheets.
+const emotionStylesFor = (el: Element): string => {
+  const styleText = Array.from(document.querySelectorAll('style'))
+    .map((s) => s.textContent ?? '')
+    .join('\n');
+  return Array.from(el.classList)
+    .filter((c) => c.startsWith('css-'))
+    .map((c) => {
+      const re = new RegExp(`\\.${c}\\s*\\{([^}]*)\\}`, 'g');
+      let match: RegExpExecArray | null;
+      let body = '';
+      while ((match = re.exec(styleText)) !== null) {
+        body += match[1];
+      }
+      return body;
+    })
+    .join('\n');
+};
+
 describe('GNB', () => {
   beforeEach(() => {
     // Reset session before each test
@@ -101,6 +123,20 @@ describe('GNB', () => {
     renderWithTheme(<GNB mobileOpen={false} onMenuToggle={vi.fn()} />);
 
     expect(screen.queryByLabelText('close menu')).not.toBeInTheDocument();
+  });
+
+  it('should offset the AppBar below the device safe-area inset (PWA standalone notch)', () => {
+    // In PWA standalone mode the manifest uses viewport-fit=cover, so content
+    // extends under the status bar / notch. Without a safe-area top offset the
+    // fixed AppBar overlaps the status bar and the hamburger button becomes
+    // untappable (#480). The AppBar must reserve env(safe-area-inset-top).
+    const { container } = renderWithTheme(
+      <GNB mobileOpen={false} onMenuToggle={vi.fn()} />
+    );
+
+    const appBar = container.querySelector('.MuiAppBar-root');
+    expect(appBar).not.toBeNull();
+    expect(emotionStylesFor(appBar as Element)).toContain('env(safe-area-inset-top)');
   });
 
   it('should render navigation links with correct hrefs', () => {

--- a/platform/services/mcctl-console/src/components/layout/GNB.tsx
+++ b/platform/services/mcctl-console/src/components/layout/GNB.tsx
@@ -211,6 +211,10 @@ export function GNB({ mobileOpen, onMenuToggle }: GNBProps) {
             boxSizing: 'border-box',
             width: 280,
             backgroundColor: 'background.paper',
+            // Mirror the AppBar's safe-area offset (#480): the full-height
+            // drawer renders from top:0, so without this its header (close
+            // button and first nav item) overlaps the status bar / notch.
+            paddingTop: 'env(safe-area-inset-top)',
           },
         }}
       >

--- a/platform/services/mcctl-console/src/components/layout/GNB.tsx
+++ b/platform/services/mcctl-console/src/components/layout/GNB.tsx
@@ -71,6 +71,11 @@ export function GNB({ mobileOpen, onMenuToggle }: GNBProps) {
           borderBottom: '1px solid',
           borderColor: 'divider',
           zIndex: (theme) => theme.zIndex.drawer + 1,
+          // PWA standalone mode uses viewport-fit=cover, so the fixed AppBar
+          // would otherwise sit under the status bar / notch and the hamburger
+          // button becomes untappable (#480). Reserve the safe-area inset so the
+          // bar's background fills the notch and its Toolbar drops below it.
+          paddingTop: 'env(safe-area-inset-top)',
         }}
       >
         <Toolbar

--- a/platform/services/mcctl-console/src/components/layout/MainLayout.test.tsx
+++ b/platform/services/mcctl-console/src/components/layout/MainLayout.test.tsx
@@ -20,6 +20,26 @@ const renderWithTheme = (component: React.ReactNode) => {
   return render(<ThemeProvider>{component}</ThemeProvider>);
 };
 
+// Collects the emotion CSS rule bodies that apply to the given element by
+// matching its `css-*` classes against the injected <style> tags.
+const emotionStylesFor = (el: Element): string => {
+  const styleText = Array.from(document.querySelectorAll('style'))
+    .map((s) => s.textContent ?? '')
+    .join('\n');
+  return Array.from(el.classList)
+    .filter((c) => c.startsWith('css-'))
+    .map((c) => {
+      const re = new RegExp(`\\.${c}\\s*\\{([^}]*)\\}`, 'g');
+      let match: RegExpExecArray | null;
+      let body = '';
+      while ((match = re.exec(styleText)) !== null) {
+        body += match[1];
+      }
+      return body;
+    })
+    .join('\n');
+};
+
 describe('MainLayout', () => {
   it('should render children content', () => {
     renderWithTheme(
@@ -73,6 +93,21 @@ describe('MainLayout', () => {
 
     const mainContent = screen.getByTestId('main-content');
     expect(mainContent).toBeInTheDocument();
+  });
+
+  it('should pad the main content below the safe-area inset so it is not clipped by the AppBar', () => {
+    // The AppBar grows by env(safe-area-inset-top) in PWA standalone mode, so
+    // the main content's top padding must add the same inset to avoid being
+    // hidden under the AppBar (#480).
+    const { container } = renderWithTheme(
+      <MainLayout>
+        <div>Content</div>
+      </MainLayout>
+    );
+
+    const main = container.querySelector('main');
+    expect(main).not.toBeNull();
+    expect(emotionStylesFor(main as Element)).toContain('env(safe-area-inset-top)');
   });
 
   it('should render navigation links in GNB', () => {

--- a/platform/services/mcctl-console/src/components/layout/MainLayout.tsx
+++ b/platform/services/mcctl-console/src/components/layout/MainLayout.tsx
@@ -36,7 +36,13 @@ export function MainLayout({ children }: MainLayoutProps) {
           flexGrow: 1,
           display: 'flex',
           flexDirection: 'column',
-          pt: { xs: `${GNB_HEIGHT + 24}px`, sm: `${GNB_HEIGHT + 32}px` },
+          // The AppBar grows by env(safe-area-inset-top) in PWA standalone mode
+          // (#480); add the same inset here so content clears the AppBar instead
+          // of being hidden under it.
+          pt: {
+            xs: `calc(${GNB_HEIGHT + 24}px + env(safe-area-inset-top))`,
+            sm: `calc(${GNB_HEIGHT + 32}px + env(safe-area-inset-top))`,
+          },
           pb: { xs: 3, sm: 4 },
           px: { xs: 2, sm: 3, md: 4 },
           maxWidth: '1400px',


### PR DESCRIPTION
## Summary

PWA standalone 모드(홈 화면 바로가기)에서 상단 AppBar가 기기 상태바/노치와 겹쳐 **햄버거 메뉴 버튼이 클릭되지 않던 문제**(#480)를 수정합니다.

## Root Cause

v2.22.0 (#478)에서 PWA standalone 전환 시 `viewport-fit=cover` + `black-translucent` 상태바를 적용하여 콘텐츠가 노치 아래까지 확장되도록 했으나, 이를 보정하는 `env(safe-area-inset-top)` 처리를 추가하지 않았습니다. 결과적으로 `position: fixed; top: 0`인 AppBar가 상태바와 물리적으로 겹쳤습니다.

## Changes

- **`GNB.tsx`**: AppBar `sx`에 `paddingTop: 'env(safe-area-inset-top)'` 추가 → AppBar 배경이 노치를 채우고 Toolbar(햄버거 버튼)가 안전 영역 아래로 내려감
- **`MainLayout.tsx`**: `<main>` 콘텐츠의 `pt`를 `calc(...px + env(safe-area-inset-top))`로 변경 → 높아진 AppBar에 본문이 가려지지 않음

safe area가 없는 환경에서는 `env()`가 `0`으로 폴백되므로 데스크톱/일반 브라우저 레이아웃에 회귀가 없습니다.

## Tests (TDD)

- RED → GREEN: AppBar와 main 요소의 emotion 스타일에 `env(safe-area-inset-top)` 적용 여부를 검증하는 테스트 추가
- `GNB.test.tsx`, `MainLayout.test.tsx` 포함 레이아웃 테스트 26/26 통과

> Note: `ConfigSnapshot*` 관련 type-check/테스트 실패 2건은 이 PR과 **무관한 develop의 사전 존재 결함**입니다 (develop에서 동일하게 재현). 별도 이슈로 처리 권장.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
