### PR TITLE
fix(api): run version-matched create/delete scripts instead of stale deployed copy (#483)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,14 @@ jobs:
           ls -la platform/services/cli/scripts/
           echo "Scripts synced successfully"
 
+      - name: Sync scripts to mcctl-api package
+        run: |
+          echo "Syncing scripts to mcctl-api package..."
+          rm -rf platform/services/mcctl-api/scripts
+          cp -r platform/scripts platform/services/mcctl-api/scripts
+          ls -la platform/services/mcctl-api/scripts/
+          echo "Scripts synced successfully"
+
       - name: Publish @minecraft-docker/mcctl-api
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}

--- a/platform/services/mcctl-api/.gitignore
+++ b/platform/services/mcctl-api/.gitignore
@@ -1,0 +1,2 @@
+# Bundled platform scripts (generated from ../../scripts at publish time via sync-scripts)
+/scripts/

--- a/platform/services/mcctl-api/package.json
+++ b/platform/services/mcctl-api/package.json
@@ -9,7 +9,8 @@
     "mcctl-api": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "scripts"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,7 +26,9 @@
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "sync-scripts": "rm -rf scripts && cp -r ../../scripts . && rm -f scripts/.gitkeep",
+    "prepublishOnly": "npm run sync-scripts"
   },
   "keywords": [
     "minecraft",

--- a/platform/services/mcctl-api/src/lib/script-resolver.ts
+++ b/platform/services/mcctl-api/src/lib/script-resolver.ts
@@ -1,0 +1,80 @@
+import { join, dirname } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Resolve the mcctl-api package root (the directory containing its package.json)
+ * starting from this module's location.
+ *
+ * The compiled module lives at `<pkgRoot>/dist/lib/script-resolver.js`, so we
+ * walk up until we find the `@minecraft-docker/mcctl-api` package.json.
+ */
+function getApiPackageRoot(): string {
+  const start = dirname(fileURLToPath(import.meta.url));
+  let dir = start;
+
+  while (dir !== dirname(dir)) {
+    const pkgPath = join(dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        if (pkg.name === '@minecraft-docker/mcctl-api') {
+          return dir;
+        }
+      } catch {
+        // Ignore malformed package.json and keep walking up.
+      }
+    }
+    dir = dirname(dir);
+  }
+
+  return start;
+}
+
+/**
+ * Directory of the scripts bundled with the mcctl-api package.
+ *
+ * These are synced from `platform/scripts` at publish time (see the
+ * `sync-scripts` npm script) and are therefore version-matched with the API.
+ * In a development build (running from `src/` via tsx) this directory does not
+ * exist, in which case the resolver falls back to the deployed platform copy.
+ */
+export function getBundledScriptsDir(): string {
+  return join(getApiPackageRoot(), 'scripts');
+}
+
+export interface ResolvedScript {
+  /** Absolute path to the resolved `.sh` script. */
+  scriptPath: string;
+  /** Directory containing the script (exported as MCCTL_SCRIPTS to the script). */
+  scriptsDir: string;
+}
+
+/**
+ * Resolve the script to execute for a given script name.
+ *
+ * Resolution order:
+ *   1. Bundled scripts shipped with mcctl-api (version-matched).
+ *   2. Scripts deployed under `<platformPath>/scripts` (legacy / may be stale).
+ *
+ * Returns `null` when the script is found in neither location, signalling the
+ * caller to fall back to the globally installed `mcctl` CLI.
+ */
+export function resolveScriptPath(
+  scriptName: string,
+  platformPath: string,
+  bundledScriptsDir: string = getBundledScriptsDir(),
+): ResolvedScript | null {
+  const bundled = join(bundledScriptsDir, scriptName);
+  if (existsSync(bundled)) {
+    return { scriptPath: bundled, scriptsDir: bundledScriptsDir };
+  }
+
+  const deployedDir = join(platformPath, 'scripts');
+  const deployed = join(deployedDir, scriptName);
+  if (existsSync(deployed)) {
+    return { scriptPath: deployed, scriptsDir: deployedDir };
+  }
+
+  return null;
+}

--- a/platform/services/mcctl-api/src/routes/servers.ts
+++ b/platform/services/mcctl-api/src/routes/servers.ts
@@ -39,12 +39,11 @@ import {
   type DeleteServerQuery,
 } from '../schemas/server.js';
 import { config } from '../config/index.js';
+import { resolveScriptPath } from '../lib/script-resolver.js';
 import { writeAuditLog } from '../services/audit-log-service.js';
 import { AuditActionEnum } from '@minecraft-docker/shared';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { join } from 'path';
-import { existsSync } from 'fs';
 
 const execPromise = promisify(exec);
 
@@ -639,21 +638,24 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       args.push('--no-start');
     }
 
-    // Find create-server.sh script
+    // Resolve create-server.sh: prefer the version-matched script bundled with
+    // mcctl-api, fall back to the deployed platform copy, then the global mcctl CLI.
+    // The deployed copy under <platformPath>/scripts is not refreshed by
+    // 'mcctl update' and can be stale (missing newer options like --memory/--modpack).
     const platformPath = config.platformPath;
-    const scriptPath = join(platformPath, 'scripts', 'create-server.sh');
+    const resolvedScript = resolveScriptPath('create-server.sh', platformPath);
 
-    // Check if script exists, fallback to global mcctl
     let command: string;
     let commandArgs: string[];
-    if (existsSync(scriptPath)) {
+    if (resolvedScript) {
       command = 'bash';
-      commandArgs = [scriptPath, ...args];
+      commandArgs = [resolvedScript.scriptPath, ...args];
     } else {
       // Use mcctl CLI if script not found
       command = 'mcctl';
       commandArgs = ['create', ...args];
     }
+    const scriptsDir = resolvedScript?.scriptsDir;
 
     // SSE streaming mode
     if (follow) {
@@ -678,6 +680,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         env: {
           ...process.env,
           MCCTL_ROOT: platformPath,
+          ...(scriptsDir ? { MCCTL_SCRIPTS: scriptsDir } : {}),
           ...(sudoPassword ? { MCCTL_SUDO_PASSWORD: sudoPassword } : {}),
         },
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -815,6 +818,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         env: {
           ...process.env,
           MCCTL_ROOT: platformPath,
+          ...(scriptsDir ? { MCCTL_SCRIPTS: scriptsDir } : {}),
           ...(sudoPassword ? { MCCTL_SUDO_PASSWORD: sudoPassword } : {}),
         },
       });
@@ -912,14 +916,15 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         }
       }
 
-      // Find delete-server.sh script
+      // Resolve delete-server.sh: prefer the bundled (version-matched) script,
+      // fall back to the deployed platform copy, then the global mcctl CLI.
       const platformPath = config.platformPath;
-      const scriptPath = join(platformPath, 'scripts', 'delete-server.sh');
+      const resolvedScript = resolveScriptPath('delete-server.sh', platformPath);
 
       // Build command
       let command: string;
-      if (existsSync(scriptPath)) {
-        command = `bash "${scriptPath}" "${name}" --force`;
+      if (resolvedScript) {
+        command = `bash "${resolvedScript.scriptPath}" "${name}" --force`;
       } else {
         // Use mcctl CLI if script not found
         command = `mcctl delete "${name}" --force`;
@@ -931,6 +936,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         env: {
           ...process.env,
           MCCTL_ROOT: platformPath,
+          ...(resolvedScript ? { MCCTL_SCRIPTS: resolvedScript.scriptsDir } : {}),
         },
       });
 

--- a/platform/services/mcctl-api/tests/script-resolver.test.ts
+++ b/platform/services/mcctl-api/tests/script-resolver.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { resolveScriptPath } from '../src/lib/script-resolver.js';
+
+const TMP = join(import.meta.dirname, '.tmp-script-resolver-test');
+const BUNDLED = join(TMP, 'bundled-scripts');
+const PLATFORM = join(TMP, 'platform');
+
+function writeScript(dir: string, name: string) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), '#!/usr/bin/env bash\n', 'utf-8');
+}
+
+describe('resolveScriptPath', () => {
+  beforeEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('prefers the bundled (version-matched) script over the deployed platform copy', () => {
+    writeScript(BUNDLED, 'create-server.sh');
+    writeScript(join(PLATFORM, 'scripts'), 'create-server.sh');
+
+    const resolved = resolveScriptPath('create-server.sh', PLATFORM, BUNDLED);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.scriptsDir).toBe(BUNDLED);
+    expect(resolved!.scriptPath).toBe(join(BUNDLED, 'create-server.sh'));
+  });
+
+  it('falls back to the deployed platform script when no bundled script exists', () => {
+    writeScript(join(PLATFORM, 'scripts'), 'create-server.sh');
+
+    const resolved = resolveScriptPath('create-server.sh', PLATFORM, BUNDLED);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.scriptsDir).toBe(join(PLATFORM, 'scripts'));
+    expect(resolved!.scriptPath).toBe(join(PLATFORM, 'scripts', 'create-server.sh'));
+  });
+
+  it('returns null when the script exists in neither location (caller uses mcctl CLI fallback)', () => {
+    const resolved = resolveScriptPath('create-server.sh', PLATFORM, BUNDLED);
+    expect(resolved).toBeNull();
+  });
+
+  it('resolves each script name independently', () => {
+    writeScript(BUNDLED, 'delete-server.sh');
+    writeScript(join(PLATFORM, 'scripts'), 'backup.sh');
+
+    const del = resolveScriptPath('delete-server.sh', PLATFORM, BUNDLED);
+    const backup = resolveScriptPath('backup.sh', PLATFORM, BUNDLED);
+    const missing = resolveScriptPath('create-server.sh', PLATFORM, BUNDLED);
+
+    expect(del!.scriptsDir).toBe(BUNDLED);
+    expect(backup!.scriptsDir).toBe(join(PLATFORM, 'scripts'));
+    expect(missing).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

웹 콘솔에서 MODRINTH 모드팩(예: `create_plus`) 서버 생성 시 `Unknown option: --memory`로 실패하던 문제를 수정합니다. `Closes #483`

## Root Cause

mcctl-api는 서버 생성 시 `<platformPath>/scripts/create-server.sh`(= `~/minecraft-servers/scripts/`)를 실행했습니다. 이 배포본은 `mcctl init` 시점에 한 번 복사된 뒤 **`mcctl update`로 갱신되지 않아** API보다 구버전으로 고착됩니다. API는 `--memory`, `--modpack`, `--modpack-version`, `--mod-loader` 옵션을 전달하도록 업데이트되었지만(#360, #243), 구버전 스크립트는 이를 모릅니다.

CLI(`mcctl create`)는 `Paths`를 통해 **패키지에 번들된 버전 일치 스크립트**를 실행하므로 영향을 받지 않았습니다. 즉 CLI와 API가 서로 다른 스크립트를 실행한 것이 근본 원인입니다.

## Fix

- **mcctl-api에 플랫폼 스크립트를 번들** (`platform/scripts` → publish 시 `sync-scripts`로 동기화, `.gitignore`로 커밋 drift 방지).
- `resolveScriptPath()`로 스크립트 해석: **번들(버전 일치) → 배포본(legacy fallback) → 전역 `mcctl` CLI** 순.
- 해석된 scripts 디렉터리를 `MCCTL_SCRIPTS`로 주입하여 스크립트가 같은 위치의 `lib/`를 source하도록 보장.
- create(SSE/JSON) 및 delete 핸들러에 적용.

## Changes

| File | Change |
|------|--------|
| `package.json` / `.gitignore` | 스크립트 번들(`files`, `sync-scripts`, `prepublishOnly`) |
| `src/lib/script-resolver.ts` | 신규: 버전 일치 스크립트 경로 해석기 |
| `src/routes/servers.ts` | create/delete가 resolver 사용 + `MCCTL_SCRIPTS` 주입 |
| `tests/script-resolver.test.ts` | 신규: 해석 우선순위 회귀 테스트 (4 cases) |

## Testing

- ✅ `script-resolver.test.ts` (4 passed) — 번들 우선 / 배포본 fallback / null fallback / 스크립트별 독립 해석
- ✅ `tsc` 빌드 통과

### Note: 사전 존재(pre-existing) 테스트 실패
`servers.test.ts` 등 일부 라우트 테스트는 `vi.mock('@minecraft-docker/shared')`에 `SqliteBackupScheduleRepository` 등 export가 누락되어 `buildApp` 단계에서 실패합니다. 이는 **develop HEAD에서도 동일하게 실패**하는 기존 문제이며(본 변경과 무관), PR 단위 CI(vitest)도 없습니다. 본 변경이 검증하려는 `Command Arguments` 테스트는 `arrayContaining`으로 modpack 인자만 확인하므로 로직상 호환됩니다.

## Out of Scope (follow-up 권고)
- `backup.ts` / `backup-scheduler.ts`의 `backup.sh`도 동일한 stale-script 패턴이지만, 보고된 버그가 아니고 현재 통과 중인 `backup-routes.test.ts`(git-fallback 검증)를 깨므로 별도 PR로 분리.
- `mcctl update` 시 `~/minecraft-servers/scripts/` 동기화 정책 검토(본 PR은 API의 배포본 의존 자체를 제거).
- 공통 shared mock 갭(`SqliteBackupScheduleRepository`) 보완.

## 사용자 즉시 워크어라운드 (배포 전)
```bash
cp "$(npm root -g)"/@minecraft-docker/mcctl/scripts/*.sh ~/minecraft-servers/scripts/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
