### PR TITLE
fix(api): 화이트리스트 조회 실패 수정 - 컨테이너 없음 404 & RCON 빈 응답 파일 fallback (#485)

### DIFF
--- a/platform/services/mcctl-api/src/routes/players.ts
+++ b/platform/services/mcctl-api/src/routes/players.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
 import fp from 'fastify-plugin';
-import { containerExists, getContainerStatus, OpLevel } from '@minecraft-docker/shared';
+import { join } from 'node:path';
+import { containerExists, getContainerStatus, serverExists, OpLevel } from '@minecraft-docker/shared';
 import {
   PlayerInfoSchema,
   OnlinePlayersResponseSchema,
@@ -95,6 +96,17 @@ const playersPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
   const checkServerExists = (name: string, reply: FastifyReply): boolean => {
     const containerName = `mc-${name}`;
     if (!containerExists(containerName)) {
+      reply.code(404).send({ error: 'NotFound', message: `Server '${name}' not found` });
+      return false;
+    }
+    return true;
+  };
+
+  // Helper to check a server is defined (container OR config.env on disk).
+  // Use for read endpoints so a defined-but-not-running server can still be
+  // served from its files instead of 404ing when no container exists.
+  const checkServerDefined = (name: string, reply: FastifyReply): boolean => {
+    if (!serverExists(name, join(config.platformPath, 'servers'))) {
       reply.code(404).send({ error: 'NotFound', message: `Server '${name}' not found` });
       return false;
     }
@@ -208,7 +220,7 @@ const playersPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     },
   }, async (request: FastifyRequest<ServerRoute>, reply: FastifyReply) => {
     const { name } = request.params;
-    if (!checkServerExists(name, reply)) return;
+    if (!checkServerDefined(name, reply)) return;
 
     const running = isServerRunning(name);
     const enabled = playerFileService.readWhitelistEnabled(name);
@@ -219,15 +231,20 @@ const playersPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         const match = result.match(/:\s*(.*)$/);
         const playerNames = match && match[1] ? match[1].split(',').map(p => p.trim()).filter(Boolean) : [];
 
-        // Enrich RCON names with UUIDs from whitelist.json
-        const fileData = playerFileService.readWhitelist(name);
-        const uuidMap = new Map(fileData.players.map(p => [p.name.toLowerCase(), p.uuid]));
+        // Only trust RCON when it actually returned players. execRconCommand never
+        // throws on connection/empty failures, so an empty parse must NOT mask a
+        // populated whitelist.json — fall through to the file in that case.
+        if (playerNames.length > 0) {
+          // Enrich RCON names with UUIDs from whitelist.json
+          const fileData = playerFileService.readWhitelist(name);
+          const uuidMap = new Map(fileData.players.map(p => [p.name.toLowerCase(), p.uuid]));
 
-        const players = playerNames.map(pName => ({
-          name: pName,
-          uuid: uuidMap.get(pName.toLowerCase()) || '',
-        }));
-        return reply.send({ players, total: players.length, source: 'rcon', enabled });
+          const players = playerNames.map(pName => ({
+            name: pName,
+            uuid: uuidMap.get(pName.toLowerCase()) || '',
+          }));
+          return reply.send({ players, total: players.length, source: 'rcon', enabled });
+        }
       } catch (error) {
         fastify.log.warn(error, 'RCON failed for whitelist, falling back to file');
       }
@@ -255,7 +272,7 @@ const playersPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     },
   }, async (request: FastifyRequest<ServerRoute>, reply: FastifyReply) => {
     const { name } = request.params;
-    if (!checkServerExists(name, reply)) return;
+    if (!checkServerDefined(name, reply)) return;
 
     try {
       const enabled = playerFileService.readWhitelistEnabled(name);

--- a/platform/services/mcctl-api/tests/whitelist-rcon-fallback.test.ts
+++ b/platform/services/mcctl-api/tests/whitelist-rcon-fallback.test.ts
@@ -69,6 +69,19 @@ function setupServer(serverName: string, opts: { whitelist?: Array<{ uuid: strin
   writeFileSync(join(dataDir, 'whitelist.json'), JSON.stringify(whitelist, null, 2), 'utf-8');
 }
 
+// Server defined on disk (config.env) but WITHOUT a container.
+// Intentionally omits docker-compose.yml so the mocked containerExists() returns false.
+function setupServerConfigOnly(serverName: string, opts: { whitelist?: Array<{ uuid: string; name: string }> } = {}) {
+  const serverDir = join(TEST_PLATFORM_PATH, 'servers', serverName);
+  const dataDir = join(serverDir, 'data');
+  mkdirSync(dataDir, { recursive: true });
+
+  writeFileSync(join(serverDir, 'config.env'), 'TYPE=PAPER\nENABLE_WHITELIST=TRUE\n', 'utf-8');
+
+  const whitelist = opts.whitelist || [];
+  writeFileSync(join(dataDir, 'whitelist.json'), JSON.stringify(whitelist, null, 2), 'utf-8');
+}
+
 function readWhitelistFile(serverName: string): Array<{ uuid: string; name: string }> {
   const filePath = join(TEST_PLATFORM_PATH, 'servers', serverName, 'data', 'whitelist.json');
   if (!existsSync(filePath)) return [];
@@ -351,6 +364,79 @@ describe('Whitelist RCON Error Detection and File Fallback', () => {
       const whitelist = readWhitelistFile('test-server');
       expect(whitelist).toHaveLength(1);
       expect(whitelist[0].name).toBe('Alex');
+    });
+  });
+
+  // ==================== GET /api/servers/:name/whitelist (read path) ====================
+  describe('GET /api/servers/:name/whitelist - read fallback', () => {
+    it('returns file-based whitelist for a defined server that has no container (not 404)', async () => {
+      setupServerConfigOnly('stopped-server', {
+        whitelist: [{ uuid: 'uuid-1', name: 'Steve' }],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/servers/stopped-server/whitelist',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.players.map((p: { name: string }) => p.name)).toEqual(['Steve']);
+      expect(json.source).toBe('file');
+    });
+
+    it('falls back to whitelist.json when a running server returns an empty RCON list', async () => {
+      setupServer('test-server', {
+        whitelist: [
+          { uuid: 'uuid-1', name: 'Steve' },
+          { uuid: 'uuid-2', name: 'Alex' },
+        ],
+      });
+      // RCON reachable but reports no whitelisted players (e.g. not reloaded after a file write)
+      rconMockImpl = async () => 'There are no whitelisted players';
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/servers/test-server/whitelist',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.players.map((p: { name: string }) => p.name).sort()).toEqual(['Alex', 'Steve']);
+      expect(json.source).toBe('file');
+    });
+
+    it('still uses RCON when it returns a populated list', async () => {
+      setupServer('test-server', {
+        whitelist: [{ uuid: 'uuid-1', name: 'Steve' }],
+      });
+      rconMockImpl = async () => 'There are 1 whitelisted player(s): Steve';
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/servers/test-server/whitelist',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.players.map((p: { name: string }) => p.name)).toEqual(['Steve']);
+      expect(json.source).toBe('rcon');
+    });
+  });
+
+  describe('GET /api/servers/:name/whitelist/status - read guard', () => {
+    it('returns status for a defined server without a container (not 404)', async () => {
+      setupServerConfigOnly('stopped-server');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/servers/stopped-server/whitelist/status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.enabled).toBe(true);
+      expect(json.source).toBe('config');
     });
   });
 });


### PR DESCRIPTION
## Summary

웹 콘솔 화이트리스트 **조회(GET)** 실패를 수정합니다. `Closes #485`

증상:
- `GET .../whitelist?server=botagent` → 404 (컨테이너 없는 서버)
- `GET .../whitelist?server=factory` → `{"players":[],"source":"rcon"}` (파일엔 있는데 빈 목록)
- 입력(POST)은 `source:"file+reload"`로 정상 반영됨

## Root Cause & Fix

`platform/services/mcctl-api/src/routes/players.ts`의 읽기 경로 두 가지 버그:

### 1. 컨테이너 없는 서버 404
- 기존: 읽기 가드가 `containerExists()`(docker inspect)만 확인 → config.env로 정의됐지만 미기동인 서버는 `whitelist.json`을 보기도 전에 404.
- 수정: `serverExists()`(컨테이너 **또는** config.env) 기반 `checkServerDefined()` 가드를 도입해 `GET whitelist`/`GET whitelist/status`에 적용. 진짜 미존재 서버는 여전히 404.

### 2. RCON 빈 응답이 파일을 가림
- 기존: 파일 fallback이 `execRconCommand` **throw 시에만** 실행. 그러나 `execRcon`은 실패해도 `resolve('')` (reject 안 함) → 빈/실패 RCON이 `{players:[],source:'rcon'}`를 반환.
- 수정: RCON이 **실제로 플레이어를 파싱했을 때만** rcon 결과 반환, 그 외에는 `whitelist.json`으로 fallthrough. 쓰기(파일 권위) 모델과 일치.

## Tests (TDD)

`tests/whitelist-rcon-fallback.test.ts`에 회귀 테스트 3종 추가:
- 컨테이너 없는(config.env만) 서버 조회 → 404 아님, 파일 기반 결과(`source:file`)
- 기동 중 서버 RCON 빈 응답 + 파일에 항목 → 파일 목록 반환(`source:file`)
- 기동 중 서버 RCON 정상 목록 → `source:rcon` 유지(회귀 방지)

검증: 해당 파일 15/15 통과, 인접 테스트(whitelist-status, player-file-service) 41/41 통과, `tsc` 빌드 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
