### PR TITLE
fix(worlds): 월드별 사용 서버 목록 표시 (shared+api+console) (#487)

### DIFF
--- a/platform/services/mcctl-api/src/routes/worlds.ts
+++ b/platform/services/mcctl-api/src/routes/worlds.ts
@@ -109,6 +109,7 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
           lockedBy: world.lockedBy,
           size: world.size,
           lastModified: world.lastModified?.toISOString(),
+          servers: world.servers,
         })),
         total: worlds.length,
       });
@@ -160,6 +161,7 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
           lockedBy: world.lockedBy,
           size: world.size,
           lastModified: world.lastModified?.toISOString(),
+          servers: world.servers,
         },
       });
     } catch (error) {

--- a/platform/services/mcctl-api/src/schemas/world.ts
+++ b/platform/services/mcctl-api/src/schemas/world.ts
@@ -14,6 +14,7 @@ export const WorldSummarySchema = Type.Object({
   lockedBy: Type.Optional(Type.String()),
   size: Type.String(),
   lastModified: Type.Optional(Type.String({ format: 'date-time' })),
+  servers: Type.Array(Type.String()),
 });
 
 /**
@@ -26,6 +27,7 @@ export const WorldDetailSchema = Type.Object({
   lockedBy: Type.Optional(Type.String()),
   size: Type.String(),
   lastModified: Type.Optional(Type.String({ format: 'date-time' })),
+  servers: Type.Array(Type.String()),
 });
 
 // ========================================

--- a/platform/services/mcctl-api/tests/worlds-servers.test.ts
+++ b/platform/services/mcctl-api/tests/worlds-servers.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_PLATFORM_PATH = join(import.meta.dirname, '.tmp-worlds-servers-test');
+
+// Set env BEFORE imports so config + Paths resolve to the fixture.
+process.env.MCCTL_ROOT = TEST_PLATFORM_PATH;
+process.env.PLATFORM_PATH = TEST_PLATFORM_PATH;
+process.env.AUTH_MODE = 'disabled';
+process.env.NODE_ENV = 'test';
+
+function makeWorld(name: string) {
+  mkdirSync(join(TEST_PLATFORM_PATH, 'worlds', name), { recursive: true });
+}
+
+function makeServer(name: string, env: Record<string, string>) {
+  const dir = join(TEST_PLATFORM_PATH, 'servers', name);
+  mkdirSync(dir, { recursive: true });
+  const content = Object.entries(env).map(([k, v]) => `${k}=${v}`).join('\n') + '\n';
+  writeFileSync(join(dir, 'config.env'), content, 'utf-8');
+}
+
+describe('GET /api/worlds - servers using each world', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    if (existsSync(TEST_PLATFORM_PATH)) {
+      rmSync(TEST_PLATFORM_PATH, { recursive: true, force: true });
+    }
+    // Backup-schedule plugin needs a writable meta dir for its sqlite db.
+    mkdirSync(join(TEST_PLATFORM_PATH, 'backups', 'meta'), { recursive: true });
+    mkdirSync(join(TEST_PLATFORM_PATH, 'worlds'), { recursive: true });
+    mkdirSync(join(TEST_PLATFORM_PATH, 'servers'), { recursive: true });
+
+    makeWorld('shared-world');
+    makeWorld('solo');
+    makeServer('alpha', { TYPE: 'PAPER', LEVEL: 'shared-world' });
+    makeServer('beta', { TYPE: 'PAPER', LEVEL: 'shared-world' });
+    makeServer('solo', { TYPE: 'PAPER' }); // no LEVEL → owns worlds/solo
+
+    const { config } = await import('../src/config/index.js');
+    (config as any).platformPath = TEST_PLATFORM_PATH;
+    (config as any).mcctlRoot = TEST_PLATFORM_PATH;
+
+    const { buildApp } = await import('../src/app.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    if (existsSync(TEST_PLATFORM_PATH)) {
+      rmSync(TEST_PLATFORM_PATH, { recursive: true, force: true });
+    }
+  });
+
+  it('includes the list of servers using each world in the list response', async () => {
+    const response = await app.inject({ method: 'GET', url: '/api/worlds' });
+    expect(response.statusCode).toBe(200);
+
+    const json = response.json();
+    const shared = json.worlds.find((w: { name: string }) => w.name === 'shared-world');
+    const solo = json.worlds.find((w: { name: string }) => w.name === 'solo');
+
+    expect(shared.servers.sort()).toEqual(['alpha', 'beta']);
+    expect(solo.servers).toEqual(['solo']);
+  });
+
+  it('includes the servers list in the world detail response', async () => {
+    const response = await app.inject({ method: 'GET', url: '/api/worlds/shared-world' });
+    expect(response.statusCode).toBe(200);
+
+    const json = response.json();
+    expect(json.world.servers.sort()).toEqual(['alpha', 'beta']);
+  });
+});

--- a/platform/services/mcctl-console/src/components/worlds/WorldCard.test.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldCard.test.tsx
@@ -128,4 +128,17 @@ describe('WorldCard', () => {
     renderWithTheme(<WorldCard world={worldNoSize} />);
     expect(screen.getByText('Unknown size')).toBeInTheDocument();
   });
+
+  it('should render the names of servers using the world', () => {
+    const worldWithServers: World = { ...mockAvailableWorld, servers: ['alpha', 'beta'] };
+    renderWithTheme(<WorldCard world={worldWithServers} />);
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+  });
+
+  it('should indicate when no servers use the world', () => {
+    const worldNoServers: World = { ...mockAvailableWorld, servers: [] };
+    renderWithTheme(<WorldCard world={worldNoServers} />);
+    expect(screen.getByText('No servers')).toBeInTheDocument();
+  });
 });

--- a/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
@@ -12,6 +12,7 @@ import LinkIcon from '@mui/icons-material/Link';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import DeleteIcon from '@mui/icons-material/Delete';
 import StorageIcon from '@mui/icons-material/Storage';
+import DnsIcon from '@mui/icons-material/Dns';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import type { World } from '@/ports/api/IMcctlApiClient';
 
@@ -50,7 +51,6 @@ export function WorldCard({ world, onAssign, onRelease, onDelete, loading = fals
       role="article"
       sx={{
         transition: 'all 0.2s',
-        height: { xs: 'auto', sm: 200 },
         minHeight: { xs: 160, sm: 200 },
         display: 'flex',
         flexDirection: 'column',
@@ -112,6 +112,20 @@ export function WorldCard({ world, onAssign, onRelease, onDelete, loading = fals
             </Tooltip>
           </Box>
         )}
+
+        {/* Servers using this world */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5, flexWrap: 'wrap' }}>
+          <DnsIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+          {world.servers && world.servers.length > 0 ? (
+            world.servers.map((server) => (
+              <Chip key={server} label={server} size="small" variant="outlined" />
+            ))
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No servers
+            </Typography>
+          )}
+        </Box>
 
         {/* Last Modified */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -104,6 +104,8 @@ export interface World {
   lockedBy?: string;
   size?: string;
   lastModified?: string;
+  /** Names of servers configured to use this world. */
+  servers?: string[];
 }
 
 export interface WorldListResponse {

--- a/platform/services/shared/src/application/ports/inbound/IWorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/ports/inbound/IWorldManagementUseCase.ts
@@ -76,6 +76,8 @@ export interface WorldListResult {
   lockedBy?: string;
   size: string;
   lastModified?: Date;
+  /** Names of servers configured to use this world (via their LEVEL config). */
+  servers: string[];
 }
 
 /**

--- a/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
@@ -276,8 +276,10 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
   /**
    * Build a reverse map of world name -> server names that use it.
    *
-   * A server's world directory is its LEVEL config value; when LEVEL is unset
-   * the server owns worlds/<server-name>, so it defaults to the server name.
+   * A server's world directory is its LEVEL config value (or the WORLD_NAME
+   * alias); when neither is set the server owns worlds/<server-name>, so it
+   * defaults to the server name. This mirrors the world-name precedence used
+   * for detailed server info (LEVEL > WORLD_NAME > server name).
    */
   private async getServersByWorld(): Promise<Map<string, string[]>> {
     const names = await this.serverRepo.listNames();
@@ -287,7 +289,10 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
       const config = await this.serverRepo.getConfig(name);
       if (!config) continue;
 
-      const level = config.customEnv?.['LEVEL']?.trim() || name;
+      const level =
+        config.customEnv?.['LEVEL']?.trim() ||
+        config.customEnv?.['WORLD_NAME']?.trim() ||
+        name;
       const servers = map.get(level) ?? [];
       servers.push(name);
       map.set(level, servers);

--- a/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
@@ -260,6 +260,7 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
    */
   async listWorlds(): Promise<WorldListResult[]> {
     const worlds = await this.worldRepo.findAll();
+    const serversByWorld = await this.getServersByWorld();
 
     return worlds.map((world) => ({
       name: world.name,
@@ -268,7 +269,31 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
       lockedBy: world.lockedBy,
       size: world.sizeFormatted,
       lastModified: world.lastModified,
+      servers: serversByWorld.get(world.name) ?? [],
     }));
+  }
+
+  /**
+   * Build a reverse map of world name -> server names that use it.
+   *
+   * A server's world directory is its LEVEL config value; when LEVEL is unset
+   * the server owns worlds/<server-name>, so it defaults to the server name.
+   */
+  private async getServersByWorld(): Promise<Map<string, string[]>> {
+    const names = await this.serverRepo.listNames();
+    const map = new Map<string, string[]>();
+
+    for (const name of names) {
+      const config = await this.serverRepo.getConfig(name);
+      if (!config) continue;
+
+      const level = config.customEnv?.['LEVEL']?.trim() || name;
+      const servers = map.get(level) ?? [];
+      servers.push(name);
+      map.set(level, servers);
+    }
+
+    return map;
   }
 
   /**

--- a/platform/services/shared/tests/worldManagement-servers.test.ts
+++ b/platform/services/shared/tests/worldManagement-servers.test.ts
@@ -72,6 +72,29 @@ describe('WorldManagementUseCase.listWorlds - servers using each world', () => {
     expect(result.find((x) => x.name === 'other')?.servers).toEqual(['gamma']);
   });
 
+  test('falls back to WORLD_NAME when LEVEL is unset (matches docker world-name precedence)', async () => {
+    const serverRepo = makeServerRepo({
+      legacy: { WORLD_NAME: 'shared-world' }, // no LEVEL, uses WORLD_NAME alias
+    });
+    const useCase = makeUseCase(['shared-world'], serverRepo);
+
+    const result = await useCase.listWorlds();
+
+    expect(result.find((x) => x.name === 'shared-world')?.servers).toEqual(['legacy']);
+  });
+
+  test('prefers LEVEL over WORLD_NAME when both are set', async () => {
+    const serverRepo = makeServerRepo({
+      srv: { LEVEL: 'level-world', WORLD_NAME: 'name-world' },
+    });
+    const useCase = makeUseCase(['level-world', 'name-world'], serverRepo);
+
+    const result = await useCase.listWorlds();
+
+    expect(result.find((x) => x.name === 'level-world')?.servers).toEqual(['srv']);
+    expect(result.find((x) => x.name === 'name-world')?.servers).toEqual([]);
+  });
+
   test('defaults a server with no LEVEL to a world named after the server', async () => {
     const serverRepo = makeServerRepo({
       myserver: { TYPE: 'PAPER' }, // no LEVEL → owns worlds/myserver

--- a/platform/services/shared/tests/worldManagement-servers.test.ts
+++ b/platform/services/shared/tests/worldManagement-servers.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from 'vitest';
+import { WorldManagementUseCase } from '../src/application/use-cases/WorldManagementUseCase.js';
+import type {
+  IPromptPort,
+  IShellPort,
+  IWorldRepository,
+  IServerRepository,
+  ServerConfigData,
+} from '../src/application/ports/index.js';
+
+// Minimal stub world objects matching the fields listWorlds() reads.
+function world(name: string) {
+  return {
+    name,
+    path: `/worlds/${name}`,
+    isLocked: false,
+    lockedBy: undefined,
+    sizeFormatted: '1.0 MB',
+    lastModified: undefined,
+  };
+}
+
+function makeServerRepo(configs: Record<string, Record<string, string> | null>): IServerRepository {
+  return {
+    listNames: async () => Object.keys(configs),
+    getConfig: async (name: string): Promise<ServerConfigData | null> => {
+      const env = configs[name];
+      if (!env) return null;
+      return {
+        name,
+        type: env['TYPE'] ?? 'PAPER',
+        version: env['VERSION'] ?? 'LATEST',
+        customEnv: env,
+      } as ServerConfigData;
+    },
+  } as unknown as IServerRepository;
+}
+
+function makeUseCase(worlds: string[], serverRepo: IServerRepository) {
+  const worldRepo = {
+    findAll: async () => worlds.map(world),
+  } as unknown as IWorldRepository;
+  const prompt = {} as IPromptPort;
+  const shell = {} as IShellPort;
+  return new WorldManagementUseCase(prompt, shell, worldRepo, serverRepo);
+}
+
+describe('WorldManagementUseCase.listWorlds - servers using each world', () => {
+  test('maps a server to the world named by its LEVEL config', async () => {
+    const serverRepo = makeServerRepo({
+      survival: { LEVEL: 'shared-world' },
+    });
+    const useCase = makeUseCase(['shared-world'], serverRepo);
+
+    const result = await useCase.listWorlds();
+    const w = result.find((x) => x.name === 'shared-world');
+
+    expect(w?.servers).toEqual(['survival']);
+  });
+
+  test('lists multiple servers that share the same world', async () => {
+    const serverRepo = makeServerRepo({
+      alpha: { LEVEL: 'shared-world' },
+      beta: { LEVEL: 'shared-world' },
+      gamma: { LEVEL: 'other' },
+    });
+    const useCase = makeUseCase(['shared-world', 'other'], serverRepo);
+
+    const result = await useCase.listWorlds();
+
+    expect(result.find((x) => x.name === 'shared-world')?.servers?.sort()).toEqual(['alpha', 'beta']);
+    expect(result.find((x) => x.name === 'other')?.servers).toEqual(['gamma']);
+  });
+
+  test('defaults a server with no LEVEL to a world named after the server', async () => {
+    const serverRepo = makeServerRepo({
+      myserver: { TYPE: 'PAPER' }, // no LEVEL → owns worlds/myserver
+    });
+    const useCase = makeUseCase(['myserver'], serverRepo);
+
+    const result = await useCase.listWorlds();
+
+    expect(result.find((x) => x.name === 'myserver')?.servers).toEqual(['myserver']);
+  });
+
+  test('returns an empty server list for a world that no server uses', async () => {
+    const serverRepo = makeServerRepo({
+      survival: { LEVEL: 'survival' },
+    });
+    const useCase = makeUseCase(['unused-world'], serverRepo);
+
+    const result = await useCase.listWorlds();
+
+    expect(result.find((x) => x.name === 'unused-world')?.servers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Worlds 메뉴에서 월드가 어떤 서버들에 의해 사용되는지 표시되지 않던 문제를 전 계층(shared+api+console)에서 수정합니다. `Closes #487`

기존에는 월드의 단일 락 보유자(`lockedBy`)만 노출되어, `--world`로 여러 서버가 공유하는 월드의 사용 서버 목록이 보이지 않았습니다.

## Root Cause

서버→월드 관계는 각 서버 `config.env`의 `LEVEL=<world>`(기본값 `LEVEL=<server-name>`)로 결정되는데, **역방향(월드 기준 서버 목록)을 계산·노출하는 코드가 어느 계층에도 없었습니다.** 또한 API 응답 스키마에 `servers` 필드가 없어 Fastify 직렬화가 제거했을 것입니다.

## Changes (layer by layer)

### shared (`feat(shared)`)
- `WorldManagementUseCase.listWorlds()`가 각 월드에 `servers[]`를 부착. 모든 서버의 effective `LEVEL`(미설정 시 서버명)을 스캔해 역참조 맵 생성. `WorldListResult.servers` 추가.

### mcctl-api (`feat(api)`)
- `WorldSummarySchema`/`WorldDetailSchema`에 `servers: Type.Array(Type.String())` 추가(Fastify strip 방지).
- `GET /api/worlds`, `GET /api/worlds/:name`이 `servers`를 매핑.

### mcctl-console (`feat(console)`)
- `World` 타입에 `servers?: string[]` 추가.
- `WorldCard`가 사용 서버를 Chip 목록으로 렌더(+`No servers` 빈 상태). 카드 높이를 가변으로 변경해 목록이 잘리지 않도록.

기존 흐름(backend → Next.js proxy → `useWorlds` → `WorldList` → `WorldCard`)이 `servers`를 그대로 전달함을 확인.

## Tests (TDD)

- **shared**: `worldManagement-servers.test.ts` (4) — LEVEL 매핑, 다중 서버 공유, LEVEL 미설정 기본값, 미사용 월드 빈 배열.
- **api**: `worlds-servers.test.ts` (2) — `buildApp` + 임시 platformPath 픽스처로 list/detail 응답에 `servers` 포함 검증(직렬화 포함).
- **console**: `WorldCard.test.tsx` (+2, 총 17) — 서버 칩 렌더 / 빈 상태.

검증: shared 4/4, api 2/2, console 17/17 통과. shared·cli·api `tsc` 빌드 통과.

### Note: 사전 존재 tsc 에러
`mcctl-console`의 `ConfigSnapshotServerCard.test.tsx`, `ConfigSnapshotCompareBar.test.tsx`에 tsc 에러가 있으나 **develop에서도 동일하게 발생**하는 기존 문제이며 본 변경과 무관합니다.

## Out of Scope (follow-up)
- `ServerRepository.getConfig()`의 `worldName`이 `config['WORLD']`(다운로드 URL)을 읽는 의미상 결함은 별도 관심사라 본 PR 범위 밖(역참조는 `LEVEL`을 직접 사용해 회귀 위험 회피). 서버 엔티티의 WorldOptions 정합성은 후속 검토 권고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
