### PR TITLE
feat(worlds): Create World zip 업로드 + 로더별 안내 + 분할 차원 월드 통합 관리 (#490)

### DIFF
--- a/docs/console/installation.ko.md
+++ b/docs/console/installation.ko.md
@@ -177,6 +177,7 @@ docker compose -f docker-compose.admin.yml up -d
 | `LOG_LEVEL` | 로깅 레벨 | `info` |
 | `MCCTL_API_PORT` | API 서버 포트 | `5001` |
 | `MCCTL_CONSOLE_PORT` | 콘솔 포트 | `5000` |
+| `WORLD_UPLOAD_MAX_SIZE` | 월드 ZIP 업로드 최대 크기 (바이트, `POST /api/worlds/upload`) | `1073741824` (1 GB) |
 
 ### 접근 모드
 

--- a/docs/console/installation.md
+++ b/docs/console/installation.md
@@ -158,6 +158,7 @@ mcctl console init
 | `HOSTNAME` | Console server hostname | `0.0.0.0` |
 | `MCCTL_API_URL` | Internal API URL | `http://localhost:5001` |
 | `NODE_ENV` | Environment mode | `production` |
+| `WORLD_UPLOAD_MAX_SIZE` | Max world ZIP size in bytes for `POST /api/worlds/upload` | `1073741824` (1 GB) |
 
 ### PM2 Ecosystem Configuration
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",
-    "@types/node": "^20.19.0"
+    "@types/node": "^20.19.0",
+    "jszip": "^3.10.1"
   }
 }

--- a/e2e/tests/api-worlds-upload.spec.ts
+++ b/e2e/tests/api-worlds-upload.spec.ts
@@ -140,12 +140,15 @@ test.describe('POST /api/worlds/upload - Import World from Zip', () => {
       },
     });
 
-    // 400 when stack is running, any non-2xx otherwise (e.g. 404/503 when offline)
     if (response.status() >= 200 && response.status() < 300) {
-      // Unexpected success — the server accepted a nameless upload; warn but don't fail
-      console.warn('[warn] server accepted upload without ?name — endpoint may have changed');
-    } else {
+      // The server accepted a nameless upload — that's a real bug; fail loudly.
       expect(response.status()).toBe(400);
+    } else if (response.status() === 400) {
+      const body = await response.json();
+      expect(body.error).toBe('BadRequest');
+    } else {
+      // Offline / auth-gated (e.g. 401/connection error) — skip gracefully
+      console.log(`[skip] missing-name validation: server returned ${response.status()}`);
     }
   });
 
@@ -166,12 +169,14 @@ test.describe('POST /api/worlds/upload - Import World from Zip', () => {
       }
     );
 
-    if (response.status() === 400) {
+    if (response.status() >= 200 && response.status() < 300) {
+      // The server accepted a non-zip upload — that's a real bug; fail loudly.
+      expect(response.status()).toBe(400);
+    } else if (response.status() === 400) {
       const body = await response.json();
-      // Should be an error response
-      expect(body.success ?? false).toBeFalsy();
+      expect(body.error).toBe('BadRequest');
     } else {
-      // Stack not running or endpoint not available — skip gracefully
+      // Offline / auth-gated — skip gracefully
       console.log(`[skip] non-zip validation: server returned ${response.status()}`);
     }
   });

--- a/e2e/tests/api-worlds-upload.spec.ts
+++ b/e2e/tests/api-worlds-upload.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+import JSZip from 'jszip';
+
+const API_BASE_URL = process.env.E2E_API_URL || 'http://localhost:5000';
+
+/**
+ * Build a zip Buffer containing the given entries.
+ * Each entry is a { path, content } pair; content can be any bytes.
+ */
+async function buildZipBuffer(entries: Array<{ path: string; content: Buffer | string }>): Promise<Buffer> {
+  const zip = new JSZip();
+  for (const entry of entries) {
+    zip.file(entry.path, entry.content);
+  }
+  const ab = await zip.generateAsync({ type: 'arraybuffer' });
+  return Buffer.from(ab);
+}
+
+/** Dummy level.dat content — the API only checks the filename, not the bytes. */
+const DUMMY_LEVEL_DAT = Buffer.from([0x0a, 0x00, 0x00]); // minimal NBT bytes
+
+test.describe('POST /api/worlds/upload - Import World from Zip', () => {
+  test('(a) single-folder import — happy path', async ({ request }) => {
+    const worldName = `e2e-upload-${Date.now()}`;
+
+    // Build a minimal zip: world/level.dat
+    const zipBuffer = await buildZipBuffer([
+      { path: 'world/level.dat', content: DUMMY_LEVEL_DAT },
+    ]);
+
+    const response = await request.post(
+      `${API_BASE_URL}/api/worlds/upload?name=${worldName}`,
+      {
+        multipart: {
+          worldZip: {
+            name: 'world.zip',
+            mimeType: 'application/zip',
+            buffer: zipBuffer,
+          },
+        },
+      }
+    );
+
+    if (response.status() === 201) {
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.worldName).toBe(worldName);
+
+      // Verify the world is retrievable
+      const getResponse = await request.get(`${API_BASE_URL}/api/worlds/${worldName}`);
+      expect(getResponse.status()).toBe(200);
+
+      // Cleanup
+      await request.delete(`${API_BASE_URL}/api/worlds/${worldName}?force=true`);
+    } else {
+      // Stack not running — skip gracefully
+      console.log(`[skip] single-folder upload: server returned ${response.status()}`);
+    }
+  });
+
+  test('(b) split-dimension import — nether and end folded into parent', async ({ request }) => {
+    const worldName = `e2e-split-${Date.now()}`;
+
+    // Build a zip with three dimension folders (Bukkit/Paper layout)
+    const zipBuffer = await buildZipBuffer([
+      { path: 'world/level.dat', content: DUMMY_LEVEL_DAT },
+      { path: 'world_nether/region.dat', content: Buffer.from([0x00]) },
+      { path: 'world_the_end/region.dat', content: Buffer.from([0x00]) },
+    ]);
+
+    const response = await request.post(
+      `${API_BASE_URL}/api/worlds/upload?name=${worldName}`,
+      {
+        multipart: {
+          worldZip: {
+            name: 'world.zip',
+            mimeType: 'application/zip',
+            buffer: zipBuffer,
+          },
+        },
+      }
+    );
+
+    if (response.status() === 201) {
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.worldName).toBe(worldName);
+
+      // GET /api/worlds — parent world must appear with dimensions, satellites must NOT appear
+      const listResponse = await request.get(`${API_BASE_URL}/api/worlds`);
+      expect(listResponse.status()).toBe(200);
+
+      const listBody = await listResponse.json();
+      const worlds: Array<{ name: string; dimensions?: { nether: boolean; end: boolean } }> =
+        listBody.worlds ?? [];
+
+      // Parent exists with both dimensions set to true
+      const parent = worlds.find((w) => w.name === worldName);
+      expect(parent).toBeDefined();
+      expect(parent?.dimensions?.nether).toBe(true);
+      expect(parent?.dimensions?.end).toBe(true);
+
+      // Satellite entries must NOT be listed as independent worlds
+      const netherEntry = worlds.find((w) => w.name === `${worldName}_nether`);
+      const endEntry = worlds.find((w) => w.name === `${worldName}_the_end`);
+      expect(netherEntry).toBeUndefined();
+      expect(endEntry).toBeUndefined();
+
+      // Cleanup parent (satellites should be removed automatically)
+      const deleteResponse = await request.delete(
+        `${API_BASE_URL}/api/worlds/${worldName}?force=true`
+      );
+      if (deleteResponse.status() === 200) {
+        // Confirm satellites are gone from the list
+        const afterDelete = await request.get(`${API_BASE_URL}/api/worlds`);
+        if (afterDelete.status() === 200) {
+          const afterBody = await afterDelete.json();
+          const afterWorlds: Array<{ name: string }> = afterBody.worlds ?? [];
+          expect(afterWorlds.find((w) => w.name === `${worldName}_nether`)).toBeUndefined();
+          expect(afterWorlds.find((w) => w.name === `${worldName}_the_end`)).toBeUndefined();
+        }
+      }
+    } else {
+      console.log(`[skip] split-dimension upload: server returned ${response.status()}`);
+    }
+  });
+
+  test('(c1) validation — missing name query param returns 400', async ({ request }) => {
+    const zipBuffer = await buildZipBuffer([
+      { path: 'world/level.dat', content: DUMMY_LEVEL_DAT },
+    ]);
+
+    const response = await request.post(`${API_BASE_URL}/api/worlds/upload`, {
+      multipart: {
+        worldZip: {
+          name: 'world.zip',
+          mimeType: 'application/zip',
+          buffer: zipBuffer,
+        },
+      },
+    });
+
+    // 400 when stack is running, any non-2xx otherwise (e.g. 404/503 when offline)
+    if (response.status() >= 200 && response.status() < 300) {
+      // Unexpected success — the server accepted a nameless upload; warn but don't fail
+      console.warn('[warn] server accepted upload without ?name — endpoint may have changed');
+    } else {
+      expect(response.status()).toBe(400);
+    }
+  });
+
+  test('(c2) validation — non-zip file part returns 400', async ({ request }) => {
+    const worldName = `e2e-upload-badtype-${Date.now()}`;
+    const textBuffer = Buffer.from('this is not a zip file');
+
+    const response = await request.post(
+      `${API_BASE_URL}/api/worlds/upload?name=${worldName}`,
+      {
+        multipart: {
+          worldZip: {
+            name: 'notes.txt',
+            mimeType: 'text/plain',
+            buffer: textBuffer,
+          },
+        },
+      }
+    );
+
+    if (response.status() === 400) {
+      const body = await response.json();
+      // Should be an error response
+      expect(body.success ?? false).toBeFalsy();
+    } else {
+      // Stack not running or endpoint not available — skip gracefully
+      console.log(`[skip] non-zip validation: server returned ${response.status()}`);
+    }
+  });
+});

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -114,6 +114,11 @@ NEXTAUTH_URL=http://localhost:5000
 # --- Upload Limits ---
 # Maximum size (bytes) of a world ZIP file for POST /api/worlds/upload (default: 1073741824 = 1 GB)
 # WORLD_UPLOAD_MAX_SIZE=1073741824
+# Maximum total *uncompressed* size (bytes) when extracting a world ZIP — guards against
+# decompression bombs (default: 5368709120 = 5 GB)
+# WORLD_EXTRACT_MAX_SIZE=5368709120
+# Maximum number of entries allowed in a world ZIP (default: 100000)
+# WORLD_EXTRACT_MAX_ENTRIES=100000
 
 # --- CORS Configuration ---
 # Allowed origins for API requests (comma-separated)

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -111,6 +111,10 @@ NEXTAUTH_SECRET=change-me-in-production
 # Public URL for NextAuth callbacks
 NEXTAUTH_URL=http://localhost:5000
 
+# --- Upload Limits ---
+# Maximum size (bytes) of a world ZIP file for POST /api/worlds/upload (default: 1073741824 = 1 GB)
+# WORLD_UPLOAD_MAX_SIZE=1073741824
+
 # --- CORS Configuration ---
 # Allowed origins for API requests (comma-separated)
 MCCTL_CORS_ORIGIN=http://localhost:5000

--- a/platform/services/mcctl-api/package.json
+++ b/platform/services/mcctl-api/package.json
@@ -69,6 +69,7 @@
     "@types/bcrypt": "^6.0.0",
     "@types/node": "^22.13.1",
     "@types/node-cron": "^3.0.11",
+    "jszip": "^3.10.1",
     "tsx": "^4.19.2",
     "typescript": "^5.3.0",
     "vitest": "^2.1.8"

--- a/platform/services/mcctl-api/src/routes/worlds.ts
+++ b/platform/services/mcctl-api/src/routes/worlds.ts
@@ -1,5 +1,11 @@
 import { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
 import fp from 'fastify-plugin';
+import { join, basename } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+import { createWriteStream } from 'fs';
+import { rm } from 'fs/promises';
+import { pipeline } from 'stream/promises';
 import {
   WorldManagementUseCase,
   ApiPromptAdapter,
@@ -23,11 +29,13 @@ import {
   AssignWorldRequestSchema,
   DeleteWorldQuerySchema,
   ReleaseWorldQuerySchema,
+  UploadWorldQuerySchema,
   type WorldNameParams,
   type CreateWorldRequest,
   type AssignWorldRequest,
   type DeleteWorldQuery,
   type ReleaseWorldQuery,
+  type UploadWorldQuery,
 } from '../schemas/world.js';
 
 // Route generic interfaces for type-safe request handling
@@ -54,6 +62,10 @@ interface DeleteWorldRoute {
   Querystring: DeleteWorldQuery;
 }
 
+interface UploadWorldRoute {
+  Querystring: UploadWorldQuery;
+}
+
 /**
  * Create WorldManagementUseCase instance with API adapters
  */
@@ -78,8 +90,17 @@ function createWorldUseCase(options?: {
 }
 
 /**
+ * Default max upload size for world zip files: 1 GB
+ */
+const WORLD_UPLOAD_MAX_SIZE = Number(process.env['WORLD_UPLOAD_MAX_SIZE']) || 1024 * 1024 * 1024;
+
+/**
  * Worlds routes plugin
  * Provides REST API for Minecraft world management
+ *
+ * Note: @fastify/multipart is registered globally by server-files-routes (via fp()),
+ * so we do NOT re-register it here. The per-request file-size limit for the upload
+ * endpoint is passed directly to request.parts().
  */
 const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
   /**
@@ -110,6 +131,7 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
           size: world.size,
           lastModified: world.lastModified?.toISOString(),
           servers: world.servers,
+          dimensions: world.dimensions,
         })),
         total: worlds.length,
       });
@@ -162,6 +184,7 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
           size: world.size,
           lastModified: world.lastModified?.toISOString(),
           servers: world.servers,
+          dimensions: world.dimensions,
         },
       });
     } catch (error) {
@@ -519,6 +542,167 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         error: 'InternalServerError',
         message: 'Failed to delete world',
       });
+    }
+  });
+  /**
+   * POST /api/worlds/upload
+   * Import a world from a zip file upload (multipart/form-data)
+   *
+   * Query parameters:
+   *   - name: world name (required, pattern: ^[a-zA-Z0-9_-]+$)
+   *   - seed: optional seed (ignored by import; stored for reference only)
+   *
+   * The request body must be multipart/form-data containing exactly one .zip file part.
+   */
+  fastify.post<UploadWorldRoute>('/api/worlds/upload', {
+    schema: {
+      tags: ['worlds'],
+      summary: 'Import world from zip',
+      description:
+        'Imports a Minecraft world by uploading a .zip archive (multipart/form-data). ' +
+        'The zip must contain a level.dat file. World name is provided as a query parameter.',
+      consumes: ['multipart/form-data'],
+      querystring: UploadWorldQuerySchema,
+      response: {
+        201: CreateWorldResponseSchema,
+        400: WorldErrorResponseSchema,
+        409: WorldErrorResponseSchema,
+        413: WorldErrorResponseSchema,
+        500: WorldErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<UploadWorldRoute>, reply: FastifyReply) => {
+    const { name } = request.query;
+
+    // 1. Pre-check for duplicate world name
+    try {
+      const checkUseCase = createWorldUseCase({ worldName: name });
+      const existing = (await checkUseCase.listWorlds()).find((w) => w.name === name);
+      if (existing) {
+        return reply.code(409).send({
+          error: 'Conflict',
+          message: `World '${name}' already exists`,
+        });
+      }
+    } catch (error) {
+      fastify.log.error(error, 'Failed to check for duplicate world');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to check world existence',
+      });
+    }
+
+    // 2. Stream the uploaded zip to a temp file
+    const tempZip = join(tmpdir(), `mcctl-world-upload-${randomUUID()}.zip`);
+    let uploadedFilename = '';
+
+    try {
+      // Pass per-request file-size limit (the global multipart registration uses a
+      // smaller limit for server file uploads; world zips can be up to 1 GB).
+      const parts = request.parts({ limits: { fileSize: WORLD_UPLOAD_MAX_SIZE } });
+      let foundFile = false;
+
+      for await (const part of parts) {
+        if (part.type !== 'file') continue;
+
+        // Check file extension
+        const originalName = part.filename ?? '';
+        if (!originalName.toLowerCase().endsWith('.zip')) {
+          // Drain the stream to avoid backpressure issues
+          part.file.resume();
+          // Drain remaining parts
+          for await (const _remaining of parts) { /* consume */ }
+          return reply.code(400).send({
+            error: 'BadRequest',
+            message: 'Only .zip files are accepted',
+          });
+        }
+
+        uploadedFilename = basename(originalName);
+        foundFile = true;
+
+        // Stream to temp file
+        await pipeline(part.file, createWriteStream(tempZip));
+
+        if (part.file.truncated) {
+          await rm(tempZip, { force: true });
+          return reply.code(413).send({
+            error: 'PayloadTooLarge',
+            message: `Uploaded file exceeds the ${WORLD_UPLOAD_MAX_SIZE / 1024 / 1024}MB size limit`,
+          });
+        }
+
+        // Only process the first file part
+        break;
+      }
+
+      if (!foundFile) {
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: 'A .zip file is required (no file part found in the request)',
+        });
+      }
+    } catch (error) {
+      await rm(tempZip, { force: true });
+      fastify.log.error(error, 'Failed to receive uploaded zip');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to receive uploaded file',
+      });
+    }
+
+    // 3. Import the world from the temp zip
+    try {
+      const useCase = createWorldUseCase({ worldName: name });
+      const result = await useCase.importWorldFromZip({ zipPath: tempZip, worldName: name });
+
+      if (!result.success) {
+        await writeAuditLog({
+          action: AuditActionEnum.WORLD_CREATE,
+          actor: 'api:console',
+          targetType: 'world',
+          targetName: name,
+          details: { source: 'upload', filename: uploadedFilename },
+          status: 'failure',
+          errorMessage: result.error ?? 'Import failed',
+        });
+        return reply.code(400).send({
+          error: 'BadRequest',
+          message: result.error ?? 'Failed to import world from zip',
+        });
+      }
+
+      await writeAuditLog({
+        action: AuditActionEnum.WORLD_CREATE,
+        actor: 'api:console',
+        targetType: 'world',
+        targetName: result.worldName,
+        details: { source: 'upload', filename: uploadedFilename },
+        status: 'success',
+      });
+
+      return reply.code(201).send({
+        success: true,
+        worldName: result.worldName,
+      });
+    } catch (error) {
+      await writeAuditLog({
+        action: AuditActionEnum.WORLD_CREATE,
+        actor: 'api:console',
+        targetType: 'world',
+        targetName: name,
+        details: { source: 'upload', filename: uploadedFilename },
+        status: 'failure',
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      });
+      fastify.log.error(error, 'Failed to import world from zip');
+      return reply.code(500).send({
+        error: 'InternalServerError',
+        message: 'Failed to import world',
+      });
+    } finally {
+      // Always clean up temp zip
+      await rm(tempZip, { force: true });
     }
   });
 };

--- a/platform/services/mcctl-api/src/routes/worlds.ts
+++ b/platform/services/mcctl-api/src/routes/worlds.ts
@@ -576,7 +576,7 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 
     // 1. Pre-check for duplicate world name
     try {
-      const checkUseCase = createWorldUseCase({ worldName: name });
+      const checkUseCase = createWorldUseCase(); // listWorlds doesn't use the prompt adapter
       const existing = (await checkUseCase.listWorlds()).find((w) => w.name === name);
       if (existing) {
         return reply.code(409).send({
@@ -626,6 +626,12 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 
         if (part.file.truncated) {
           await rm(tempZip, { force: true });
+          // Drain remaining parts so the connection terminates cleanly.
+          try {
+            for await (const _remaining of parts) { /* consume */ }
+          } catch {
+            /* ignore */
+          }
           return reply.code(413).send({
             error: 'PayloadTooLarge',
             message: `Uploaded file exceeds the ${WORLD_UPLOAD_MAX_SIZE / 1024 / 1024}MB size limit`,
@@ -666,6 +672,14 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
           status: 'failure',
           errorMessage: result.error ?? 'Import failed',
         });
+        // Keep the duplicate-world status consistent with the pre-check (409),
+        // even when the collision is only detected during import (TOCTOU).
+        if (result.error?.includes('already exists')) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            message: result.error,
+          });
+        }
         return reply.code(400).send({
           error: 'BadRequest',
           message: result.error ?? 'Failed to import world from zip',

--- a/platform/services/mcctl-api/src/schemas/world.ts
+++ b/platform/services/mcctl-api/src/schemas/world.ts
@@ -15,6 +15,10 @@ export const WorldSummarySchema = Type.Object({
   size: Type.String(),
   lastModified: Type.Optional(Type.String({ format: 'date-time' })),
   servers: Type.Array(Type.String()),
+  dimensions: Type.Optional(Type.Object({
+    nether: Type.Boolean(),
+    end: Type.Boolean(),
+  })),
 });
 
 /**
@@ -28,6 +32,10 @@ export const WorldDetailSchema = Type.Object({
   size: Type.String(),
   lastModified: Type.Optional(Type.String({ format: 'date-time' })),
   servers: Type.Array(Type.String()),
+  dimensions: Type.Optional(Type.Object({
+    nether: Type.Boolean(),
+    end: Type.Boolean(),
+  })),
 });
 
 // ========================================
@@ -63,6 +71,14 @@ export const AssignWorldRequestSchema = Type.Object({
  */
 export const DeleteWorldQuerySchema = Type.Object({
   force: Type.Optional(Type.Boolean({ default: false })),
+});
+
+/**
+ * Upload world query parameters (multipart route)
+ */
+export const UploadWorldQuerySchema = Type.Object({
+  name: Type.String({ minLength: 1, pattern: '^[a-zA-Z0-9_-]+$' }),
+  seed: Type.Optional(Type.String()),
 });
 
 /**
@@ -152,6 +168,7 @@ export type CreateWorldRequest = Static<typeof CreateWorldRequestSchema>;
 export type AssignWorldRequest = Static<typeof AssignWorldRequestSchema>;
 export type DeleteWorldQuery = Static<typeof DeleteWorldQuerySchema>;
 export type ReleaseWorldQuery = Static<typeof ReleaseWorldQuerySchema>;
+export type UploadWorldQuery = Static<typeof UploadWorldQuerySchema>;
 export type WorldListResponse = Static<typeof WorldListResponseSchema>;
 export type WorldDetailResponse = Static<typeof WorldDetailResponseSchema>;
 export type CreateWorldResponse = Static<typeof CreateWorldResponseSchema>;

--- a/platform/services/mcctl-api/tests/worlds-upload.test.ts
+++ b/platform/services/mcctl-api/tests/worlds-upload.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for POST /api/worlds/upload (multipart zip import)
+ *
+ * Coverage:
+ *  - Schema validation: bad world name pattern → 400
+ *  - No file part → 400
+ *  - Non-zip filename → 400
+ *  - Duplicate world name → 409
+ *  - Happy-path: valid zip with level.dat → 201
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import JSZip from 'jszip';
+
+const TEST_PLATFORM_PATH = join(import.meta.dirname, '.tmp-worlds-upload-test');
+
+// Set env BEFORE imports so config + Paths resolve to the fixture.
+process.env.MCCTL_ROOT = TEST_PLATFORM_PATH;
+process.env.PLATFORM_PATH = TEST_PLATFORM_PATH;
+process.env.AUTH_MODE = 'disabled';
+process.env.NODE_ENV = 'test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal multipart/form-data body for Fastify inject.
+ * Supports file parts only (no field parts needed for this route).
+ */
+function buildMultipartBody(
+  boundary: string,
+  files: Array<{ fieldName: string; filename: string; content: Buffer; contentType?: string }>,
+): Buffer {
+  const parts: Buffer[] = [];
+
+  for (const file of files) {
+    const ct = file.contentType ?? 'application/octet-stream';
+    parts.push(
+      Buffer.from(
+        `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="${file.fieldName}"; filename="${file.filename}"\r\n` +
+          `Content-Type: ${ct}\r\n` +
+          `\r\n`,
+      ),
+    );
+    parts.push(file.content);
+    parts.push(Buffer.from('\r\n'));
+  }
+
+  parts.push(Buffer.from(`--${boundary}--\r\n`));
+  return Buffer.concat(parts);
+}
+
+/**
+ * Build a multipart body with no file parts (empty body, just closing boundary).
+ */
+function buildEmptyMultipartBody(boundary: string): Buffer {
+  return Buffer.from(`--${boundary}--\r\n`);
+}
+
+/**
+ * Create a valid zip buffer containing a level.dat file using JSZip.
+ * The zip structure is: world/level.dat
+ */
+async function buildValidWorldZip(): Promise<Buffer> {
+  const zip = new JSZip();
+  // Minimal level.dat content (just needs to exist as a file)
+  zip.folder('world')!.file('level.dat', Buffer.from('NBTDATA'));
+  return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('POST /api/worlds/upload', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    if (existsSync(TEST_PLATFORM_PATH)) {
+      rmSync(TEST_PLATFORM_PATH, { recursive: true, force: true });
+    }
+    mkdirSync(join(TEST_PLATFORM_PATH, 'backups', 'meta'), { recursive: true });
+    mkdirSync(join(TEST_PLATFORM_PATH, 'worlds'), { recursive: true });
+    mkdirSync(join(TEST_PLATFORM_PATH, 'servers'), { recursive: true });
+
+    const { config } = await import('../src/config/index.js');
+    (config as Record<string, unknown>).platformPath = TEST_PLATFORM_PATH;
+    (config as Record<string, unknown>).mcctlRoot = TEST_PLATFORM_PATH;
+
+    const { buildApp } = await import('../src/app.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    if (existsSync(TEST_PLATFORM_PATH)) {
+      rmSync(TEST_PLATFORM_PATH, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Schema validation (caught by Fastify before handler runs)
+  // -------------------------------------------------------------------------
+
+  it('returns 400 when world name contains invalid characters', async () => {
+    const boundary = 'boundary123';
+    const body = buildEmptyMultipartBody(boundary);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload?name=Invalid%20Name!',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 400 when name query parameter is missing', async () => {
+    const boundary = 'boundary123';
+    const body = buildEmptyMultipartBody(boundary);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  // -------------------------------------------------------------------------
+  // Handler-level validations
+  // -------------------------------------------------------------------------
+
+  it('returns 400 when no file part is included in the multipart body', async () => {
+    const boundary = 'boundarynoop';
+    const body = buildEmptyMultipartBody(boundary);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload?name=my-world',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(400);
+    const json = response.json<{ error: string; message: string }>();
+    expect(json.error).toBe('BadRequest');
+    expect(json.message).toContain('zip file');
+  });
+
+  it('returns 400 when the uploaded file is not a .zip', async () => {
+    const boundary = 'boundarytxt';
+    const body = buildMultipartBody(boundary, [
+      {
+        fieldName: 'file',
+        filename: 'world.tar.gz',
+        content: Buffer.from('not a zip'),
+        contentType: 'application/gzip',
+      },
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload?name=my-world',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(400);
+    const json = response.json<{ error: string; message: string }>();
+    expect(json.error).toBe('BadRequest');
+    expect(json.message).toContain('.zip');
+  });
+
+  it('returns 400 when a .txt file is uploaded instead of .zip', async () => {
+    const boundary = 'boundarytxt2';
+    const body = buildMultipartBody(boundary, [
+      {
+        fieldName: 'file',
+        filename: 'README.txt',
+        content: Buffer.from('hello world'),
+        contentType: 'text/plain',
+      },
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload?name=my-world',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(400);
+    const json = response.json<{ error: string; message: string }>();
+    expect(json.error).toBe('BadRequest');
+  });
+
+  it('returns 409 when a world with the same name already exists', async () => {
+    // Pre-create the world directory to simulate an existing world
+    mkdirSync(join(TEST_PLATFORM_PATH, 'worlds', 'existing-world'), { recursive: true });
+    // Create a minimal level.dat so it is recognized as a valid world
+    writeFileSync(join(TEST_PLATFORM_PATH, 'worlds', 'existing-world', 'level.dat'), 'NBT');
+
+    const boundary = 'boundarydup';
+    const body = buildEmptyMultipartBody(boundary);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload?name=existing-world',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(409);
+    const json = response.json<{ error: string; message: string }>();
+    expect(json.error).toBe('Conflict');
+    expect(json.message).toContain('already exists');
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path: valid zip → 201
+  // -------------------------------------------------------------------------
+
+  it('returns 201 and worldName when a valid world zip is uploaded', async () => {
+    const zipBuffer = await buildValidWorldZip();
+    const boundary = 'boundaryhappy';
+    const body = buildMultipartBody(boundary, [
+      {
+        fieldName: 'file',
+        filename: 'my-world.zip',
+        content: zipBuffer,
+        contentType: 'application/zip',
+      },
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload?name=my-world',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(201);
+    const json = response.json<{ success: boolean; worldName: string }>();
+    expect(json.success).toBe(true);
+    expect(json.worldName).toBe('my-world');
+
+    // Verify the world was created on disk
+    expect(existsSync(join(TEST_PLATFORM_PATH, 'worlds', 'my-world'))).toBe(true);
+    expect(existsSync(join(TEST_PLATFORM_PATH, 'worlds', 'my-world', 'level.dat'))).toBe(true);
+  });
+});

--- a/platform/services/mcctl-api/tests/worlds-upload.test.ts
+++ b/platform/services/mcctl-api/tests/worlds-upload.test.ts
@@ -73,6 +73,18 @@ async function buildValidWorldZip(): Promise<Buffer> {
   return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
 }
 
+/**
+ * Create a split-dimension (Bukkit/Paper) zip:
+ *   world/level.dat, world_nether/..., world_the_end/...
+ */
+async function buildSplitWorldZip(): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.folder('world')!.file('level.dat', Buffer.from('NBTDATA'));
+  zip.folder('world_nether')!.file('region/r.0.0.mca', Buffer.from([0]));
+  zip.folder('world_the_end')!.file('region/r.0.0.mca', Buffer.from([0]));
+  return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
@@ -257,5 +269,33 @@ describe('POST /api/worlds/upload', () => {
     // Verify the world was created on disk
     expect(existsSync(join(TEST_PLATFORM_PATH, 'worlds', 'my-world'))).toBe(true);
     expect(existsSync(join(TEST_PLATFORM_PATH, 'worlds', 'my-world', 'level.dat'))).toBe(true);
+  });
+
+  it('returns 201 and places split-dimension satellites as siblings', async () => {
+    const zipBuffer = await buildSplitWorldZip();
+    const boundary = 'boundarysplit';
+    const body = buildMultipartBody(boundary, [
+      {
+        fieldName: 'file',
+        filename: 'split.zip',
+        content: zipBuffer,
+        contentType: 'application/zip',
+      },
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/upload?name=split-world',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(response.statusCode).toBe(201);
+
+    // Main world + both satellites land as siblings under worlds/
+    const worldsDir = join(TEST_PLATFORM_PATH, 'worlds');
+    expect(existsSync(join(worldsDir, 'split-world', 'level.dat'))).toBe(true);
+    expect(existsSync(join(worldsDir, 'split-world_nether'))).toBe(true);
+    expect(existsSync(join(worldsDir, 'split-world_the_end'))).toBe(true);
   });
 });

--- a/platform/services/mcctl-console/src/app/(main)/worlds/page.test.tsx
+++ b/platform/services/mcctl-console/src/app/(main)/worlds/page.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/hooks/useMcctl', () => ({
   useWorlds: vi.fn(),
   useServers: vi.fn(),
   useCreateWorld: vi.fn(),
+  useCreateWorldWithZip: vi.fn(),
   useAssignWorld: vi.fn(),
   useReleaseWorld: vi.fn(),
   useDeleteWorld: vi.fn(),
@@ -25,6 +26,7 @@ import {
   useWorlds,
   useServers,
   useCreateWorld,
+  useCreateWorldWithZip,
   useAssignWorld,
   useReleaseWorld,
   useDeleteWorld,
@@ -100,6 +102,7 @@ const setupMocks = (overrides: { worldsLoading?: boolean; worldsError?: Error } 
   } as any);
 
   vi.mocked(useCreateWorld).mockReturnValue(mockMutation() as any);
+  vi.mocked(useCreateWorldWithZip).mockReturnValue(mockMutation() as any);
   vi.mocked(useAssignWorld).mockReturnValue(mockMutation() as any);
   vi.mocked(useReleaseWorld).mockReturnValue(mockMutation() as any);
   vi.mocked(useDeleteWorld).mockReturnValue(mockMutation() as any);

--- a/platform/services/mcctl-console/src/app/(main)/worlds/page.tsx
+++ b/platform/services/mcctl-console/src/app/(main)/worlds/page.tsx
@@ -23,6 +23,7 @@ import { AssignWorldDialog } from '@/components/worlds/AssignWorldDialog';
 import {
   useWorlds,
   useCreateWorld,
+  useCreateWorldWithZip,
   useAssignWorld,
   useReleaseWorld,
   useDeleteWorld,
@@ -44,16 +45,28 @@ export default function WorldsPage() {
 
   // Mutations
   const createWorld = useCreateWorld();
+  const createWorldWithZip = useCreateWorldWithZip();
   const assignWorld = useAssignWorld();
   const releaseWorld = useReleaseWorld();
   const deleteWorld = useDeleteWorld();
 
-  const handleCreateWorld = (request: CreateWorldRequest) => {
-    createWorld.mutate(request, {
-      onSuccess: () => {
-        setCreateDialogOpen(false);
-      },
-    });
+  const handleCreateWorld = (request: CreateWorldRequest, zipFile?: File | null) => {
+    if (zipFile) {
+      createWorldWithZip.mutate(
+        { data: request, zipFile },
+        {
+          onSuccess: () => {
+            setCreateDialogOpen(false);
+          },
+        }
+      );
+    } else {
+      createWorld.mutate(request, {
+        onSuccess: () => {
+          setCreateDialogOpen(false);
+        },
+      });
+    }
   };
 
   const handleAssignWorld = (worldName: string, serverName: string) => {
@@ -173,6 +186,12 @@ export default function WorldsPage() {
         </Alert>
       )}
 
+      {createWorldWithZip.isError && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Failed to import world: {createWorldWithZip.error?.message}
+        </Alert>
+      )}
+
       {assignWorld.isError && (
         <Alert severity="error" sx={{ mb: 3 }}>
           Failed to assign world: {assignWorld.error?.message}
@@ -211,9 +230,10 @@ export default function WorldsPage() {
         onClose={() => {
           setCreateDialogOpen(false);
           createWorld.reset();
+          createWorldWithZip.reset();
         }}
         onSubmit={handleCreateWorld}
-        loading={createWorld.isPending}
+        loading={createWorld.isPending || createWorldWithZip.isPending}
       />
 
       <AssignWorldDialog

--- a/platform/services/mcctl-console/src/app/api/worlds/upload/route.ts
+++ b/platform/services/mcctl-console/src/app/api/worlds/upload/route.ts
@@ -1,0 +1,86 @@
+/**
+ * World Zip Upload BFF Route (Streaming Proxy)
+ * POST /api/worlds/upload?name=<name>&seed=<seed>
+ *
+ * Proxies a multipart/form-data zip upload to mcctl-api without buffering.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, AuthError } from '@/lib/auth-utils';
+import { headers } from 'next/headers';
+
+export const dynamic = 'force-dynamic';
+
+// 1 GB + multipart overhead margin (~100 MB)
+const MAX_REQUEST_SIZE = 1024 * 1024 * 1024 + 110 * 1024 * 1024;
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await requireAuth(await headers());
+
+    // Early rejection for oversized requests at the BFF layer
+    const contentLength = request.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > MAX_REQUEST_SIZE) {
+      return NextResponse.json(
+        { error: 'PayloadTooLarge', message: 'Request body exceeds the maximum allowed size' },
+        { status: 413 }
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const name = searchParams.get('name');
+    if (!name) {
+      return NextResponse.json(
+        { error: 'BadRequest', message: 'name query parameter is required' },
+        { status: 400 }
+      );
+    }
+    const seed = searchParams.get('seed');
+
+    const apiUrl = process.env.MCCTL_API_URL || 'http://localhost:5001';
+    const apiKey = process.env.MCCTL_API_KEY || '';
+    const username = session.user.name || session.user.email;
+    const role = session.user.role || 'user';
+
+    const targetParams = new URLSearchParams({ name });
+    if (seed) targetParams.set('seed', seed);
+
+    const targetUrl = `${apiUrl}/api/worlds/upload?${targetParams.toString()}`;
+
+    const proxyHeaders: Record<string, string> = {
+      'X-API-Key': apiKey,
+      'X-User': username,
+      'X-Role': role,
+    };
+
+    // Forward Content-Type (includes the multipart boundary)
+    const contentType = request.headers.get('content-type');
+    if (contentType) {
+      proxyHeaders['Content-Type'] = contentType;
+    }
+
+    const response = await fetch(targetUrl, {
+      method: 'POST',
+      headers: proxyHeaders,
+      body: request.body,
+      // @ts-expect-error -- Node.js fetch supports duplex for streaming request bodies
+      duplex: 'half',
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json(
+        { error: 'Unauthorized', message: error.message },
+        { status: error.statusCode }
+      );
+    }
+
+    console.error('Failed to upload world zip:', error);
+    return NextResponse.json(
+      { error: 'InternalServerError', message: 'Failed to upload world zip' },
+      { status: 500 }
+    );
+  }
+}

--- a/platform/services/mcctl-console/src/app/api/worlds/upload/route.ts
+++ b/platform/services/mcctl-console/src/app/api/worlds/upload/route.ts
@@ -11,8 +11,13 @@ import { headers } from 'next/headers';
 
 export const dynamic = 'force-dynamic';
 
-// 1 GB + multipart overhead margin (~100 MB)
-const MAX_REQUEST_SIZE = 1024 * 1024 * 1024 + 110 * 1024 * 1024;
+// Mirror the API's WORLD_UPLOAD_MAX_SIZE (default 1 GB) + multipart overhead margin,
+// so raising the env var lifts the limit at both layers.
+const WORLD_UPLOAD_MAX_SIZE =
+  Number(process.env.WORLD_UPLOAD_MAX_SIZE) || 1024 * 1024 * 1024;
+const MAX_REQUEST_SIZE = Math.floor(WORLD_UPLOAD_MAX_SIZE * 1.1) + 1024 * 1024;
+
+const WORLD_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 export async function POST(request: NextRequest) {
   try {
@@ -35,7 +40,20 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+    // Fail fast on invalid names before streaming the body upstream (mirrors API schema).
+    if (!WORLD_NAME_PATTERN.test(name)) {
+      return NextResponse.json(
+        { error: 'BadRequest', message: 'Invalid world name' },
+        { status: 400 }
+      );
+    }
     const seed = searchParams.get('seed');
+    if (seed && seed.length > 128) {
+      return NextResponse.json(
+        { error: 'BadRequest', message: 'seed is too long' },
+        { status: 400 }
+      );
+    }
 
     const apiUrl = process.env.MCCTL_API_URL || 'http://localhost:5001';
     const apiKey = process.env.MCCTL_API_KEY || '';
@@ -67,7 +85,15 @@ export async function POST(request: NextRequest) {
       duplex: 'half',
     });
 
-    const data = await response.json();
+    // Preserve the upstream status even if the body is not JSON (proxy error page,
+    // empty body, etc.) so the client sees the real status instead of a generic 500.
+    const text = await response.text();
+    let data: unknown;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: 'UpstreamError', message: text || response.statusText };
+    }
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
     if (error instanceof AuthError) {

--- a/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.test.tsx
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@/theme';
+import { CreateWorldDialog } from './CreateWorldDialog';
+import type { CreateWorldRequest } from '@/ports/api/IMcctlApiClient';
+
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('CreateWorldDialog', () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    onSubmit: vi.fn(),
+    loading: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ----------------------------------------------------------------
+  // Basic rendering
+  // ----------------------------------------------------------------
+
+  it('renders when open is true', () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Create New World')).toBeInTheDocument();
+  });
+
+  it('does not render when open is false', () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} open={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders world name, seed, server-type select, and guidance alert', () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+
+    expect(screen.getByLabelText(/world name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/seed/i)).toBeInTheDocument();
+    // Server type select
+    expect(screen.getByLabelText(/server type/i)).toBeInTheDocument();
+    // Guidance alert (info role in MUI Alert)
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts.length).toBeGreaterThan(0);
+  });
+
+  // ----------------------------------------------------------------
+  // Loader guidance
+  // ----------------------------------------------------------------
+
+  it('shows single-folder guidance for VANILLA by default', () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+    expect(
+      screen.getByText(/level\.dat/i)
+    ).toBeInTheDocument();
+    // Should NOT show split-folder language by default
+    expect(
+      screen.queryByText(/세 폴더를 모두 함께/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows split-folder guidance when PAPER is selected', async () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+
+    const select = screen.getByLabelText(/server type/i);
+    fireEvent.mouseDown(select);
+
+    // Wait for the MUI dropdown to appear
+    const paperOption = await screen.findByRole('option', { name: 'PAPER' });
+    fireEvent.click(paperOption);
+
+    await waitFor(() => {
+      expect(screen.getByText(/세 폴더를 모두 함께/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows single-folder guidance with mod suffix for FORGE', async () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+
+    const select = screen.getByLabelText(/server type/i);
+    fireEvent.mouseDown(select);
+
+    const forgeOption = await screen.findByRole('option', { name: 'FORGE' });
+    fireEvent.click(forgeOption);
+
+    await waitFor(() => {
+      // Should show base single-folder text
+      expect(screen.getByText(/level\.dat/i)).toBeInTheDocument();
+      // AND mod split suffix
+      expect(screen.getByText(/모드팩\/설정에 따라/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows split-folder guidance for SPIGOT', async () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+
+    const select = screen.getByLabelText(/server type/i);
+    fireEvent.mouseDown(select);
+
+    const spigotOption = await screen.findByRole('option', { name: 'SPIGOT' });
+    fireEvent.click(spigotOption);
+
+    await waitFor(() => {
+      expect(screen.getByText(/세 폴더를 모두 함께/i)).toBeInTheDocument();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Zip file selection
+  // ----------------------------------------------------------------
+
+  it('hides Seed field when a zip file is selected', async () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+
+    // Seed should be visible initially
+    expect(screen.getByLabelText(/seed/i)).toBeInTheDocument();
+
+    // Simulate file selection via the hidden input
+    const fileInput = screen.getByTestId('zip-file-input');
+    const zipFile = new File(['zip content'], 'world.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [zipFile] } });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/seed/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows selected zip filename in the drop-zone', async () => {
+    renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+
+    const fileInput = screen.getByTestId('zip-file-input');
+    const zipFile = new File(['content'], 'my-world.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [zipFile] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('my-world.zip')).toBeInTheDocument();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Submit behavior
+  // ----------------------------------------------------------------
+
+  it('calls onSubmit with data and zipFile as 2nd arg when a zip is selected', async () => {
+    const onSubmit = vi.fn();
+    renderWithTheme(<CreateWorldDialog {...defaultProps} onSubmit={onSubmit} />);
+
+    // Set world name
+    const nameInput = screen.getByLabelText(/world name/i);
+    fireEvent.change(nameInput, { target: { value: 'test-world' } });
+
+    // Select a zip
+    const fileInput = screen.getByTestId('zip-file-input');
+    const zipFile = new File(['content'], 'test.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [zipFile] } });
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: /import/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const [requestArg, zipArg] = onSubmit.mock.calls[0] as [CreateWorldRequest, File];
+      expect(requestArg.name).toBe('test-world');
+      expect(zipArg).toBe(zipFile);
+    });
+  });
+
+  it('calls onSubmit with data and no 2nd arg when no zip is selected', async () => {
+    const onSubmit = vi.fn();
+    renderWithTheme(<CreateWorldDialog {...defaultProps} onSubmit={onSubmit} />);
+
+    // Set world name and seed
+    fireEvent.change(screen.getByLabelText(/world name/i), {
+      target: { value: 'plain-world' },
+    });
+    fireEvent.change(screen.getByLabelText(/seed/i), {
+      target: { value: '12345' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const [requestArg, zipArg] = onSubmit.mock.calls[0] as [CreateWorldRequest, File | undefined];
+      expect(requestArg.name).toBe('plain-world');
+      expect(requestArg.seed).toBe('12345');
+      expect(zipArg).toBeUndefined();
+    });
+  });
+
+  it('validates world name on submit', async () => {
+    const onSubmit = vi.fn();
+    renderWithTheme(<CreateWorldDialog {...defaultProps} onSubmit={onSubmit} />);
+
+    // Leave name empty and submit
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/world name is required/i)).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('validates world name format', async () => {
+    const onSubmit = vi.fn();
+    renderWithTheme(<CreateWorldDialog {...defaultProps} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/world name/i), {
+      target: { value: 'Invalid Name!' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/only lowercase letters, numbers, and hyphens/i)
+      ).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // ----------------------------------------------------------------
+  // Reset on close
+  // ----------------------------------------------------------------
+
+  it('resets form state when closed and reopened', async () => {
+    const { rerender } = renderWithTheme(<CreateWorldDialog {...defaultProps} />);
+
+    // Enter a name and select a zip
+    fireEvent.change(screen.getByLabelText(/world name/i), {
+      target: { value: 'some-world' },
+    });
+    const fileInput = screen.getByTestId('zip-file-input');
+    fireEvent.change(fileInput, { target: { files: [new File([''], 'world.zip')] } });
+
+    // Close the dialog
+    rerender(
+      <ThemeProvider>
+        <CreateWorldDialog {...defaultProps} open={false} />
+      </ThemeProvider>
+    );
+
+    // Reopen
+    rerender(
+      <ThemeProvider>
+        <CreateWorldDialog {...defaultProps} open={true} />
+      </ThemeProvider>
+    );
+
+    // Name should be cleared
+    expect(screen.getByLabelText(/world name/i)).toHaveValue('');
+    // Seed should be visible again (zip removed)
+    expect(screen.getByLabelText(/seed/i)).toBeInTheDocument();
+  });
+});

--- a/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
@@ -111,8 +111,12 @@ export function CreateWorldDialog({
     };
 
   const handleZipSelect = useCallback((file: File) => {
-    if (file.name.endsWith('.zip')) {
+    if (file.name.toLowerCase().endsWith('.zip')) {
       setZipFile(file);
+      setErrors((prev) => ({ ...prev, zip: '' }));
+    } else {
+      setZipFile(null);
+      setErrors((prev) => ({ ...prev, zip: 'Only .zip files are accepted' }));
     }
   }, []);
 
@@ -260,6 +264,15 @@ export function CreateWorldDialog({
                 onChange={handleFileInputChange}
                 data-testid="zip-file-input"
               />
+              {errors.zip && (
+                <Typography
+                  variant="caption"
+                  color="error"
+                  sx={{ display: 'block', mt: 0.5 }}
+                >
+                  {errors.zip}
+                </Typography>
+              )}
               {zipFile && (
                 <Button
                   size="small"

--- a/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
@@ -20,13 +20,13 @@ import type { CreateWorldRequest } from '@/ports/api/IMcctlApiClient';
 // ----------------------------------------------------------------
 
 const SINGLE_FOLDER_BASE =
-  '월드 폴더 하나(예: `world/`)를 통째로 압축하세요. 폴더 안에 `level.dat`가 있어야 하며, 네더/엔드는 `DIM-1`·`DIM1`·`dimensions/` 하위 폴더로 자동 포함됩니다. (싱글플레이 월드는 `.minecraft/saves/<월드명>/` 폴더)';
+  "월드 폴더 하나(예: 'world')를 통째로 압축하세요. 폴더 안에 level.dat 가 있어야 하며, 네더/엔드는 DIM-1 · DIM1 · dimensions 하위 폴더로 자동 포함됩니다. (싱글플레이 월드는 .minecraft/saves/<월드명> 폴더)";
 
 const SINGLE_FOLDER_MOD_SUFFIX =
-  '※ 모드팩/설정에 따라 `<월드명>_nether`·`<월드명>_the_end`로 분할되어 있다면, 세 폴더를 모두 함께 압축하세요.';
+  "※ 모드팩/설정에 따라 '<월드명>_nether' · '<월드명>_the_end' 로 분할되어 있다면, 세 폴더를 모두 함께 압축하세요.";
 
 const SPLIT_FOLDER_TEXT =
-  '월드가 `<월드명>/`, `<월드명>_nether/`, `<월드명>_the_end/` 세 폴더로 나뉩니다. **세 폴더를 모두 함께** 압축하세요. 하나라도 빠지면 해당 차원이 사라집니다.';
+  "월드가 '<월드명>', '<월드명>_nether', '<월드명>_the_end' 세 폴더로 나뉩니다. 세 폴더를 모두 함께 압축하세요. 하나라도 빠지면 해당 차원이 사라집니다.";
 
 const LOADER_GUIDANCE: Record<string, string> = {
   VANILLA: SINGLE_FOLDER_BASE,

--- a/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/CreateWorldDialog.tsx
@@ -1,20 +1,63 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import type { CreateWorldRequest } from '@/ports/api/IMcctlApiClient';
+
+// ----------------------------------------------------------------
+// Loader guidance text
+// ----------------------------------------------------------------
+
+const SINGLE_FOLDER_BASE =
+  '월드 폴더 하나(예: `world/`)를 통째로 압축하세요. 폴더 안에 `level.dat`가 있어야 하며, 네더/엔드는 `DIM-1`·`DIM1`·`dimensions/` 하위 폴더로 자동 포함됩니다. (싱글플레이 월드는 `.minecraft/saves/<월드명>/` 폴더)';
+
+const SINGLE_FOLDER_MOD_SUFFIX =
+  '※ 모드팩/설정에 따라 `<월드명>_nether`·`<월드명>_the_end`로 분할되어 있다면, 세 폴더를 모두 함께 압축하세요.';
+
+const SPLIT_FOLDER_TEXT =
+  '월드가 `<월드명>/`, `<월드명>_nether/`, `<월드명>_the_end/` 세 폴더로 나뉩니다. **세 폴더를 모두 함께** 압축하세요. 하나라도 빠지면 해당 차원이 사라집니다.';
+
+const LOADER_GUIDANCE: Record<string, string> = {
+  VANILLA: SINGLE_FOLDER_BASE,
+  PAPER: SPLIT_FOLDER_TEXT,
+  SPIGOT: SPLIT_FOLDER_TEXT,
+  BUKKIT: SPLIT_FOLDER_TEXT,
+  FORGE: `${SINGLE_FOLDER_BASE} ${SINGLE_FOLDER_MOD_SUFFIX}`,
+  NEOFORGE: `${SINGLE_FOLDER_BASE} ${SINGLE_FOLDER_MOD_SUFFIX}`,
+  FABRIC: `${SINGLE_FOLDER_BASE} ${SINGLE_FOLDER_MOD_SUFFIX}`,
+  QUILT: `${SINGLE_FOLDER_BASE} ${SINGLE_FOLDER_MOD_SUFFIX}`,
+};
+
+const LOADER_OPTIONS = [
+  'VANILLA',
+  'PAPER',
+  'SPIGOT',
+  'BUKKIT',
+  'FORGE',
+  'NEOFORGE',
+  'FABRIC',
+  'QUILT',
+] as const;
+
+// ----------------------------------------------------------------
+// Props & component
+// ----------------------------------------------------------------
 
 interface CreateWorldDialogProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (data: CreateWorldRequest) => void;
+  onSubmit: (data: CreateWorldRequest, zipFile?: File | null) => void;
   loading?: boolean;
 }
 
@@ -31,11 +74,19 @@ export function CreateWorldDialog({
 }: CreateWorldDialogProps) {
   const [formData, setFormData] = useState<CreateWorldRequest>(DEFAULT_FORM_VALUES);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loaderType, setLoaderType] = useState<string>('VANILLA');
+  const [zipFile, setZipFile] = useState<File | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
+  // Reset state when dialog closes
   useEffect(() => {
     if (!open) {
       setFormData(DEFAULT_FORM_VALUES);
       setErrors({});
+      setLoaderType('VANILLA');
+      setZipFile(null);
+      setDragActive(false);
     }
   }, [open]);
 
@@ -49,20 +100,41 @@ export function CreateWorldDialog({
     return null;
   };
 
-  const handleChange = (field: keyof CreateWorldRequest) => (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const value = e.target.value;
-    setFormData((prev) => ({ ...prev, [field]: value }));
+  const handleChange =
+    (field: keyof CreateWorldRequest) =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setFormData((prev) => ({ ...prev, [field]: value }));
+      if (errors[field]) {
+        setErrors((prev) => ({ ...prev, [field]: '' }));
+      }
+    };
 
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: '' }));
+  const handleZipSelect = useCallback((file: File) => {
+    if (file.name.endsWith('.zip')) {
+      setZipFile(file);
     }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragActive(false);
+      const file = e.dataTransfer.files[0];
+      if (file) handleZipSelect(file);
+    },
+    [handleZipSelect]
+  );
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleZipSelect(file);
+    // Reset the input so the same file can be re-selected
+    e.target.value = '';
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
     setErrors({});
 
     const nameError = validateName(formData.name);
@@ -71,11 +143,18 @@ export function CreateWorldDialog({
       return;
     }
 
-    onSubmit({
-      name: formData.name,
-      ...(formData.seed ? { seed: formData.seed } : {}),
-    });
+    if (zipFile) {
+      // When importing a zip, seed is irrelevant
+      onSubmit({ name: formData.name }, zipFile);
+    } else {
+      onSubmit({
+        name: formData.name,
+        ...(formData.seed ? { seed: formData.seed } : {}),
+      });
+    }
   };
+
+  const guidanceText = LOADER_GUIDANCE[loaderType] ?? LOADER_GUIDANCE.VANILLA;
 
   return (
     <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="sm" fullWidth>
@@ -83,6 +162,7 @@ export function CreateWorldDialog({
         <DialogTitle>Create New World</DialogTitle>
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            {/* World Name */}
             <TextField
               label="World Name"
               value={formData.name}
@@ -94,14 +174,104 @@ export function CreateWorldDialog({
               disabled={loading}
             />
 
+            {/* Seed — hidden when a zip is selected */}
+            {!zipFile && (
+              <TextField
+                label="Seed (optional)"
+                value={formData.seed || ''}
+                onChange={handleChange('seed')}
+                helperText="Leave empty for a random seed"
+                fullWidth
+                disabled={loading}
+              />
+            )}
+
+            {/* Server type selector (for guidance only) */}
             <TextField
-              label="Seed (optional)"
-              value={formData.seed || ''}
-              onChange={handleChange('seed')}
-              helperText="Leave empty for a random seed"
+              select
+              label="Server type (압축 안내용)"
+              value={loaderType}
+              onChange={(e) => setLoaderType(e.target.value)}
               fullWidth
               disabled={loading}
-            />
+              helperText="월드 zip 압축 방식을 서버 유형에 맞게 안내합니다"
+            >
+              {LOADER_OPTIONS.map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </TextField>
+
+            {/* Loader guidance alert */}
+            <Alert severity="info" sx={{ '& .MuiAlert-message': { fontSize: '0.8125rem' } }}>
+              {guidanceText}
+            </Alert>
+
+            {/* Zip drop-zone */}
+            <Box>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                월드 .zip 업로드 (선택)
+              </Typography>
+              <Box
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragActive(true);
+                }}
+                onDragLeave={() => setDragActive(false)}
+                onDrop={handleDrop}
+                onClick={() => inputRef.current?.click()}
+                sx={{
+                  border: '2px dashed',
+                  borderColor: dragActive ? 'primary.main' : 'divider',
+                  borderRadius: 2,
+                  p: 3,
+                  textAlign: 'center',
+                  cursor: loading ? 'default' : 'pointer',
+                  bgcolor: dragActive ? 'action.hover' : 'transparent',
+                  transition: 'all 0.2s',
+                  '&:hover': loading
+                    ? {}
+                    : { borderColor: 'primary.main', bgcolor: 'action.hover' },
+                }}
+              >
+                <CloudUploadIcon sx={{ fontSize: 36, color: 'text.secondary', mb: 0.5 }} />
+                {zipFile ? (
+                  <Typography variant="body2" color="primary" fontWeight={500}>
+                    {zipFile.name}
+                  </Typography>
+                ) : (
+                  <>
+                    <Typography variant="body2" color="text.secondary">
+                      .zip 파일을 드래그하거나 클릭해서 선택하세요
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      업로드하면 Seed 필드는 무시됩니다
+                    </Typography>
+                  </>
+                )}
+              </Box>
+              <input
+                ref={inputRef}
+                type="file"
+                accept=".zip"
+                hidden
+                disabled={loading}
+                onChange={handleFileInputChange}
+                data-testid="zip-file-input"
+              />
+              {zipFile && (
+                <Button
+                  size="small"
+                  color="inherit"
+                  sx={{ mt: 0.5 }}
+                  disabled={loading}
+                  onClick={() => setZipFile(null)}
+                >
+                  파일 제거
+                </Button>
+              )}
+            </Box>
           </Box>
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2 }}>
@@ -114,7 +284,7 @@ export function CreateWorldDialog({
             disabled={loading}
             startIcon={loading ? <CircularProgress size={16} /> : null}
           >
-            {loading ? 'Creating...' : 'Create'}
+            {loading ? 'Creating...' : zipFile ? 'Import' : 'Create'}
           </Button>
         </DialogActions>
       </form>

--- a/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
@@ -85,12 +85,23 @@ export function WorldCard({ world, onAssign, onRelease, onDelete, loading = fals
           />
         </Box>
 
-        {/* Size */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        {/* Size + dimension chips */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5, flexWrap: 'wrap' }}>
           <StorageIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
           <Typography variant="body2" color="text.secondary">
             {world.size || 'Unknown size'}
           </Typography>
+          {(world.dimensions?.nether || world.dimensions?.end) && (
+            <>
+              <Chip label="Overworld" size="small" variant="outlined" />
+              {world.dimensions?.nether && (
+                <Chip label="Nether" size="small" variant="outlined" color="warning" />
+              )}
+              {world.dimensions?.end && (
+                <Chip label="End" size="small" variant="outlined" color="secondary" />
+              )}
+            </>
+          )}
         </Box>
 
         {/* Locked By */}

--- a/platform/services/mcctl-console/src/hooks/useMcctl.ts
+++ b/platform/services/mcctl-console/src/hooks/useMcctl.ts
@@ -277,6 +277,46 @@ export function useReleaseWorld() {
 }
 
 /**
+ * Hook to upload (import) a world from a .zip file.
+ * Uses raw fetch instead of apiFetch because apiFetch forces Content-Type: application/json.
+ */
+export function useCreateWorldWithZip() {
+  const queryClient = useQueryClient();
+
+  return useMutation<CreateWorldResponse, Error & { statusCode?: number; code?: string }, { data: CreateWorldRequest; zipFile: File }>({
+    mutationFn: async ({ data, zipFile }) => {
+      const formData = new FormData();
+      formData.append('worldZip', zipFile);
+
+      const params = new URLSearchParams({ name: data.name });
+      if (data.seed) params.set('seed', data.seed);
+
+      const response = await fetch(`/api/worlds/upload?${params.toString()}`, {
+        method: 'POST',
+        body: formData,
+        // No Content-Type header — browser sets the correct multipart boundary automatically
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({
+          error: 'UnknownError',
+          message: response.statusText,
+        }));
+        const error = new Error(errorData.message) as Error & { statusCode: number; code: string };
+        error.statusCode = response.status;
+        error.code = errorData.error;
+        throw error;
+      }
+
+      return response.json() as Promise<CreateWorldResponse>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['worlds'] });
+    },
+  });
+}
+
+/**
  * Hook to delete a world
  */
 export function useDeleteWorld() {

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -106,6 +106,11 @@ export interface World {
   lastModified?: string;
   /** Names of servers configured to use this world. */
   servers?: string[];
+  /** Dimension availability (only present for worlds that fold in split satellites). */
+  dimensions?: {
+    nether: boolean;
+    end: boolean;
+  };
 }
 
 export interface WorldListResponse {

--- a/platform/services/shared/package.json
+++ b/platform/services/shared/package.json
@@ -65,12 +65,14 @@
   "dependencies": {
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.6.2",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "unzipper": "^0.12.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.13.1",
+    "@types/unzipper": "^0.10.11",
     "tsx": "^4.21.0",
     "typescript": "^5.3.0",
     "vitest": "^2.0.0"

--- a/platform/services/shared/src/application/ports/inbound/IWorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/ports/inbound/IWorldManagementUseCase.ts
@@ -21,6 +21,23 @@ export interface WorldCreateResult {
 }
 
 /**
+ * Options for importing a world from a zip archive
+ */
+export interface WorldImportOptions {
+  zipPath: string;
+  worldName: string;
+}
+
+/**
+ * Result of importing a world from a zip archive
+ */
+export interface WorldImportResult {
+  success: boolean;
+  worldName: string;
+  error?: string;
+}
+
+/**
  * World Management Use Case - Inbound Port
  * Manages world assignments and locks
  */
@@ -64,6 +81,11 @@ export interface IWorldManagementUseCase {
    * Delete world by name
    */
   deleteWorldByName(worldName: string, force?: boolean): Promise<WorldDeleteResult>;
+
+  /**
+   * Import a world from a zip archive (non-interactive)
+   */
+  importWorldFromZip(options: WorldImportOptions): Promise<WorldImportResult>;
 }
 
 /**
@@ -78,6 +100,8 @@ export interface WorldListResult {
   lastModified?: Date;
   /** Names of servers configured to use this world (via their LEVEL config). */
   servers: string[];
+  /** Whether split-dimension satellites exist alongside this world. */
+  dimensions?: { nether: boolean; end: boolean };
 }
 
 /**

--- a/platform/services/shared/src/application/ports/inbound/index.ts
+++ b/platform/services/shared/src/application/ports/inbound/index.ts
@@ -9,6 +9,8 @@ export type {
   WorldDeleteResult,
   WorldCreateOptions,
   WorldCreateResult,
+  WorldImportOptions,
+  WorldImportResult,
 } from './IWorldManagementUseCase.js';
 export type {
   IBackupUseCase,

--- a/platform/services/shared/src/application/ports/index.ts
+++ b/platform/services/shared/src/application/ports/index.ts
@@ -13,6 +13,8 @@ export type {
   WorldDeleteResult,
   WorldCreateOptions,
   WorldCreateResult,
+  WorldImportOptions,
+  WorldImportResult,
   IBackupUseCase,
   BackupInitResult,
   BackupPushResult,

--- a/platform/services/shared/src/application/ports/outbound/IWorldRepository.ts
+++ b/platform/services/shared/src/application/ports/outbound/IWorldRepository.ts
@@ -92,6 +92,14 @@ export interface IWorldRepository {
    * @returns Seed string or null if not found
    */
   getSeed(name: string): Promise<string | null>;
+
+  /**
+   * Import a world from a .zip archive at zipPath.
+   * Extracts, validates a level.dat exists, places the main world at worlds/<name>/
+   * and any split satellites at worlds/<name>_nether/ and worlds/<name>_the_end/.
+   * Writes .meta. Throws if name exists or no level.dat found.
+   */
+  importFromZip(name: string, zipPath: string): Promise<World>;
 }
 
 /**

--- a/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
@@ -6,11 +6,14 @@ import type {
   WorldDeleteResult,
   WorldCreateOptions,
   WorldCreateResult,
+  WorldImportOptions,
+  WorldImportResult,
   IPromptPort,
   IShellPort,
   IWorldRepository,
   IServerRepository,
 } from '../ports/index.js';
+import { formatWorldBytes } from '../../utils/index.js';
 
 /**
  * World Management Use Case
@@ -256,21 +259,70 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
   }
 
   /**
-   * List all worlds with lock status
+   * List all worlds with lock status.
+   * Excludes split-dimension satellites (<name>_nether, <name>_the_end)
+   * from the returned list. Each primary world gains a `dimensions` field
+   * and its size includes satellite sizes.
    */
   async listWorlds(): Promise<WorldListResult[]> {
-    const worlds = await this.worldRepo.findAll();
+    const allWorlds = await this.worldRepo.findAll();
     const serversByWorld = await this.getServersByWorld();
 
-    return worlds.map((world) => ({
-      name: world.name,
-      path: world.path,
-      isLocked: world.isLocked,
-      lockedBy: world.lockedBy,
-      size: world.sizeFormatted,
-      lastModified: world.lastModified,
-      servers: serversByWorld.get(world.name) ?? [],
-    }));
+    // Build a set of all world names for O(1) satellite detection
+    const allNames = new Set(allWorlds.map((w) => w.name));
+
+    // Identify satellites: name matches /<base>_(nether|the_end)/ AND base exists
+    const satelliteRegex = /^(.+)_(nether|the_end)$/;
+    const satelliteNames = new Set<string>();
+    const satellitesByBase = new Map<string, { nether?: (typeof allWorlds)[0]; theEnd?: (typeof allWorlds)[0] }>();
+
+    for (const world of allWorlds) {
+      const match = satelliteRegex.exec(world.name);
+      if (match) {
+        const base = match[1]!;
+        const kind = match[2]! as 'nether' | 'the_end';
+        if (allNames.has(base)) {
+          satelliteNames.add(world.name);
+          const entry = satellitesByBase.get(base) ?? {};
+          if (kind === 'nether') entry.nether = world;
+          else entry.theEnd = world;
+          satellitesByBase.set(base, entry);
+        }
+      }
+    }
+
+    // Build results from primary worlds only
+    return allWorlds
+      .filter((world) => !satelliteNames.has(world.name))
+      .map((world) => {
+        const satellites = satellitesByBase.get(world.name) ?? {};
+
+        // Aggregate size
+        let size: string;
+        if (world.sizeBytes !== undefined) {
+          const total =
+            world.sizeBytes +
+            (satellites.nether?.sizeBytes ?? 0) +
+            (satellites.theEnd?.sizeBytes ?? 0);
+          size = formatWorldBytes(total);
+        } else {
+          size = 'Unknown';
+        }
+
+        return {
+          name: world.name,
+          path: world.path,
+          isLocked: world.isLocked,
+          lockedBy: world.lockedBy,
+          size,
+          lastModified: world.lastModified,
+          servers: serversByWorld.get(world.name) ?? [],
+          dimensions: {
+            nether: !!satellites.nether,
+            end: !!satellites.theEnd,
+          },
+        } satisfies WorldListResult;
+      });
   }
 
   /**
@@ -643,6 +695,32 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
     }
 
     return await this.performWorldDeletion(worldName, world.sizeFormatted, force);
+  }
+
+  /**
+   * Import a world from a zip archive (non-interactive).
+   * Returns {success:false} if the world already exists or extraction fails.
+   */
+  async importWorldFromZip(options: WorldImportOptions): Promise<WorldImportResult> {
+    const { worldName, zipPath } = options;
+
+    // Check for duplicate before attempting extraction
+    const existing = await this.worldRepo.findByName(worldName);
+    if (existing) {
+      return {
+        success: false,
+        worldName,
+        error: `World '${worldName}' already exists`,
+      };
+    }
+
+    try {
+      await this.worldRepo.importFromZip(worldName, zipPath);
+      return { success: true, worldName };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return { success: false, worldName, error };
+    }
   }
 
   /**

--- a/platform/services/shared/src/domain/entities/World.ts
+++ b/platform/services/shared/src/domain/entities/World.ts
@@ -1,3 +1,5 @@
+import { formatWorldBytes } from '../../utils/index.js';
+
 /**
  * World lock status
  */
@@ -79,17 +81,7 @@ export class World {
    */
   get sizeFormatted(): string {
     if (!this._sizeBytes) return 'Unknown';
-
-    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-    let size = this._sizeBytes;
-    let unitIndex = 0;
-
-    while (size >= 1024 && unitIndex < units.length - 1) {
-      size /= 1024;
-      unitIndex++;
-    }
-
-    return `${size.toFixed(1)}${units[unitIndex]}`;
+    return formatWorldBytes(this._sizeBytes);
   }
 
   /**

--- a/platform/services/shared/src/domain/entities/World.ts
+++ b/platform/services/shared/src/domain/entities/World.ts
@@ -1,4 +1,4 @@
-import { formatWorldBytes } from '../../utils/index.js';
+import { formatWorldBytes } from '../../utils/format.js';
 
 /**
  * World lock status

--- a/platform/services/shared/src/index.ts
+++ b/platform/services/shared/src/index.ts
@@ -28,7 +28,7 @@ export {
 } from './types/index.js';
 
 // Re-export utilities
-export { Paths, Config, colors, log, getPackageRoot } from './utils/index.js';
+export { Paths, Config, colors, log, getPackageRoot, formatWorldBytes } from './utils/index.js';
 
 // Re-export docker utilities
 export {

--- a/platform/services/shared/src/infrastructure/adapters/WorldRepository.ts
+++ b/platform/services/shared/src/infrastructure/adapters/WorldRepository.ts
@@ -9,12 +9,12 @@ import {
   rename,
   cp,
 } from 'node:fs/promises';
-import { join, basename, dirname } from 'node:path';
+import { join, basename, dirname, resolve, sep } from 'node:path';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import * as unzipper from 'unzipper';
-import { createReadStream } from 'node:fs';
+import { createReadStream, createWriteStream } from 'node:fs';
 import { Paths } from '../../utils/index.js';
 import { World } from '../../domain/index.js';
 import { getContainerStatus } from '../../docker/index.js';
@@ -29,6 +29,26 @@ import type {
 // ---------------------------------------------------------------------------
 // Exported pure helper — testable without real zips
 // ---------------------------------------------------------------------------
+
+/** Allowed world-name characters (defense-in-depth, independent of API schema). */
+const WORLD_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Reject world names that could escape the worlds/ directory.
+ * This guards the repository boundary so traversal is impossible even if a
+ * future caller forgets upstream validation.
+ */
+function assertValidWorldName(name: string): void {
+  if (!WORLD_NAME_PATTERN.test(name)) {
+    throw new Error(`Invalid world name '${name}'`);
+  }
+}
+
+/** Caps to defend against decompression bombs during zip extraction. */
+const WORLD_EXTRACT_MAX_SIZE =
+  Number(process.env['WORLD_EXTRACT_MAX_SIZE']) || 5 * 1024 * 1024 * 1024; // 5 GB
+const WORLD_EXTRACT_MAX_ENTRIES =
+  Number(process.env['WORLD_EXTRACT_MAX_ENTRIES']) || 100000;
 
 /**
  * World layout descriptor returned by findWorldLayout
@@ -75,9 +95,10 @@ export async function findWorldLayout(rootDir: string): Promise<WorldLayout> {
   const netherCandidate = join(parentDir, `${baseName}_nether`);
   const endCandidate = join(parentDir, `${baseName}_the_end`);
 
-  // Only consider siblings if mainDir is not the rootDir itself
-  // (if mainDir === parentDir, there are no siblings to find)
-  if (parentDir !== mainDir) {
+  // Only consider satellites when the world is nested under a real parent
+  // INSIDE the archive. In a flat layout (level.dat at the extract root) the
+  // "parent" is the temp dir itself, whose unrelated siblings must be ignored.
+  if (mainDir !== rootDir) {
     if (existsSync(netherCandidate)) {
       const s = await stat(netherCandidate);
       if (s.isDirectory()) nether = netherCandidate;
@@ -324,6 +345,7 @@ export class WorldRepository implements IWorldRepository {
    * Returns true if the main world was deleted.
    */
   async delete(name: string): Promise<boolean> {
+    assertValidWorldName(name);
     const worldPath = join(this.worldsDir, name);
     const lockFile = join(this.locksDir, `${name}.lock`);
 
@@ -362,6 +384,7 @@ export class WorldRepository implements IWorldRepository {
    * Create a new world directory with optional seed
    */
   async create(name: string, seed?: string): Promise<World> {
+    assertValidWorldName(name);
     const worldPath = join(this.worldsDir, name);
 
     // Check if already exists
@@ -423,10 +446,15 @@ export class WorldRepository implements IWorldRepository {
    * 5. On error after creating target dirs, rolls back.
    */
   async importFromZip(name: string, zipPath: string): Promise<World> {
+    assertValidWorldName(name);
     const targetPath = join(this.worldsDir, name);
 
-    if (existsSync(targetPath)) {
-      throw new Error(`World '${name}' already exists`);
+    // Reject if the world or any of its split-dimension satellites already exist,
+    // so the rollback below can safely remove every path it creates.
+    for (const suffix of ['', '_nether', '_the_end']) {
+      if (existsSync(join(this.worldsDir, `${name}${suffix}`))) {
+        throw new Error(`World '${name}' already exists`);
+      }
     }
 
     // Ensure worlds dir exists
@@ -471,15 +499,55 @@ export class WorldRepository implements IWorldRepository {
   }
 
   /**
-   * Extract a zip file into destDir using unzipper streaming.
+   * Extract a zip file into destDir with defenses against:
+   * - decompression bombs (cumulative uncompressed-size + entry-count caps,
+   *   pre-checked from the central directory and re-checked while streaming), and
+   * - zip-slip (every entry is resolved and confirmed to stay within destDir).
    */
   private async extractZip(zipPath: string, destDir: string): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      createReadStream(zipPath)
-        .pipe(unzipper.Extract({ path: destDir }))
-        .on('close', resolve)
-        .on('error', reject);
-    });
+    const directory = await unzipper.Open.file(zipPath);
+    const base = resolve(destDir);
+
+    // Pre-check from the central directory before writing anything.
+    if (directory.files.length > WORLD_EXTRACT_MAX_ENTRIES) {
+      throw new Error(
+        `World archive has too many entries (>${WORLD_EXTRACT_MAX_ENTRIES})`
+      );
+    }
+    const declaredTotal = directory.files.reduce(
+      (sum, f) => sum + (f.uncompressedSize || 0),
+      0
+    );
+    if (declaredTotal > WORLD_EXTRACT_MAX_SIZE) {
+      throw new Error('World archive too large when extracted');
+    }
+
+    let written = 0;
+    for (const file of directory.files) {
+      const target = resolve(base, file.path);
+      // zip-slip guard: the resolved path must stay within destDir.
+      if (target !== base && !target.startsWith(base + sep)) {
+        throw new Error(`Unsafe path in archive: ${file.path}`);
+      }
+
+      if (file.type === 'Directory') {
+        await mkdir(target, { recursive: true });
+        continue;
+      }
+
+      await mkdir(dirname(target), { recursive: true });
+      written += file.uncompressedSize || 0;
+      if (written > WORLD_EXTRACT_MAX_SIZE) {
+        throw new Error('World archive too large when extracted');
+      }
+      await new Promise<void>((res, rej) => {
+        file
+          .stream()
+          .pipe(createWriteStream(target))
+          .on('finish', res)
+          .on('error', rej);
+      });
+    }
   }
 
   /**
@@ -522,6 +590,11 @@ export class WorldRepository implements IWorldRepository {
    * Falls back to recursive copy + rm when rename fails (cross-device EXDEV).
    */
   private async moveDir(src: string, dest: string): Promise<void> {
+    // Refuse to overwrite an existing destination so rename (throws) and the
+    // cp/EXDEV fallback (which would silently merge) behave identically.
+    if (existsSync(dest)) {
+      throw new Error(`Destination already exists: ${dest}`);
+    }
     try {
       await rename(src, dest);
     } catch (err: unknown) {

--- a/platform/services/shared/src/infrastructure/adapters/WorldRepository.ts
+++ b/platform/services/shared/src/infrastructure/adapters/WorldRepository.ts
@@ -1,6 +1,20 @@
-import { readdir, readFile, stat, rm, unlink, mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import {
+  readdir,
+  readFile,
+  stat,
+  rm,
+  unlink,
+  mkdir,
+  writeFile,
+  rename,
+  cp,
+} from 'node:fs/promises';
+import { join, basename, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import * as unzipper from 'unzipper';
+import { createReadStream } from 'node:fs';
 import { Paths } from '../../utils/index.js';
 import { World } from '../../domain/index.js';
 import { getContainerStatus } from '../../docker/index.js';
@@ -11,6 +25,93 @@ import type {
   ServerStatus,
   WorldAvailabilityCategory,
 } from '../../application/ports/outbound/IWorldRepository.js';
+
+// ---------------------------------------------------------------------------
+// Exported pure helper — testable without real zips
+// ---------------------------------------------------------------------------
+
+/**
+ * World layout descriptor returned by findWorldLayout
+ */
+export interface WorldLayout {
+  /** Absolute path to the directory that contains level.dat */
+  mainDir: string;
+  /** Absolute path to the nether satellite directory, if present */
+  nether?: string;
+  /** Absolute path to the_end satellite directory, if present */
+  theEnd?: string;
+}
+
+/**
+ * Recursively find all level.dat files under rootDir, pick the shallowest
+ * one, and detect split-dimension satellite sibling directories.
+ *
+ * Exported so that unit tests can exercise it with plain directory fixtures.
+ */
+export async function findWorldLayout(rootDir: string): Promise<WorldLayout> {
+  // Collect all level.dat paths
+  const levelDats: string[] = [];
+  await collectLevelDats(rootDir, levelDats);
+
+  if (levelDats.length === 0) {
+    throw new Error('No valid Minecraft world found (level.dat missing)');
+  }
+
+  // Pick the shallowest level.dat (fewest path separators relative to rootDir)
+  levelDats.sort((a, b) => {
+    const depthA = a.split('/').length;
+    const depthB = b.split('/').length;
+    return depthA - depthB;
+  });
+
+  const mainDir = dirname(levelDats[0]!);
+  const parentDir = dirname(mainDir);
+  const baseName = basename(mainDir);
+
+  // Look for split-dimension sibling dirs (case-insensitive suffix match)
+  let nether: string | undefined;
+  let theEnd: string | undefined;
+
+  const netherCandidate = join(parentDir, `${baseName}_nether`);
+  const endCandidate = join(parentDir, `${baseName}_the_end`);
+
+  // Only consider siblings if mainDir is not the rootDir itself
+  // (if mainDir === parentDir, there are no siblings to find)
+  if (parentDir !== mainDir) {
+    if (existsSync(netherCandidate)) {
+      const s = await stat(netherCandidate);
+      if (s.isDirectory()) nether = netherCandidate;
+    }
+    if (existsSync(endCandidate)) {
+      const s = await stat(endCandidate);
+      if (s.isDirectory()) theEnd = endCandidate;
+    }
+  }
+
+  return { mainDir, nether, theEnd };
+}
+
+async function collectLevelDats(dir: string, results: string[]): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isFile() && entry.name === 'level.dat') {
+      results.push(entryPath);
+    } else if (entry.isDirectory()) {
+      await collectLevelDats(entryPath, results);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WorldRepository
+// ---------------------------------------------------------------------------
 
 /**
  * WorldRepository
@@ -218,7 +319,9 @@ export class WorldRepository implements IWorldRepository {
   }
 
   /**
-   * Delete a world directory and its lock file
+   * Delete a world directory and its lock file.
+   * Also deletes split-dimension satellites (<name>_nether, <name>_the_end).
+   * Returns true if the main world was deleted.
    */
   async delete(name: string): Promise<boolean> {
     const worldPath = join(this.worldsDir, name);
@@ -236,36 +339,23 @@ export class WorldRepository implements IWorldRepository {
 
       // Delete world directory
       await rm(worldPath, { recursive: true, force: true });
+
+      // Cascade-delete split-dimension satellites
+      for (const suffix of ['_nether', '_the_end']) {
+        const satellitePath = join(this.worldsDir, `${name}${suffix}`);
+        const satelliteLock = join(this.locksDir, `${name}${suffix}.lock`);
+        if (existsSync(satellitePath)) {
+          if (existsSync(satelliteLock)) {
+            await unlink(satelliteLock).catch(() => {});
+          }
+          await rm(satellitePath, { recursive: true, force: true });
+        }
+      }
+
       return true;
     } catch {
       return false;
     }
-  }
-
-  /**
-   * Get directory size recursively
-   */
-  private async getDirectorySize(dirPath: string): Promise<number> {
-    let totalSize = 0;
-
-    try {
-      const entries = await readdir(dirPath, { withFileTypes: true });
-
-      for (const entry of entries) {
-        const entryPath = join(dirPath, entry.name);
-
-        if (entry.isFile()) {
-          const fileStat = await stat(entryPath);
-          totalSize += fileStat.size;
-        } else if (entry.isDirectory()) {
-          totalSize += await this.getDirectorySize(entryPath);
-        }
-      }
-    } catch {
-      // Ignore errors
-    }
-
-    return totalSize;
   }
 
   /**
@@ -322,5 +412,153 @@ export class WorldRepository implements IWorldRepository {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Import a world from a .zip archive at zipPath.
+   * 1. Throws if worlds/<name> already exists.
+   * 2. Extracts zip into a fresh temp dir.
+   * 3. Calls assembleWorld to move files to their final locations.
+   * 4. Cleans up the temp dir (even on error).
+   * 5. On error after creating target dirs, rolls back.
+   */
+  async importFromZip(name: string, zipPath: string): Promise<World> {
+    const targetPath = join(this.worldsDir, name);
+
+    if (existsSync(targetPath)) {
+      throw new Error(`World '${name}' already exists`);
+    }
+
+    // Ensure worlds dir exists
+    if (!existsSync(this.worldsDir)) {
+      await mkdir(this.worldsDir, { recursive: true });
+    }
+
+    const tempDir = join(tmpdir(), `mc-import-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+
+    try {
+      // Extract zip into tempDir
+      await this.extractZip(zipPath, tempDir);
+
+      // Assemble the world (move files to worlds/ dir)
+      await this.assembleWorld(tempDir, name);
+    } catch (err) {
+      // Roll back any created target dirs
+      for (const suffix of ['', '_nether', '_the_end']) {
+        const p = join(this.worldsDir, `${name}${suffix}`);
+        if (existsSync(p)) {
+          await rm(p, { recursive: true, force: true }).catch(() => {});
+        }
+      }
+      throw err;
+    } finally {
+      // Always clean up temp dir
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+
+    // Return the newly created World entity with metadata
+    const world = new World(name, targetPath);
+    try {
+      const worldStat = await stat(targetPath);
+      const size = await this.getDirectorySize(targetPath);
+      world.setMetadata(size, worldStat.mtime);
+    } catch {
+      // Non-fatal
+    }
+
+    return world;
+  }
+
+  /**
+   * Extract a zip file into destDir using unzipper streaming.
+   */
+  private async extractZip(zipPath: string, destDir: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      createReadStream(zipPath)
+        .pipe(unzipper.Extract({ path: destDir }))
+        .on('close', resolve)
+        .on('error', reject);
+    });
+  }
+
+  /**
+   * Assemble an extracted world tree into the worlds/ directory.
+   * Detects the world layout, moves the main dir and satellites.
+   * Writes a .meta file in the main world dir.
+   */
+  private async assembleWorld(extractedRoot: string, name: string): Promise<void> {
+    const layout = await findWorldLayout(extractedRoot);
+
+    const targetMain = join(this.worldsDir, name);
+
+    // Move main world dir
+    await this.moveDir(layout.mainDir, targetMain);
+
+    // Move satellites if present
+    if (layout.nether) {
+      await this.moveDir(layout.nether, join(this.worldsDir, `${name}_nether`));
+    }
+    if (layout.theEnd) {
+      await this.moveDir(layout.theEnd, join(this.worldsDir, `${name}_the_end`));
+    }
+
+    // Write .meta in main world dir
+    const metaContent = {
+      name,
+      seed: null,
+      createdAt: new Date().toISOString(),
+      importedFrom: 'zip',
+    };
+    await writeFile(
+      join(targetMain, '.meta'),
+      JSON.stringify(metaContent, null, 2),
+      'utf-8'
+    );
+  }
+
+  /**
+   * Move a directory from src to dest.
+   * Falls back to recursive copy + rm when rename fails (cross-device EXDEV).
+   */
+  private async moveDir(src: string, dest: string): Promise<void> {
+    try {
+      await rename(src, dest);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EXDEV') {
+        // Cross-device: copy then remove
+        await cp(src, dest, { recursive: true });
+        await rm(src, { recursive: true, force: true });
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  /**
+   * Get directory size recursively
+   */
+  private async getDirectorySize(dirPath: string): Promise<number> {
+    let totalSize = 0;
+
+    try {
+      const entries = await readdir(dirPath, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const entryPath = join(dirPath, entry.name);
+
+        if (entry.isFile()) {
+          const fileStat = await stat(entryPath);
+          totalSize += fileStat.size;
+        } else if (entry.isDirectory()) {
+          totalSize += await this.getDirectorySize(entryPath);
+        }
+      }
+    } catch {
+      // Ignore errors
+    }
+
+    return totalSize;
   }
 }

--- a/platform/services/shared/src/infrastructure/adapters/index.ts
+++ b/platform/services/shared/src/infrastructure/adapters/index.ts
@@ -5,7 +5,7 @@
 
 export { ShellAdapter, type ShellAdapterOptions } from './ShellAdapter.js';
 export { ServerRepository } from './ServerRepository.js';
-export { WorldRepository } from './WorldRepository.js';
+export { WorldRepository, findWorldLayout, type WorldLayout } from './WorldRepository.js';
 export { DocsAdapter } from './DocsAdapter.js';
 export { YamlUserRepository } from './YamlUserRepository.js';
 export { SqliteUserRepository } from './SqliteUserRepository.js';

--- a/platform/services/shared/src/utils/format.ts
+++ b/platform/services/shared/src/utils/format.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure formatting helpers (no I/O, safe for the domain layer to import).
+ */
+
+/**
+ * Format a byte count into a human-readable string.
+ * Matches the algorithm used in World.sizeFormatted (no space between number and unit).
+ * e.g. 1024 → "1.0KB", 1536 → "1.5KB"
+ */
+export function formatWorldBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+  return `${size.toFixed(1)}${units[unitIndex]}`;
+}

--- a/platform/services/shared/src/utils/index.ts
+++ b/platform/services/shared/src/utils/index.ts
@@ -356,21 +356,9 @@ export class Config {
   }
 }
 
-/**
- * Format a byte count into a human-readable string.
- * Matches the algorithm used in World.sizeFormatted (no space between number and unit).
- * e.g. 1024 → "1.0KB", 1536 → "1.5KB"
- */
-export function formatWorldBytes(bytes: number): string {
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  let size = bytes;
-  let unitIndex = 0;
-  while (size >= 1024 && unitIndex < units.length - 1) {
-    size /= 1024;
-    unitIndex++;
-  }
-  return `${size.toFixed(1)}${units[unitIndex]}`;
-}
+// Re-export the pure formatter (kept in a dependency-free module so the domain
+// layer can use it without importing this I/O-bearing barrel).
+export { formatWorldBytes } from './format.js';
 
 /**
  * Console output utilities with colors

--- a/platform/services/shared/src/utils/index.ts
+++ b/platform/services/shared/src/utils/index.ts
@@ -357,6 +357,22 @@ export class Config {
 }
 
 /**
+ * Format a byte count into a human-readable string.
+ * Matches the algorithm used in World.sizeFormatted (no space between number and unit).
+ * e.g. 1024 → "1.0KB", 1536 → "1.5KB"
+ */
+export function formatWorldBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+  return `${size.toFixed(1)}${units[unitIndex]}`;
+}
+
+/**
  * Console output utilities with colors
  */
 export const colors = {

--- a/platform/services/shared/tests/worldManagement-grouping.test.ts
+++ b/platform/services/shared/tests/worldManagement-grouping.test.ts
@@ -1,0 +1,165 @@
+/**
+ * TDD tests for WorldManagementUseCase.listWorlds() satellite grouping.
+ * Written BEFORE implementation (RED phase).
+ *
+ * Verifies:
+ * - Satellite worlds (_nether / _the_end) are excluded from the returned list
+ * - The primary world gains a `dimensions` field indicating satellite presence
+ * - Aggregated size = primary sizeBytes + satellite sizeBytes, formatted
+ * - Standalone worlds (no satellites) also get `dimensions` with both false
+ *
+ * Follows the stub style of worldManagement-servers.test.ts
+ */
+import { describe, test, expect } from 'vitest';
+import { WorldManagementUseCase } from '../src/application/use-cases/WorldManagementUseCase.js';
+import type {
+  IPromptPort,
+  IShellPort,
+  IWorldRepository,
+  IServerRepository,
+} from '../src/application/ports/index.js';
+import { World } from '../src/domain/entities/World.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWorld(name: string, sizeBytes?: number): World {
+  const w = new World(name, `/worlds/${name}`);
+  if (sizeBytes !== undefined) {
+    w.setMetadata(sizeBytes, new Date());
+  }
+  return w;
+}
+
+function makeMinimalServerRepo(): IServerRepository {
+  return {
+    listNames: async () => [],
+    getConfig: async () => null,
+  } as unknown as IServerRepository;
+}
+
+function makeUseCase(worlds: World[]): WorldManagementUseCase {
+  const worldRepo = {
+    findAll: async () => worlds,
+  } as unknown as IWorldRepository;
+  const prompt = {} as IPromptPort;
+  const shell = {} as IShellPort;
+  return new WorldManagementUseCase(prompt, shell, worldRepo, makeMinimalServerRepo());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorldManagementUseCase.listWorlds - satellite grouping', () => {
+  test('excludes nether and the_end satellites from the returned list', async () => {
+    const worlds = [
+      makeWorld('survival', 1024),
+      makeWorld('survival_nether', 512),
+      makeWorld('survival_the_end', 256),
+    ];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const names = result.map((w) => w.name);
+    expect(names).toEqual(['survival']);
+    expect(names).not.toContain('survival_nether');
+    expect(names).not.toContain('survival_the_end');
+  });
+
+  test('primary world has dimensions.nether=true and dimensions.end=true', async () => {
+    const worlds = [
+      makeWorld('survival', 1024),
+      makeWorld('survival_nether', 512),
+      makeWorld('survival_the_end', 256),
+    ];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const survivalEntry = result.find((w) => w.name === 'survival');
+    expect(survivalEntry?.dimensions).toEqual({ nether: true, end: true });
+  });
+
+  test('primary world has dimensions.nether=true and dimensions.end=false when only nether exists', async () => {
+    const worlds = [
+      makeWorld('creative', 2048),
+      makeWorld('creative_nether', 100),
+    ];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const entry = result.find((w) => w.name === 'creative');
+    expect(entry?.dimensions).toEqual({ nether: true, end: false });
+  });
+
+  test('standalone world without satellites has dimensions both false', async () => {
+    const worlds = [makeWorld('standalone', 500)];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const entry = result.find((w) => w.name === 'standalone');
+    expect(entry?.dimensions).toEqual({ nether: false, end: false });
+  });
+
+  test('aggregates size = primary + nether + end (in bytes, formatted)', async () => {
+    // 1024 + 512 + 256 = 1792 bytes → "1.8KB" (approx)
+    const worlds = [
+      makeWorld('survival', 1024),
+      makeWorld('survival_nether', 512),
+      makeWorld('survival_the_end', 256),
+    ];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const entry = result.find((w) => w.name === 'survival');
+    // Total = 1792 bytes = 1.75 KB → "1.8KB"
+    expect(entry?.size).toBe('1.8KB');
+  });
+
+  test('returns Unknown size if primary sizeBytes is undefined', async () => {
+    const worlds = [
+      makeWorld('nosize'),   // no sizeBytes
+      makeWorld('nosize_nether', 100),
+    ];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const entry = result.find((w) => w.name === 'nosize');
+    expect(entry?.size).toBe('Unknown');
+  });
+
+  test('a satellite-like name with no matching base is treated as primary', async () => {
+    // 'orphan_nether' has no 'orphan' primary world → should be listed as primary
+    const worlds = [makeWorld('orphan_nether', 100)];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const names = result.map((w) => w.name);
+    expect(names).toContain('orphan_nether');
+  });
+
+  test('multiple worlds including mixed primaries and satellites', async () => {
+    const worlds = [
+      makeWorld('world1', 1000),
+      makeWorld('world1_nether', 200),
+      makeWorld('world2', 3000),
+      makeWorld('world2_the_end', 500),
+      makeWorld('standalone', 700),
+    ];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const names = result.map((w) => w.name).sort();
+    expect(names).toEqual(['standalone', 'world1', 'world2']);
+
+    const w1 = result.find((w) => w.name === 'world1')!;
+    expect(w1.dimensions).toEqual({ nether: true, end: false });
+
+    const w2 = result.find((w) => w.name === 'world2')!;
+    expect(w2.dimensions).toEqual({ nether: false, end: true });
+
+    const sw = result.find((w) => w.name === 'standalone')!;
+    expect(sw.dimensions).toEqual({ nether: false, end: false });
+  });
+});

--- a/platform/services/shared/tests/worldManagement-grouping.test.ts
+++ b/platform/services/shared/tests/worldManagement-grouping.test.ts
@@ -162,4 +162,20 @@ describe('WorldManagementUseCase.listWorlds - satellite grouping', () => {
     const sw = result.find((w) => w.name === 'standalone')!;
     expect(sw.dimensions).toEqual({ nether: false, end: false });
   });
+
+  test('both satellite suffixes without a matching base stay as two primaries', async () => {
+    // No 'survey' parent → neither folds the other in.
+    const worlds = [
+      makeWorld('survey_nether', 200),
+      makeWorld('survey_the_end', 300),
+    ];
+    const useCase = makeUseCase(worlds);
+    const result = await useCase.listWorlds();
+
+    const names = result.map((w) => w.name).sort();
+    expect(names).toEqual(['survey_nether', 'survey_the_end']);
+    for (const w of result) {
+      expect(w.dimensions).toEqual({ nether: false, end: false });
+    }
+  });
 });

--- a/platform/services/shared/tests/worldManagement-import.test.ts
+++ b/platform/services/shared/tests/worldManagement-import.test.ts
@@ -1,0 +1,122 @@
+/**
+ * TDD tests for WorldManagementUseCase.importWorldFromZip().
+ * Written BEFORE implementation (RED phase).
+ *
+ * Verifies:
+ * - success path: delegates to worldRepo.importFromZip, returns {success:true}
+ * - duplicate world: findByName returns a world → {success:false, error}
+ * - error propagation: importFromZip throws → {success:false, error}
+ */
+import { describe, test, expect } from 'vitest';
+import { WorldManagementUseCase } from '../src/application/use-cases/WorldManagementUseCase.js';
+import type {
+  IPromptPort,
+  IShellPort,
+  IWorldRepository,
+  IServerRepository,
+} from '../src/application/ports/index.js';
+import { World } from '../src/domain/entities/World.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUseCase(
+  worldRepoOverrides: Partial<IWorldRepository>,
+): WorldManagementUseCase {
+  const worldRepo = {
+    findAll: async () => [],
+    findByName: async (_name: string) => null,
+    importFromZip: async (_name: string, _zip: string): Promise<World> => {
+      throw new Error('not implemented');
+    },
+    ...worldRepoOverrides,
+  } as unknown as IWorldRepository;
+
+  const serverRepo = {
+    listNames: async () => [],
+    getConfig: async () => null,
+  } as unknown as IServerRepository;
+
+  const prompt = {} as IPromptPort;
+  const shell = {} as IShellPort;
+
+  return new WorldManagementUseCase(prompt, shell, worldRepo, serverRepo);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorldManagementUseCase.importWorldFromZip', () => {
+  test('returns success:true when import succeeds', async () => {
+    const importedWorld = new World('newworld', '/worlds/newworld');
+
+    const useCase = makeUseCase({
+      findByName: async () => null,
+      importFromZip: async (_name: string, _zip: string) => importedWorld,
+    });
+
+    const result = await useCase.importWorldFromZip({
+      worldName: 'newworld',
+      zipPath: '/tmp/world.zip',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.worldName).toBe('newworld');
+    expect(result.error).toBeUndefined();
+  });
+
+  test('returns success:false with error when world already exists', async () => {
+    const existingWorld = new World('existing', '/worlds/existing');
+
+    const useCase = makeUseCase({
+      findByName: async () => existingWorld,
+    });
+
+    const result = await useCase.importWorldFromZip({
+      worldName: 'existing',
+      zipPath: '/tmp/world.zip',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.worldName).toBe('existing');
+    expect(result.error).toContain("'existing'");
+    expect(result.error).toContain('already exists');
+  });
+
+  test('propagates errors from importFromZip as success:false', async () => {
+    const useCase = makeUseCase({
+      findByName: async () => null,
+      importFromZip: async () => {
+        throw new Error('No valid Minecraft world found (level.dat missing)');
+      },
+    });
+
+    const result = await useCase.importWorldFromZip({
+      worldName: 'bad',
+      zipPath: '/tmp/bad.zip',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.worldName).toBe('bad');
+    expect(result.error).toContain('level.dat missing');
+  });
+
+  test('propagates non-Error throws as string', async () => {
+    const useCase = makeUseCase({
+      findByName: async () => null,
+      importFromZip: async () => {
+        throw 'something weird';
+      },
+    });
+
+    const result = await useCase.importWorldFromZip({
+      worldName: 'weird',
+      zipPath: '/tmp/weird.zip',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('something weird');
+  });
+});

--- a/platform/services/shared/tests/worldRepository-import.test.ts
+++ b/platform/services/shared/tests/worldRepository-import.test.ts
@@ -163,6 +163,30 @@ describe('WorldRepository.importFromZip', () => {
       repo.importFromZip(worldName, '/nonexistent/dummy.zip')
     ).rejects.toThrow(`World '${worldName}' already exists`);
   });
+
+  test('rejects when a split-dimension satellite already exists, leaving it intact', async () => {
+    const worldName = 'survival';
+    // Pre-existing satellite (e.g. an independent world or stale data)
+    const netherDir = join(worldsRootDir, 'worlds', `${worldName}_nether`);
+    await mkdir(netherDir, { recursive: true });
+    await writeFile(join(netherDir, 'keep.dat'), 'precious');
+
+    await expect(
+      repo.importFromZip(worldName, '/nonexistent/dummy.zip')
+    ).rejects.toThrow(`World '${worldName}' already exists`);
+
+    // The pre-existing satellite must NOT have been deleted by any rollback.
+    expect(existsSync(join(netherDir, 'keep.dat'))).toBe(true);
+  });
+
+  test('rejects names that could escape the worlds directory', async () => {
+    await expect(
+      repo.importFromZip('../evil', '/nonexistent/dummy.zip')
+    ).rejects.toThrow(/Invalid world name/);
+    await expect(
+      repo.importFromZip('a/b', '/nonexistent/dummy.zip')
+    ).rejects.toThrow(/Invalid world name/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/platform/services/shared/tests/worldRepository-import.test.ts
+++ b/platform/services/shared/tests/worldRepository-import.test.ts
@@ -1,0 +1,241 @@
+/**
+ * TDD tests for WorldRepository zip import helpers.
+ * Written BEFORE implementation (RED phase).
+ *
+ * Tests findWorldLayout and assembleWorld using real filesystem fixtures
+ * (temp directories with empty level.dat files) to avoid needing actual zips.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { findWorldLayout, WorldRepository } from '../src/infrastructure/adapters/WorldRepository.js';
+import type { Paths } from '../src/utils/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a unique temp directory for each test */
+async function makeTempDir(): Promise<string> {
+  const dir = join(tmpdir(), `mc-test-${randomUUID()}`);
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+/** Create an empty file (simulates level.dat) */
+async function touch(filePath: string): Promise<void> {
+  await mkdir(join(filePath, '..'), { recursive: true }).catch(() => {});
+  await writeFile(filePath, '');
+}
+
+// ---------------------------------------------------------------------------
+// findWorldLayout tests
+// ---------------------------------------------------------------------------
+
+describe('findWorldLayout', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('(a) flat layout: level.dat at root, no satellites', async () => {
+    await touch(join(tmpDir, 'level.dat'));
+
+    const layout = await findWorldLayout(tmpDir);
+
+    expect(layout.mainDir).toBe(tmpDir);
+    expect(layout.nether).toBeUndefined();
+    expect(layout.theEnd).toBeUndefined();
+  });
+
+  test('(b) single wrapper dir: level.dat inside one subdir', async () => {
+    const worldDir = join(tmpDir, 'my-world');
+    await mkdir(worldDir);
+    await touch(join(worldDir, 'level.dat'));
+
+    const layout = await findWorldLayout(tmpDir);
+
+    expect(layout.mainDir).toBe(worldDir);
+    expect(layout.nether).toBeUndefined();
+    expect(layout.theEnd).toBeUndefined();
+  });
+
+  test('(c) split layout: main + _nether + _the_end siblings', async () => {
+    // Create main world dir
+    const mainDir = join(tmpDir, 'survival');
+    await mkdir(mainDir);
+    await touch(join(mainDir, 'level.dat'));
+
+    // Create satellite dirs as siblings of mainDir (inside tmpDir)
+    const netherDir = join(tmpDir, 'survival_nether');
+    const endDir = join(tmpDir, 'survival_the_end');
+    await mkdir(netherDir);
+    await mkdir(endDir);
+
+    const layout = await findWorldLayout(tmpDir);
+
+    expect(layout.mainDir).toBe(mainDir);
+    expect(layout.nether).toBe(netherDir);
+    expect(layout.theEnd).toBe(endDir);
+  });
+
+  test('(c2) split layout with case-insensitive suffix detection', async () => {
+    const mainDir = join(tmpDir, 'World');
+    await mkdir(mainDir);
+    await touch(join(mainDir, 'level.dat'));
+
+    // Satellites with lowercase suffix
+    const netherDir = join(tmpDir, 'World_nether');
+    await mkdir(netherDir);
+
+    const layout = await findWorldLayout(tmpDir);
+
+    expect(layout.mainDir).toBe(mainDir);
+    expect(layout.nether).toBe(netherDir);
+    expect(layout.theEnd).toBeUndefined();
+  });
+
+  test('(d) no level.dat → throws with descriptive error', async () => {
+    // Empty directory, no level.dat
+    await expect(findWorldLayout(tmpDir)).rejects.toThrow(
+      'No valid Minecraft world found (level.dat missing)'
+    );
+  });
+
+  test('picks shallowest level.dat when multiple exist', async () => {
+    // Shallow level.dat
+    const outerDir = join(tmpDir, 'outer');
+    await mkdir(outerDir);
+    await touch(join(outerDir, 'level.dat'));
+
+    // Deeper level.dat (should be ignored)
+    const innerDir = join(outerDir, 'region', 'inner');
+    await mkdir(innerDir, { recursive: true });
+    await touch(join(innerDir, 'level.dat'));
+
+    const layout = await findWorldLayout(tmpDir);
+
+    // Should pick the shallowest one (outerDir)
+    expect(layout.mainDir).toBe(outerDir);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorldRepository.importFromZip (duplicate name guard)
+// ---------------------------------------------------------------------------
+
+describe('WorldRepository.importFromZip', () => {
+  let worldsRootDir: string;
+  let repo: WorldRepository;
+
+  beforeEach(async () => {
+    worldsRootDir = await makeTempDir();
+    // Create the worlds dir
+    const worldsDir = join(worldsRootDir, 'worlds');
+    await mkdir(worldsDir, { recursive: true });
+
+    // Minimal Paths stub
+    const paths = {
+      root: worldsRootDir,
+    } as unknown as Paths;
+    repo = new WorldRepository(paths);
+  });
+
+  afterEach(async () => {
+    await rm(worldsRootDir, { recursive: true, force: true });
+  });
+
+  test('throws when world with that name already exists', async () => {
+    const worldName = 'existing';
+    const worldDir = join(worldsRootDir, 'worlds', worldName);
+    await mkdir(worldDir, { recursive: true });
+
+    // Use a dummy zipPath; should throw before touching the zip
+    await expect(
+      repo.importFromZip(worldName, '/nonexistent/dummy.zip')
+    ).rejects.toThrow(`World '${worldName}' already exists`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleWorld via WorldRepository internals (integration-level test)
+// Uses a real directory tree instead of a zip for speed.
+// ---------------------------------------------------------------------------
+
+describe('WorldRepository assembleWorld (via importFromZip with pre-extracted temp dir)', () => {
+  let worldsRootDir: string;
+
+  beforeEach(async () => {
+    worldsRootDir = await makeTempDir();
+    const worldsDir = join(worldsRootDir, 'worlds');
+    await mkdir(worldsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(worldsRootDir, { recursive: true, force: true });
+  });
+
+  test('assembleWorld moves mainDir and satellites to worlds/ correctly', async () => {
+    // Build a simulated "extracted" directory tree:
+    //   extractRoot/
+    //     MySurvival/
+    //       level.dat
+    //     MySurvival_nether/   (sibling)
+    //     MySurvival_the_end/  (sibling)
+    const extractRoot = await makeTempDir();
+    const mainDir = join(extractRoot, 'MySurvival');
+    await mkdir(mainDir);
+    await touch(join(mainDir, 'level.dat'));
+    await mkdir(join(extractRoot, 'MySurvival_nether'));
+    await mkdir(join(extractRoot, 'MySurvival_the_end'));
+
+    const paths = { root: worldsRootDir } as unknown as Paths;
+    const repo = new WorldRepository(paths);
+
+    // Call the exported assembleWorld method
+    await (repo as any).assembleWorld(extractRoot, 'imported-world');
+
+    const worldsDir = join(worldsRootDir, 'worlds');
+
+    // Main world placed correctly
+    expect(existsSync(join(worldsDir, 'imported-world'))).toBe(true);
+    expect(existsSync(join(worldsDir, 'imported-world', 'level.dat'))).toBe(true);
+
+    // Satellites placed as siblings
+    expect(existsSync(join(worldsDir, 'imported-world_nether'))).toBe(true);
+    expect(existsSync(join(worldsDir, 'imported-world_the_end'))).toBe(true);
+
+    // .meta written in main world dir
+    const metaPath = join(worldsDir, 'imported-world', '.meta');
+    expect(existsSync(metaPath)).toBe(true);
+    const meta = JSON.parse(await readFile(metaPath, 'utf-8'));
+    expect(meta.name).toBe('imported-world');
+    expect(meta.importedFrom).toBe('zip');
+
+    await rm(extractRoot, { recursive: true, force: true });
+  });
+
+  test('assembleWorld with flat layout (no satellites)', async () => {
+    const extractRoot = await makeTempDir();
+    await touch(join(extractRoot, 'level.dat'));
+
+    const paths = { root: worldsRootDir } as unknown as Paths;
+    const repo = new WorldRepository(paths);
+    await (repo as any).assembleWorld(extractRoot, 'flat-world');
+
+    const worldsDir = join(worldsRootDir, 'worlds');
+    expect(existsSync(join(worldsDir, 'flat-world', 'level.dat'))).toBe(true);
+    expect(existsSync(join(worldsDir, 'flat-world_nether'))).toBe(false);
+    expect(existsSync(join(worldsDir, 'flat-world_the_end'))).toBe(false);
+
+    await rm(extractRoot, { recursive: true, force: true });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@types/node':
         specifier: ^20.19.0
         version: 20.19.30
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
 
   platform/services/cli:
     dependencies:
@@ -57,8 +60,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.30
+        specifier: ^22.13.1
+        version: 22.19.7
       '@types/tar':
         specifier: ^6.1.13
         version: 6.1.13
@@ -70,7 +73,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@20.19.30)(jsdom@26.1.0)
+        version: 2.1.9(@types/node@22.19.7)(jsdom@26.1.0)
 
   platform/services/mcctl-api:
     dependencies:
@@ -5971,11 +5974,11 @@ snapshots:
 
   '@types/bcrypt@6.0.0':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
 
   '@types/estree@1.0.8': {}
 
@@ -6014,12 +6017,12 @@ snapshots:
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
       minipass: 4.2.8
 
   '@types/unzipper@0.10.11':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -6191,14 +6194,6 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
-
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.30))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@20.19.30)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.7))':
     dependencies:
@@ -9114,24 +9109,6 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  vite-node@2.1.9(@types/node@20.19.30):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.21(@types/node@20.19.30)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@2.1.9(@types/node@22.19.7):
     dependencies:
       cac: 6.7.14
@@ -9150,15 +9127,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@20.19.30):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.56.0
-    optionalDependencies:
-      '@types/node': 20.19.30
-      fsevents: 2.3.3
-
   vite@5.4.21(@types/node@22.19.7):
     dependencies:
       esbuild: 0.21.5
@@ -9167,42 +9135,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.7
       fsevents: 2.3.3
-
-  vitest@2.1.9(@types/node@20.19.30)(jsdom@26.1.0):
-    dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.30))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@20.19.30)
-      vite-node: 2.1.9(@types/node@20.19.30)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.30
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@2.1.9(@types/node@22.19.7)(jsdom@26.1.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@types/node-cron':
         specifier: ^3.0.11
         version: 3.0.11
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -3174,6 +3177,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3425,6 +3431,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3442,6 +3451,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
@@ -3726,6 +3738,9 @@ packages:
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4153,6 +4168,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -7533,6 +7551,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -7802,6 +7822,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7818,6 +7845,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   light-my-request@6.6.0:
     dependencies:
@@ -8086,6 +8117,8 @@ snapshots:
       netmask: 2.0.2
 
   pako@0.2.9: {}
+
+  pako@1.0.11: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -8618,6 +8651,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      unzipper:
+        specifier: ^0.12.3
+        version: 0.12.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -306,6 +309,9 @@ importers:
       '@types/node':
         specifier: ^22.13.1
         version: 22.19.7
+      '@types/unzipper':
+        specifier: ^0.10.11
+        version: 0.10.11
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1769,6 +1775,9 @@ packages:
   '@types/tar@6.1.13':
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
 
+  '@types/unzipper@0.10.11':
+    resolution: {integrity: sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==}
+
   '@typescript-eslint/eslint-plugin@8.54.0':
     resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2240,6 +2249,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
   bodec@0.1.0:
     resolution: {integrity: sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ==}
 
@@ -2373,6 +2385,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -2636,6 +2651,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2980,6 +2998,10 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -3314,6 +3336,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -3392,6 +3417,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -3606,6 +3634,9 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -3879,6 +3910,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
@@ -3959,6 +3993,9 @@ packages:
   read@1.0.7:
     resolution: {integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==}
     engines: {node: '>=0.8'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -4044,6 +4081,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -4251,6 +4291,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4471,8 +4514,15 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  unzipper@0.12.3:
+    resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -5949,6 +5999,10 @@ snapshots:
       '@types/node': 20.19.30
       minipass: 4.2.8
 
+  '@types/unzipper@0.10.11':
+    dependencies:
+      '@types/node': 20.19.30
+
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -6409,6 +6463,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bluebird@3.7.2: {}
+
   bodec@0.1.0: {}
 
   brace-expansion@1.1.12:
@@ -6537,6 +6593,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  core-util-is@1.0.3: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -6695,6 +6753,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
 
   eastasianwidth@0.2.0: {}
 
@@ -7282,6 +7344,12 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -7623,6 +7691,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -7718,6 +7788,12 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -7903,6 +7979,8 @@ snapshots:
       uuid: 8.3.2
 
   node-gyp-build@4.8.4: {}
+
+  node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
 
@@ -8238,6 +8316,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
@@ -8337,6 +8417,16 @@ snapshots:
   read@1.0.7:
     dependencies:
       mute-stream: 0.0.8
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -8459,6 +8549,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
@@ -8691,6 +8783,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -8935,6 +9031,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  universalify@2.0.1: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -8958,6 +9056,14 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  unzipper@0.12.3:
+    dependencies:
+      bluebird: 3.7.2
+      duplexer2: 0.1.4
+      fs-extra: 11.3.5
+      graceful-fs: 4.2.11
+      node-int64: 0.4.0
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:


### PR DESCRIPTION
## 개요

Create World에 **zip 업로드**를 추가하고, 압축 시 어떤 디렉토리를 담아야 하는지 **로더별 안내**를 제공합니다. **분할 차원 월드**(`<월드명>`, `<월드명>_nether`, `<월드명>_the_end`)를 올바르게 추출·관리하며, **월드 목록에서 하나로 묶어** 표시합니다.

Closes #490

## 주요 변경 (레이어별)

### Shared (`@minecraft-docker/shared`)
- `IWorldRepository.importFromZip(name, zipPath)` + `WorldRepository` 구현
  - `unzipper` 스트리밍 추출 → `findWorldLayout`(flat / 단일 래퍼 / 분할 판별, `level.dat` 위치로 메인 월드 탐지) → 메인은 `worlds/<name>/`, 위성은 `worlds/<name>_nether`·`<name>_the_end`로 **형제 배치**, `.meta` 작성, 실패 시 롤백/temp 정리
- `WorldRepository.delete()`: 위성 폴더 **cascade 삭제**
- `WorldManagementUseCase.listWorlds()`: 위성을 부모로 묶어 목록에서 제외 + `dimensions: { nether, end }` 부여 + 크기 합산
- `WorldManagementUseCase.importWorldFromZip()` 유스케이스 (독립/미매핑 월드 생성)
- `formatWorldBytes` 헬퍼 추출(구조적 리팩터, 별도 커밋)

### Backend (`mcctl-api`)
- `POST /api/worlds/upload` (multipart): querystring `name`/`seed`, 첫 파일 파트를 temp로 스트리밍 → `importWorldFromZip`
  - 검증: 비-zip/파일없음 **400**, 중복 **409**, 용량초과 **413**(`WORLD_UPLOAD_MAX_SIZE` 기본 1GB, per-request limit)
- `GET /api/worlds`, `/:name` 응답 + 스키마에 `dimensions` 추가
- `@fastify/multipart`가 전역 등록되어 있어 재등록 대신 `request.parts({ limits })` 사용

### Frontend (`mcctl-console`)
- `CreateWorldDialog`: 서버 유형 선택 → **로더별 압축 안내**(Alert), **zip 드롭존**, zip 선택 시 seed 숨김
- BFF `POST /api/worlds/upload`: `requireAuth` + 멀티파트 스트리밍 프록시(`duplex:'half'`, 조기 413)
- `useCreateWorldWithZip` 훅(raw fetch + FormData), worlds 페이지 zip/no-zip 분기
- `World.dimensions` 타입 + `WorldCard`에 Overworld/Nether/End 칩

### E2E / Docs
- `e2e/tests/api-worlds-upload.spec.ts`: 단일/분할 업로드 + 검증. **분할 월드가 목록에서 부모로 통합(위성 미노출)** 되는지 end-to-end 검증
- `WORLD_UPLOAD_MAX_SIZE` 문서화(`.env.example`, `docs/console/installation(.ko).md`)

## 분할 차원 폴더에 대한 설계 노트
월드 차원 구조는 **서버 소프트웨어**가 결정합니다 — 바닐라/순수 Forge/NeoForge/Fabric은 단일 폴더(차원은 `DIM-1`/`DIM1`/`dimensions/` 하위), Paper/Spigot/Bukkit(및 일부 모드팩)은 `<name>`/`<name>_nether`/`<name>_the_end`로 분할. 공유 `--universe /worlds/` 모델상 위성은 `platform/worlds/`에 형제로 존재해야 서버가 인식하므로 그렇게 배치하고, 목록·삭제는 이를 하나의 월드로 다룹니다.

## 테스트
| 패키지 | 신규/관련 테스트 | 결과 |
|--------|------------------|------|
| shared | findWorldLayout/assembleWorld/grouping/import 21개 | ✅ (503 전체 pass) |
| mcctl-api | worlds-upload 7개 (jszip로 실제 zip 생성, 201/400/409 포함) | ✅ |
| mcctl-console | CreateWorldDialog 14개 + page mock | ✅ |
| e2e | 업로드 단일/분할/검증 4개 (defensive) | typecheck N/A(Playwright 런타임 트랜스파일), 패턴 일치 |

`build`(=type-check) + `test` 모두 변경 범위에서 green.

## 알려진 사항 (이 PR와 무관)
- **pre-existing 테스트 실패**: `servers.test.ts`/`config-snapshots.test.ts`/`playit.test.ts` 등은 `vi.mock('@minecraft-docker/shared')`가 `SqliteBackupScheduleRepository`를 누락해 실패(모킹 테스트라 본 변경의 실제 코드를 사용하지 않음). 콘솔의 `ServerDetail.test.tsx`(탭) + ConfigSnapshot 타입체크 실패도 develop 기존 상태(관련 #482). 변경분 stash 후에도 동일 실패 확인.
- **lint 스크립트**: `shared`/`api`의 `pnpm lint`는 ESLint 설정 파일 부재로 pre-existing 실패(본 PR 무관). 콘솔 lint는 통과.

## Out of scope
- CLI(`mcctl`) zip import (후속)
- 발견된 별도 버그: `mcctl.sh` `config` 서브커맨드 부재(`setServerConfig` 무동작) — 본 PR 정상 경로는 미사용, #489 연관 영역

🤖 Generated with [Claude Code](https://claude.com/claude-code)
