### PR TITLE
feat(servers): Create Server 유연한 월드 선택 (미매핑 월드 / Seed / 없음) (#491)

### DIFF
--- a/platform/services/mcctl-api/src/routes/servers.ts
+++ b/platform/services/mcctl-api/src/routes/servers.ts
@@ -11,6 +11,12 @@ import {
   getContainerHealth,
   stopContainer,
   getServerPlayitDomain,
+  WorldManagementUseCase,
+  ApiPromptAdapter,
+  ShellAdapter,
+  WorldRepository,
+  ServerRepository,
+  Paths,
 } from '@minecraft-docker/shared';
 import {
   ServerListResponseSchema,
@@ -602,6 +608,52 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         error: 'BadRequest',
         message: `Modpack slug is required for ${type} server type`,
       });
+    }
+
+    // World options are mutually exclusive (seed / worldUrl / worldName).
+    // Enforce here so clients get a 400 instead of a 500 from the bash guard.
+    // NOTE: must run before the SSE branch below, where HTTP status can no
+    // longer be set once the event stream headers are written.
+    const worldOptionCount = [seed, worldUrl, worldName].filter(Boolean).length;
+    if (worldOptionCount > 1) {
+      return reply.code(400).send({
+        error: 'BadRequest',
+        message:
+          'World options (seed, worldUrl, worldName) are mutually exclusive — provide at most one',
+      });
+    }
+
+    // When attaching an existing world, verify it exists and is unmapped.
+    if (worldName) {
+      try {
+        const paths = new Paths();
+        const worldUseCase = new WorldManagementUseCase(
+          new ApiPromptAdapter({ confirmValue: true }),
+          new ShellAdapter({ paths }),
+          new WorldRepository(paths),
+          new ServerRepository(paths)
+        );
+        const worlds = await worldUseCase.listWorlds();
+        const target = worlds.find((w) => w.name === worldName);
+        if (!target) {
+          return reply.code(400).send({
+            error: 'BadRequest',
+            message: `World '${worldName}' not found`,
+          });
+        }
+        if (target.servers.length > 0 || target.isLocked) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            message: `World '${worldName}' is already in use by another server`,
+          });
+        }
+      } catch (error) {
+        fastify.log.error(error, 'Failed to validate worldName');
+        return reply.code(500).send({
+          error: 'InternalServerError',
+          message: 'Failed to validate world selection',
+        });
+      }
     }
 
     // Build create-server.sh command arguments

--- a/platform/services/mcctl-api/tests/servers-world-validation.test.ts
+++ b/platform/services/mcctl-api/tests/servers-world-validation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for POST /api/servers world-option validation (#491).
+ *
+ * Coverage:
+ *  - seed + worldName together → 400 (mutual exclusion, previously a 500 from bash)
+ *  - worldName that does not exist → 400
+ *  - worldName already mapped to a server → 409
+ *
+ * Uses the real app + a temp platform dir (servers.test.ts mocks shared, which
+ * is unrelated and currently broken). Only the validation paths that return
+ * BEFORE create-server.sh is spawned are exercised, so no Docker is needed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_PLATFORM_PATH = join(import.meta.dirname, '.tmp-servers-world-test');
+
+process.env.MCCTL_ROOT = TEST_PLATFORM_PATH;
+process.env.PLATFORM_PATH = TEST_PLATFORM_PATH;
+process.env.AUTH_MODE = 'disabled';
+process.env.NODE_ENV = 'test';
+
+describe('POST /api/servers - world option validation', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    if (existsSync(TEST_PLATFORM_PATH)) {
+      rmSync(TEST_PLATFORM_PATH, { recursive: true, force: true });
+    }
+    mkdirSync(join(TEST_PLATFORM_PATH, 'backups', 'meta'), { recursive: true });
+    mkdirSync(join(TEST_PLATFORM_PATH, 'worlds'), { recursive: true });
+    mkdirSync(join(TEST_PLATFORM_PATH, 'servers'), { recursive: true });
+
+    const { config } = await import('../src/config/index.js');
+    (config as Record<string, unknown>).platformPath = TEST_PLATFORM_PATH;
+    (config as Record<string, unknown>).mcctlRoot = TEST_PLATFORM_PATH;
+
+    const { buildApp } = await import('../src/app.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    if (existsSync(TEST_PLATFORM_PATH)) {
+      rmSync(TEST_PLATFORM_PATH, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 400 when seed and worldName are both provided', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/servers',
+      payload: { name: 'test-srv', type: 'PAPER', version: '1.21.1', seed: '123', worldName: 'whatever' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json<{ error: string }>().error).toBe('BadRequest');
+  });
+
+  it('returns 400 when worldName does not exist', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/servers',
+      payload: { name: 'test-srv', type: 'PAPER', version: '1.21.1', worldName: 'ghost-world' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json<{ message: string }>().message).toContain('not found');
+  });
+
+  it('returns 409 when worldName is already mapped to a server', async () => {
+    // A world that an existing server points at via LEVEL.
+    mkdirSync(join(TEST_PLATFORM_PATH, 'worlds', 'mapped-world'), { recursive: true });
+    mkdirSync(join(TEST_PLATFORM_PATH, 'servers', 'owner-srv'), { recursive: true });
+    writeFileSync(
+      join(TEST_PLATFORM_PATH, 'servers', 'owner-srv', 'config.env'),
+      'LEVEL=mapped-world\n',
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/servers',
+      payload: { name: 'test-srv', type: 'PAPER', version: '1.21.1', worldName: 'mapped-world' },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json<{ error: string }>().error).toBe('Conflict');
+  });
+});

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
@@ -3,6 +3,21 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@/theme';
 import { CreateServerDialog } from './CreateServerDialog';
 
+// Mock useWorlds so the dialog can render without a QueryClientProvider
+vi.mock('@/hooks/useMcctl', () => ({
+  useWorlds: vi.fn(() => ({
+    data: {
+      worlds: [
+        { name: 'free-world', path: '/worlds/free-world', isLocked: false, servers: [] },
+        { name: 'taken-world', path: '/worlds/taken-world', isLocked: false, servers: ['some-server'] },
+        { name: 'locked-world', path: '/worlds/locked-world', isLocked: true, servers: [] },
+      ],
+      total: 3,
+    },
+    isLoading: false,
+  })),
+}));
+
 const renderWithTheme = (component: React.ReactNode) => {
   return render(<ThemeProvider>{component}</ThemeProvider>);
 };
@@ -516,6 +531,155 @@ describe('CreateServerDialog', () => {
       // Check for aria-live region
       const liveRegion = screen.getByRole('status');
       expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+
+  describe('World Setup', () => {
+    it('should render the World Setup toggle with three options', () => {
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+      );
+
+      const worldToggle = screen.getByRole('group', { name: /world setup mode/i });
+      expect(worldToggle).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /default world/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^seed$/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /existing world/i })).toBeInTheDocument();
+    });
+
+    it('should default to "Default World" mode and submit without seed or worldName', async () => {
+      const onSubmit = vi.fn();
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+
+      // "Default World" should be selected by default
+      expect(screen.getByRole('button', { name: /default world/i })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+
+      const nameInput = screen.getByLabelText(/server name/i);
+      fireEvent.change(nameInput, { target: { value: 'my-server' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        const arg = onSubmit.mock.calls[0][0];
+        expect(arg).not.toHaveProperty('seed');
+        expect(arg).not.toHaveProperty('worldName');
+      });
+    });
+
+    it('should submit with seed when Seed mode is selected and seed is entered', async () => {
+      const onSubmit = vi.fn();
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+
+      // Switch to Seed mode (ToggleButton)
+      fireEvent.click(screen.getByRole('button', { name: /^seed$/i }));
+
+      // Wait for Collapse to open and Seed textbox to appear
+      // Use getByRole('textbox') to avoid ambiguity with the "Seed" toggle button
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /^seed$/i })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByRole('textbox', { name: /^seed$/i }), {
+        target: { value: '12345' },
+      });
+
+      const nameInput = screen.getByLabelText(/server name/i);
+      fireEvent.change(nameInput, { target: { value: 'seeded-server' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        const arg = onSubmit.mock.calls[0][0];
+        expect(arg.seed).toBe('12345');
+        expect(arg).not.toHaveProperty('worldName');
+      });
+    });
+
+    it('should show only unmapped worlds in Existing World mode', async () => {
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /existing world/i }));
+
+      // Wait for Collapse and the World select to appear
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^world$/i)).toBeInTheDocument();
+      });
+
+      // Open the select dropdown
+      fireEvent.mouseDown(screen.getByLabelText(/^world$/i));
+
+      await waitFor(() => {
+        // Only the unmapped, unlocked world should be available
+        expect(screen.getByRole('option', { name: 'free-world' })).toBeInTheDocument();
+        // Mapped and locked worlds must NOT appear
+        expect(screen.queryByRole('option', { name: 'taken-world' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'locked-world' })).not.toBeInTheDocument();
+      });
+    });
+
+    it('should submit with worldName when Existing World mode has a world selected', async () => {
+      const onSubmit = vi.fn();
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /existing world/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^world$/i)).toBeInTheDocument();
+      });
+
+      // Select the unmapped world
+      fireEvent.mouseDown(screen.getByLabelText(/^world$/i));
+      const option = await screen.findByRole('option', { name: 'free-world' });
+      fireEvent.click(option);
+
+      const nameInput = screen.getByLabelText(/server name/i);
+      fireEvent.change(nameInput, { target: { value: 'world-server' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        const arg = onSubmit.mock.calls[0][0];
+        expect(arg.worldName).toBe('free-world');
+        expect(arg).not.toHaveProperty('seed');
+      });
+    });
+
+    it('should show validation error and not call onSubmit when Existing World mode has no world selected', async () => {
+      const onSubmit = vi.fn();
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /existing world/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^world$/i)).toBeInTheDocument();
+      });
+
+      // Fill server name but do NOT select a world
+      const nameInput = screen.getByLabelText(/server name/i);
+      fireEvent.change(nameInput, { target: { value: 'no-world-server' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByText(/please select a world/i)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
@@ -27,6 +27,7 @@ import Collapse from '@mui/material/Collapse';
 import Alert from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
+import { useWorlds } from '@/hooks/useMcctl';
 import type { CreateServerRequest } from '@/ports/api/IMcctlApiClient';
 import type { CreateServerStatus } from '@/hooks/useCreateServerSSE';
 
@@ -89,6 +90,8 @@ export function CreateServerDialog({
   const [formData, setFormData] = useState<CreateServerRequest>(DEFAULT_FORM_VALUES);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [memoryTouched, setMemoryTouched] = useState(false);
+  const [worldMode, setWorldMode] = useState<'none' | 'seed' | 'existingWorld'>('none');
+  const [selectedWorldName, setSelectedWorldName] = useState('');
 
   // Refs for accessibility
   const firstModpackFieldRef = useRef<HTMLInputElement>(null);
@@ -98,6 +101,12 @@ export function CreateServerDialog({
   const activeStep = PROGRESS_STEPS.findIndex((step) => step.key === status);
   const isCreating = status !== 'idle' && status !== 'completed' && status !== 'error';
 
+  // World data for "Existing World" option
+  const { data: worldsData, isLoading: worldsLoading } = useWorlds();
+  const unmappedWorlds = (worldsData?.worlds ?? []).filter(
+    (w) => (!w.servers || w.servers.length === 0) && !w.isLocked
+  );
+
   // Reset form when dialog closes
   useEffect(() => {
     if (!open) {
@@ -105,6 +114,8 @@ export function CreateServerDialog({
       setFormData(DEFAULT_FORM_VALUES);
       setErrors({});
       setMemoryTouched(false);
+      setWorldMode('none');
+      setSelectedWorldName('');
     }
   }, [open]);
 
@@ -149,6 +160,22 @@ export function CreateServerDialog({
         firstModpackFieldRef.current.focus();
       }
     }, 300);
+  };
+
+  const handleWorldModeChange = (
+    _: React.MouseEvent<HTMLElement>,
+    newMode: 'none' | 'seed' | 'existingWorld' | null,
+  ) => {
+    if (newMode === null) return;
+
+    if (newMode !== 'seed') {
+      setFormData((prev) => ({ ...prev, seed: undefined }));
+    }
+    if (newMode !== 'existingWorld') {
+      setSelectedWorldName('');
+    }
+    setErrors((prev) => ({ ...prev, world: '' }));
+    setWorldMode(newMode);
   };
 
   const handleChange = (field: keyof CreateServerRequest) => (
@@ -218,6 +245,17 @@ export function CreateServerDialog({
       if (formData.modLoader) {
         submitData.modLoader = formData.modLoader;
       }
+    }
+
+    // Apply world setup fields
+    if (worldMode === 'seed' && formData.seed) {
+      submitData.seed = formData.seed;
+    } else if (worldMode === 'existingWorld') {
+      if (!selectedWorldName) {
+        setErrors((prev) => ({ ...prev, world: 'Please select a world' }));
+        return;
+      }
+      submitData.worldName = selectedWorldName;
     }
 
     // Submit
@@ -409,6 +447,84 @@ export function CreateServerDialog({
                       fullWidth
                       disabled={isCreating}
                     />
+                  </Box>
+                </Collapse>
+              </Box>
+
+              {/* Group 2.5: World Setup */}
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  World Setup
+                </Typography>
+
+                <ToggleButtonGroup
+                  value={worldMode}
+                  exclusive
+                  onChange={handleWorldModeChange}
+                  aria-label="World setup mode"
+                  fullWidth
+                  disabled={isCreating}
+                >
+                  <ToggleButton value="none" aria-label="Default World">
+                    Default World
+                  </ToggleButton>
+                  <ToggleButton value="seed" aria-label="Seed">
+                    Seed
+                  </ToggleButton>
+                  <ToggleButton value="existingWorld" aria-label="Existing World">
+                    Existing World
+                  </ToggleButton>
+                </ToggleButtonGroup>
+
+                <Collapse in={worldMode === 'seed'} unmountOnExit>
+                  <TextField
+                    label="Seed"
+                    value={formData.seed || ''}
+                    onChange={handleChange('seed')}
+                    fullWidth
+                    disabled={isCreating}
+                    sx={{ mt: 2 }}
+                  />
+                </Collapse>
+
+                <Collapse in={worldMode === 'existingWorld'} unmountOnExit>
+                  <Box sx={{ mt: 2 }}>
+                    {worldsLoading ? (
+                      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                        <CircularProgress size={24} />
+                      </Box>
+                    ) : (
+                      <TextField
+                        label="World"
+                        select
+                        value={selectedWorldName}
+                        onChange={(e) => {
+                          setSelectedWorldName(e.target.value);
+                          if (errors.world) {
+                            setErrors((prev) => ({ ...prev, world: '' }));
+                          }
+                        }}
+                        fullWidth
+                        disabled={isCreating || unmappedWorlds.length === 0}
+                        error={!!errors.world}
+                        helperText={
+                          errors.world ||
+                          (unmappedWorlds.length === 0 ? 'No unmapped worlds available' : '')
+                        }
+                      >
+                        {unmappedWorlds.length === 0 ? (
+                          <MenuItem value="" disabled>
+                            No unmapped worlds available
+                          </MenuItem>
+                        ) : (
+                          unmappedWorlds.map((world) => (
+                            <MenuItem key={world.name} value={world.name}>
+                              {world.name}
+                            </MenuItem>
+                          ))
+                        )}
+                      </TextField>
+                    )}
                   </Box>
                 </Collapse>
               </Box>

--- a/platform/services/shared/src/application/ports/inbound/IWorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/ports/inbound/IWorldManagementUseCase.ts
@@ -48,6 +48,12 @@ export interface IWorldManagementUseCase {
   listWorlds(): Promise<WorldListResult[]>;
 
   /**
+   * List worlds that are not mapped to any server (servers.length === 0).
+   * Satellites are already folded into their parent by listWorlds().
+   */
+  listUnmappedWorlds(): Promise<WorldListResult[]>;
+
+  /**
    * Interactive world creation with seed support
    */
   createWorld(options?: WorldCreateOptions): Promise<WorldCreateResult>;

--- a/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
@@ -326,6 +326,15 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
   }
 
   /**
+   * List worlds not mapped to any server (no server's LEVEL points at them).
+   * Builds on listWorlds(), which already excludes split-dimension satellites.
+   */
+  async listUnmappedWorlds(): Promise<WorldListResult[]> {
+    const worlds = await this.listWorlds();
+    return worlds.filter((w) => w.servers.length === 0);
+  }
+
+  /**
    * Build a reverse map of world name -> server names that use it.
    *
    * A server's world directory is its LEVEL config value (or the WORLD_NAME

--- a/platform/services/shared/tests/worldManagement-servers.test.ts
+++ b/platform/services/shared/tests/worldManagement-servers.test.ts
@@ -117,3 +117,36 @@ describe('WorldManagementUseCase.listWorlds - servers using each world', () => {
     expect(result.find((x) => x.name === 'unused-world')?.servers).toEqual([]);
   });
 });
+
+describe('WorldManagementUseCase.listUnmappedWorlds', () => {
+  test('returns only worlds no server maps to', async () => {
+    const serverRepo = makeServerRepo({
+      survival: { LEVEL: 'mapped-world' },
+    });
+    const useCase = makeUseCase(['mapped-world', 'free-world'], serverRepo);
+
+    const result = await useCase.listUnmappedWorlds();
+    const names = result.map((w) => w.name);
+
+    expect(names).toContain('free-world');
+    expect(names).not.toContain('mapped-world');
+  });
+
+  test('a world whose name equals an unconfigured server name is considered mapped (fallback)', async () => {
+    // Server "myserver" with no LEVEL defaults to using worlds/myserver.
+    const serverRepo = makeServerRepo({ myserver: {} });
+    const useCase = makeUseCase(['myserver', 'free-world'], serverRepo);
+
+    const names = (await useCase.listUnmappedWorlds()).map((w) => w.name);
+
+    expect(names).toEqual(['free-world']);
+  });
+
+  test('all worlds are unmapped when there are no servers', async () => {
+    const serverRepo = makeServerRepo({});
+    const useCase = makeUseCase(['a', 'b'], serverRepo);
+
+    const names = (await useCase.listUnmappedWorlds()).map((w) => w.name).sort();
+    expect(names).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## 개요

Create Server 시 월드 설정을 유연하게 선택할 수 있게 합니다: **(A) 관리 중인 미매핑 월드 선택**, **(B) Seed 입력**, **(C) 아무것도 안 함(기본 월드)** — 셋은 상호배제입니다.

Closes #491

## 주요 변경 (레이어별)

### Shared (`@minecraft-docker/shared`)
- `WorldManagementUseCase.listUnmappedWorlds()` 추가 — `listWorlds()` 위에서 `servers.length === 0` 필터(분할 차원 위성은 `listWorlds`가 이미 부모로 통합/제외). 포트에 시그니처 추가, 테스트 +3.

### Backend (`mcctl-api`)
- `POST /api/servers`에 검증 추가 (**SSE 분기 이전**, 스트림 헤더 전송 전):
  - `seed` / `worldUrl` / `worldName` 중 2개 이상 → **400** (기존엔 bash 가드가 비정상 종료해 500으로 노출됨)
  - `worldName` 지정 시: 미존재 → **400**, 이미 매핑/잠금 → **409**
- 검증 테스트 3개(실제 app 빌드, shared 모킹 없이).

### Frontend (`mcctl-console`)
- `CreateServerDialog`에 "World Setup" 토글(Default World / Seed / Existing World):
  - Existing World 선택 시 `useWorlds()`로 **미매핑 월드만**(`(!servers || servers.length===0) && !isLocked`) 드롭다운, 미매핑 없으면 안내.
  - 모드 전환 시 반대 입력 값 클리어 → 상호배제 보장. `handleSubmit`에서 seed/worldName 중 하나만 전송, Existing World 미선택 시 검증 에러.
- 테스트 +5 (총 34 통과).

> `CreateServerRequest`엔 `seed`/`worldName`/`worldUrl`이 이미 존재하여 타입/페이로드 경로 변경은 없습니다(Console→BFF→API→`create-server.sh -w/-s`).

## 테스트
| 패키지 | 테스트 | 결과 |
|--------|--------|------|
| shared | listUnmappedWorlds +3 | ✅ |
| mcctl-api | servers-world-validation 3 (400/400/409) | ✅ |
| mcctl-console | CreateServerDialog 34 (+5 World Setup) | ✅ |

`build`(=type-check) + `test` 모두 변경 범위에서 green. (shared/api의 `lint` 스크립트는 ESLint 설정 부재로 레포 차원 pre-existing 실패 — 본 PR 무관.)

## 의존성
- #490(분할 차원 월드 통합 — 머지됨)의 `listWorlds` 그룹핑에 기반(미매핑 목록에서 위성 제외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
