### PR TITLE
fix(test): mcctl-api 테스트 스위트 그린화 + ConfigSnapshot 타입오류 수정 (#494, #482)

### DIFF
--- a/platform/services/mcctl-api/tests/config-snapshot-schedules.test.ts
+++ b/platform/services/mcctl-api/tests/config-snapshot-schedules.test.ts
@@ -37,6 +37,7 @@ vi.mock('child_process', async (importOriginal) => {
 
 // Mock config-snapshot-service to avoid filesystem deps
 vi.mock('../src/services/config-snapshot-service.js', () => ({
+  getConfigSnapshotUseCase: vi.fn(() => ({})),
   createSnapshot: vi.fn(),
   listSnapshots: vi.fn(),
   getSnapshotById: vi.fn(),

--- a/platform/services/mcctl-api/tests/config-snapshots.test.ts
+++ b/platform/services/mcctl-api/tests/config-snapshots.test.ts
@@ -67,6 +67,7 @@ function createMockSnapshot(serverName: string, description?: string) {
 
 // Mock config-snapshot-service
 vi.mock('../src/services/config-snapshot-service.js', () => ({
+  getConfigSnapshotUseCase: vi.fn(() => ({})),
   createSnapshot: vi.fn().mockImplementation(async (serverName: string, description?: string) => {
     const s = createMockSnapshot(serverName, description);
     return {

--- a/platform/services/mcctl-api/tests/playit.test.ts
+++ b/platform/services/mcctl-api/tests/playit.test.ts
@@ -3,7 +3,8 @@ import { FastifyInstance } from 'fastify';
 import { buildApp } from '../src/app.js';
 
 // Mock @minecraft-docker/shared module
-vi.mock('@minecraft-docker/shared', () => ({
+vi.mock('@minecraft-docker/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@minecraft-docker/shared')>()),
   // Existing mocks (keep them for other tests)
   getAllServers: vi.fn(),
   getServerInfoFromConfig: vi.fn(),

--- a/platform/services/mcctl-api/tests/router-playit.test.ts
+++ b/platform/services/mcctl-api/tests/router-playit.test.ts
@@ -3,7 +3,8 @@ import { FastifyInstance } from 'fastify';
 import { buildApp } from '../src/app.js';
 
 // Mock @minecraft-docker/shared module
-vi.mock('@minecraft-docker/shared', () => ({
+vi.mock('@minecraft-docker/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@minecraft-docker/shared')>()),
   getRouterDetailInfo: vi.fn(),
   getAvahiStatus: vi.fn(),
   getPlayitAgentStatus: vi.fn(),

--- a/platform/services/mcctl-api/tests/servers-playit.test.ts
+++ b/platform/services/mcctl-api/tests/servers-playit.test.ts
@@ -3,7 +3,8 @@ import { FastifyInstance } from 'fastify';
 import { buildApp } from '../src/app.js';
 
 // Mock @minecraft-docker/shared module
-vi.mock('@minecraft-docker/shared', () => ({
+vi.mock('@minecraft-docker/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@minecraft-docker/shared')>()),
   getAllServers: vi.fn(),
   getServerInfoFromConfig: vi.fn(),
   serverExists: vi.fn(),

--- a/platform/services/mcctl-api/tests/servers-status.test.ts
+++ b/platform/services/mcctl-api/tests/servers-status.test.ts
@@ -4,7 +4,8 @@ import { buildApp } from '../src/app.js';
 import http from 'http';
 
 // Mock @minecraft-docker/shared module
-vi.mock('@minecraft-docker/shared', () => ({
+vi.mock('@minecraft-docker/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@minecraft-docker/shared')>()),
   getAllServers: vi.fn(),
   getServerInfoFromConfig: vi.fn(),
   getServerDetailedInfo: vi.fn(),

--- a/platform/services/mcctl-api/tests/servers.test.ts
+++ b/platform/services/mcctl-api/tests/servers.test.ts
@@ -85,7 +85,8 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 // Mock @minecraft-docker/shared module
-vi.mock('@minecraft-docker/shared', () => ({
+vi.mock('@minecraft-docker/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@minecraft-docker/shared')>()),
   getAllServers: vi.fn(),
   getServerInfoFromConfig: vi.fn(),
   getServerDetailedInfo: vi.fn(),

--- a/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.test.tsx
+++ b/platform/services/mcctl-console/src/components/backups/ConfigSnapshotServerCard.test.tsx
@@ -12,9 +12,9 @@ const createMockSnapshot = (id: string, createdAt: string): ConfigSnapshotItem =
   id,
   serverName: 'test-server',
   createdAt,
-  trigger: 'manual' as const,
+  description: 'test snapshot',
   files: [
-    { path: 'server.properties', contentHash: 'abc123' },
+    { path: 'server.properties', hash: 'abc123', size: 0 },
   ],
 });
 

--- a/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotCompareBar.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/config-history/ConfigSnapshotCompareBar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from '@/theme';
 import { ConfigSnapshotCompareBar } from './ConfigSnapshotCompareBar';


### PR DESCRIPTION
## 개요
develop의 pre-existing 테스트/타입체크 실패를 복구합니다 (#490/#491 작업 중 발견).

Closes #494
Closes #482

## 변경
### mcctl-api (#494, #482 일부)
- `servers` / `servers-status` / `playit` / `router-playit` / `servers-playit`: `vi.mock('@minecraft-docker/shared')` 수동 mock을 `importOriginal` + `...actual` 스프레드로 전환 → `SqliteBackupScheduleRepository` 등 buildApp이 요구하는 export가 자동 충족(향후 신규 export에도 견고).
- `config-snapshots` / `config-snapshot-schedules`: `config-snapshot-service` mock에 `getConfigSnapshotUseCase` 추가(스케줄러 라우트 등록에 필요).
- **결과**: mcctl-api 29파일 454테스트 green (이전: 7파일 실패).

### mcctl-console (#482)
- `ConfigSnapshotServerCard.test`: `contentHash`→`hash`+`size`, `trigger`→`description` (현행 `ConfigSnapshotItem`/`ConfigSnapshotFile` 타입에 정합).
- `ConfigSnapshotCompareBar.test`: 누락된 `beforeEach` import 추가.
- **결과**: console `type-check` clean.

## 근본 원인
buildApp/라우트가 진화하며 새 의존성(`SqliteBackupScheduleRepository`, `getConfigSnapshotUseCase`)이 생겼는데 구형 수동 mock이 이를 반영하지 못해 발생. 타입 오류는 API 타입이 변경(`contentHash`→`hash` 등)된 뒤 테스트가 갱신되지 않아 발생.

## 검증
- mcctl-api: `pnpm test` → 29 files / 454 passed (+1 skipped)
- mcctl-console: `pnpm type-check` clean

## 범위 밖 (별개 잔존 실패)
- console `ServerDetail.test`(탭 전환 3건), `players` BFF 라우트(1건) — ConfigSnapshot/#494와 무관한 별개 사전 실패. 필요 시 별도 처리.
- shared/api `lint` 스크립트(ESLint 설정 부재)는 별도 chore로 분리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)