### PR TITLE
fix(worlds): world assign이 서버 LEVEL을 갱신하도록 (#489)

### DIFF
--- a/platform/scripts/mcctl.sh
+++ b/platform/scripts/mcctl.sh
@@ -488,6 +488,36 @@ cmd_backup() {
 }
 
 # =============================================================================
+# Config
+# =============================================================================
+
+# Set a key=value in a server's config.env (used by world assign to keep LEVEL
+# in sync, and by other callers via ShellAdapter.setServerConfig).
+cmd_config() {
+    local server="$1"
+    local key="$2"
+    local value="$3"
+
+    if [[ -z "$server" || -z "$key" ]]; then
+        error "Usage: config <server> <key> <value>"
+        return 1
+    fi
+
+    local config_file="$PLATFORM_DIR/servers/$server/config.env"
+    if [[ ! -f "$config_file" ]]; then
+        error "Server '$server' config not found: $config_file"
+        return 1
+    fi
+
+    if grep -q "^${key}=" "$config_file"; then
+        sed -i "s|^${key}=.*|${key}=${value}|" "$config_file"
+    else
+        echo "${key}=${value}" >> "$config_file"
+    fi
+    info "Set ${key}=${value} in servers/${server}/config.env"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -519,6 +549,9 @@ main() {
             ;;
         backup)
             cmd_backup "$@"
+            ;;
+        config)
+            cmd_config "$@"
             ;;
         -h|--help|help)
             usage

--- a/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
@@ -423,6 +423,23 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
         };
       }
 
+      // Sync the server's LEVEL with the lock so it loads the assigned world (#489).
+      const levelResult = await this.shell.setServerConfig(
+        server.name.value,
+        'LEVEL',
+        world.name
+      );
+      if (!levelResult.success) {
+        spinner.stop('Failed to update server LEVEL');
+        this.prompt.error(levelResult.stderr || 'Failed to update server LEVEL');
+        return {
+          success: false,
+          worldName: world.name,
+          serverName: server.name.value,
+          error: levelResult.stderr || 'Failed to update server LEVEL',
+        };
+      }
+
       spinner.stop('World assigned');
       this.prompt.success(`World '${world.name}' assigned to '${server.name.value}'`);
       this.prompt.outro('Assignment complete');
@@ -484,14 +501,33 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
       };
     }
 
-    // Execute assignment
+    // Execute assignment (creates the lock)
     const result = await this.shell.worldAssign(worldName, serverName);
+    if (!result.success) {
+      return {
+        success: false,
+        worldName,
+        serverName,
+        error: result.stderr,
+      };
+    }
+
+    // Keep the server's LEVEL in sync with the lock so the container actually
+    // loads the assigned world (otherwise lockedBy and servers[]/LEVEL diverge — #489).
+    const levelResult = await this.shell.setServerConfig(serverName, 'LEVEL', worldName);
+    if (!levelResult.success) {
+      return {
+        success: false,
+        worldName,
+        serverName,
+        error: levelResult.stderr || 'Failed to update server LEVEL',
+      };
+    }
 
     return {
-      success: result.success,
+      success: true,
       worldName,
       serverName,
-      error: result.success ? undefined : result.stderr,
     };
   }
 

--- a/platform/services/shared/tests/worldManagement-assign.test.ts
+++ b/platform/services/shared/tests/worldManagement-assign.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression tests for WorldManagementUseCase.assignWorldByName (#489).
+ *
+ * Assigning a world to a server must keep the server's LEVEL in sync with the
+ * lock, so lockedBy and servers[] (derived from LEVEL) do not diverge.
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { WorldManagementUseCase } from '../src/application/use-cases/WorldManagementUseCase.js';
+import type {
+  IPromptPort,
+  IShellPort,
+  IWorldRepository,
+  IServerRepository,
+} from '../src/application/ports/index.js';
+
+function makeUseCase(overrides: {
+  worldAssign?: ReturnType<typeof vi.fn>;
+  setServerConfig?: ReturnType<typeof vi.fn>;
+  isLocked?: boolean;
+  worldExists?: boolean;
+  serverExists?: boolean;
+}) {
+  const worldAssign =
+    overrides.worldAssign ?? vi.fn().mockResolvedValue({ success: true });
+  const setServerConfig =
+    overrides.setServerConfig ?? vi.fn().mockResolvedValue({ success: true });
+
+  const shell = { worldAssign, setServerConfig } as unknown as IShellPort;
+  const worldRepo = {
+    findByName: vi.fn().mockResolvedValue(
+      overrides.worldExists === false
+        ? null
+        : { name: 'new-world', isLocked: overrides.isLocked ?? false, lockedBy: undefined }
+    ),
+  } as unknown as IWorldRepository;
+  const serverRepo = {
+    exists: vi.fn().mockResolvedValue(overrides.serverExists ?? true),
+  } as unknown as IServerRepository;
+  const prompt = {} as IPromptPort;
+
+  const useCase = new WorldManagementUseCase(prompt, shell, worldRepo, serverRepo);
+  return { useCase, worldAssign, setServerConfig };
+}
+
+describe('WorldManagementUseCase.assignWorldByName - LEVEL sync (#489)', () => {
+  test('sets the server LEVEL to the assigned world after locking', async () => {
+    const { useCase, worldAssign, setServerConfig } = makeUseCase({});
+
+    const result = await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(result.success).toBe(true);
+    expect(worldAssign).toHaveBeenCalledWith('new-world', 'srv');
+    expect(setServerConfig).toHaveBeenCalledWith('srv', 'LEVEL', 'new-world');
+  });
+
+  test('does not touch LEVEL when locking fails', async () => {
+    const worldAssign = vi.fn().mockResolvedValue({ success: false, stderr: 'lock failed' });
+    const { useCase, setServerConfig } = makeUseCase({ worldAssign });
+
+    const result = await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('lock failed');
+    expect(setServerConfig).not.toHaveBeenCalled();
+  });
+
+  test('fails when LEVEL update fails (so callers see the inconsistency)', async () => {
+    const setServerConfig = vi
+      .fn()
+      .mockResolvedValue({ success: false, stderr: 'config write failed' });
+    const { useCase } = makeUseCase({ setServerConfig });
+
+    const result = await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('config write failed');
+  });
+
+  test('rejects assigning a locked world (no LEVEL change)', async () => {
+    const { useCase, worldAssign, setServerConfig } = makeUseCase({ isLocked: true });
+
+    const result = await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(result.success).toBe(false);
+    expect(worldAssign).not.toHaveBeenCalled();
+    expect(setServerConfig).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 개요
`world assign`이 잠금 파일만 만들고 서버 `config.env`의 `LEVEL`을 갱신하지 않아, `lockedBy`(잠금)와 `servers[]`(LEVEL 기반 실제 사용 월드)가 발산하던 문제를 수정합니다. (Option 1 채택)

Closes #489

## 변경
- **`platform/scripts/mcctl.sh`**: `config <server> <key> <value>` 서브커맨드 추가 — `config.env`의 키를 설정(없으면 추가). `ShellAdapter.setServerConfig`가 호출하지만 존재하지 않던 커맨드도 함께 복구.
- **`WorldManagementUseCase.assignWorldByName` / `assignWorld`(interactive)**: `worldAssign`(잠금) 성공 후 `setServerConfig(server, 'LEVEL', world)`로 LEVEL을 동기화. LEVEL 갱신 실패 시 에러 반환(부분 상태를 호출자에게 노출).
- CLI(`mcctl world assign`, byName/interactive)와 API(`POST /api/worlds/:name/assign`)가 모두 이 use case를 경유 → 단일 지점 수정으로 양쪽 일관 적용.

## 동작
assign 후: 잠금(`lockedBy`)과 `LEVEL`(→`servers[]`)이 동일 월드를 가리켜 컨테이너가 실제로 할당된 월드를 로드.

## 테스트
- `tests/worldManagement-assign.test.ts` (신규 4건): LEVEL 동기화 호출, 잠금 실패 시 LEVEL 미변경, LEVEL 실패 시 에러, 잠긴 월드 거부.
- shared 전체 25파일 513 통과, mcctl-api 29파일 454 통과(회귀 없음), `bash -n mcctl.sh` OK.

## Acceptance Criteria
- [x] `world assign` 후 `lockedBy`와 `servers[]`(LEVEL)가 일치 (Option 1)
- [x] 회귀 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)