### PR TITLE
chore(lint): shared/api ESLint 설정 추가로 pnpm lint 복구

### DIFF
--- a/platform/services/mcctl-api/.eslintrc.json
+++ b/platform/services/mcctl-api/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended"],
+  "ignorePatterns": ["dist/", "node_modules/", "*.js", "*.cjs"],
+  "rules": {
+    "no-unused-vars": "off",
+    "no-undef": "off",
+    "no-control-regex": "off"
+  }
+}

--- a/platform/services/shared/.eslintrc.json
+++ b/platform/services/shared/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended"],
+  "ignorePatterns": ["dist/", "node_modules/", "*.js", "*.cjs"],
+  "rules": {
+    "no-unused-vars": "off",
+    "no-undef": "off",
+    "no-control-regex": "off"
+  }
+}


### PR DESCRIPTION
## 개요
`shared`/`mcctl-api`에 ESLint 설정 파일이 없어 `pnpm lint`가 "config not found"로 실패하던 문제를 **최소 설정**으로 복구합니다.

## 변경
- `platform/services/shared/.eslintrc.json`, `platform/services/mcctl-api/.eslintrc.json` 추가 (레거시 .eslintrc — 기존 설치된 eslint 8.57 + `@typescript-eslint/parser`/`eslint-plugin` 활용, 신규 의존성 없음).
- 규칙: `eslint:recommended` 기반.
  - `no-unused-vars` / `no-undef` off (TypeScript(tsc)가 담당).
  - `no-control-regex` off (ANSI escape 스트립 정규식이 정당).
  - `@typescript-eslint` 플러그인 등록(코드 내 인라인 `eslint-disable` 해석용).

## 결과
- `pnpm lint`: shared/api 모두 green (위반 0).
- 대량 규칙 강제/자동수정은 범위 밖(요청대로 최소 설정). 추후 규칙 강화는 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)