### PR TITLE
fix(console): ServerDetail 탭 + players BFF 테스트 stale 실패 수정 (#499)

### DIFF
--- a/platform/services/mcctl-console/src/app/api/players/__tests__/routes.test.ts
+++ b/platform/services/mcctl-console/src/app/api/players/__tests__/routes.test.ts
@@ -153,7 +153,7 @@ describe('Players BFF Routes - Permission Wiring', () => {
         servers: [{ name: 'sv1', status: 'running', health: 'healthy' }],
       });
       mockGetServer.mockResolvedValue({
-        server: { players: { list: ['Steve'] } },
+        server: { players: { online: 1, max: 20, players: ['Steve'] } },
       });
       const { GET } = await import('../route');
       const req = makeGetRequest('http://localhost:5000/api/players');

--- a/platform/services/mcctl-console/src/components/servers/ServerDetail.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/ServerDetail.test.tsx
@@ -20,8 +20,19 @@ vi.mock('@/hooks/useServerLogs', () => ({
 vi.mock('@/hooks/useMods', () => ({
   useServerMods: () => ({ data: { mods: {} }, isLoading: false, error: null }),
   useModSearch: () => ({ data: null, isLoading: false }),
+  useModProjects: () => ({ data: null, isLoading: false }),
   useAddMod: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useRemoveMod: () => ({ mutateAsync: vi.fn() }),
+}));
+
+// Files/Backups tabs are implemented components with their own data hooks;
+// stub them so this tab-navigation test stays focused on switching.
+vi.mock('./files/ServerFilesTab', () => ({
+  ServerFilesTab: () => <div>Files Tab Content</div>,
+}));
+
+vi.mock('./ServerBackupTab', () => ({
+  ServerBackupTab: () => <div>Backup Tab Content</div>,
 }));
 
 const renderWithTheme = (component: React.ReactNode) => {
@@ -111,7 +122,7 @@ describe('ServerDetail', () => {
     const filesTab = screen.getByRole('button', { name: /files/i });
     fireEvent.click(filesTab);
 
-    expect(screen.getByText(/file browser coming soon/i)).toBeInTheDocument();
+    expect(screen.getByText('Files Tab Content')).toBeInTheDocument();
   });
 
   it('should switch to backups tab', () => {
@@ -120,7 +131,7 @@ describe('ServerDetail', () => {
     const backupsTab = screen.getByRole('button', { name: /backups/i });
     fireEvent.click(backupsTab);
 
-    expect(screen.getByText(/backup management coming soon/i)).toBeInTheDocument();
+    expect(screen.getByText('Backup Tab Content')).toBeInTheDocument();
   });
 
   it('should switch to options tab', () => {


### PR DESCRIPTION
## 개요
develop의 mcctl-console 테스트 4건(stale)을 수정해 전체 스위트를 green으로 복구합니다.

Closes #499

## 변경
- **ServerDetail.test**: `useMods` mock에 `useModProjects` 추가(ModsTab가 사용). files/backups 탭은 이미 구현(#375~380)되어 옛 'coming soon' placeholder가 없으므로, `ServerFilesTab`/`ServerBackupTab`를 stub하고 assertion을 실제 렌더 내용으로 갱신.
- **players/routes.test**: mock의 `players` 형태를 `{ online, max, players: string[] }`로 정정(라우트와 `ServerDetail.players` 타입에 정합). 기존 `players.list`는 라우트가 읽는 `players.players`와 불일치했음.

## 결과
- mcctl-console: 81파일 **870 테스트 green** (이전 2파일/4건 실패), type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)