### PR TITLE
fix(worlds): 월드 재할당 시 이전 월드의 superseded lock 정리 (#501)

### DIFF
--- a/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
+++ b/platform/services/shared/src/application/use-cases/WorldManagementUseCase.ts
@@ -403,6 +403,9 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
       // Prompt for server selection
       const server = await this.prompt.promptServerSelection(servers);
 
+      // Remember the server's current world to release its superseded lock later.
+      const previousLevel = await this.getServerLevel(server.name.value);
+
       // Execute assignment
       const spinner = this.prompt.spinner();
       spinner.start('Assigning world...');
@@ -439,6 +442,13 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
           error: levelResult.stderr || 'Failed to update server LEVEL',
         };
       }
+
+      // Release the previous world's lock if this server held it (best-effort).
+      await this.releaseSupersededWorldLock(
+        previousLevel,
+        world.name,
+        server.name.value
+      );
 
       spinner.stop('World assigned');
       this.prompt.success(`World '${world.name}' assigned to '${server.name.value}'`);
@@ -501,6 +511,10 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
       };
     }
 
+    // Remember the world this server currently points at, so we can release its
+    // (now-superseded) lock after switching (#489 follow-up).
+    const previousLevel = await this.getServerLevel(serverName);
+
     // Execute assignment (creates the lock)
     const result = await this.shell.worldAssign(worldName, serverName);
     if (!result.success) {
@@ -524,11 +538,51 @@ export class WorldManagementUseCase implements IWorldManagementUseCase {
       };
     }
 
+    // Release the previous world's lock if this server held it (best-effort —
+    // the assignment itself already succeeded).
+    await this.releaseSupersededWorldLock(previousLevel, worldName, serverName);
+
     return {
       success: true,
       worldName,
       serverName,
     };
+  }
+
+  /**
+   * The world a server currently uses, from its LEVEL (or WORLD_NAME) config.
+   * Returns undefined when neither is set (default world named after the server).
+   */
+  private async getServerLevel(serverName: string): Promise<string | undefined> {
+    const config = await this.serverRepo.getConfig(serverName);
+    return (
+      config?.customEnv?.['LEVEL']?.trim() ||
+      config?.customEnv?.['WORLD_NAME']?.trim() ||
+      undefined
+    );
+  }
+
+  /**
+   * Release the lock on the world a server was previously using, but only if
+   * that world is actually locked by this server (avoids touching another
+   * server's lock). Best-effort: never throws.
+   */
+  private async releaseSupersededWorldLock(
+    previousLevel: string | undefined,
+    newWorldName: string,
+    serverName: string
+  ): Promise<void> {
+    if (!previousLevel || previousLevel === newWorldName) {
+      return;
+    }
+    try {
+      const lock = await this.worldRepo.getLockStatus(previousLevel);
+      if (lock?.serverName === serverName) {
+        await this.shell.worldRelease(previousLevel);
+      }
+    } catch {
+      // Best-effort cleanup; the assignment already succeeded.
+    }
   }
 
   /**

--- a/platform/services/shared/tests/worldManagement-assign.test.ts
+++ b/platform/services/shared/tests/worldManagement-assign.test.ts
@@ -16,30 +16,45 @@ import type {
 function makeUseCase(overrides: {
   worldAssign?: ReturnType<typeof vi.fn>;
   setServerConfig?: ReturnType<typeof vi.fn>;
+  worldRelease?: ReturnType<typeof vi.fn>;
   isLocked?: boolean;
   worldExists?: boolean;
   serverExists?: boolean;
+  previousLevel?: string; // the server's current LEVEL before reassigning
+  previousLock?: { serverName: string } | null; // lock on the previous world
 }) {
   const worldAssign =
     overrides.worldAssign ?? vi.fn().mockResolvedValue({ success: true });
   const setServerConfig =
     overrides.setServerConfig ?? vi.fn().mockResolvedValue({ success: true });
+  const worldRelease =
+    overrides.worldRelease ?? vi.fn().mockResolvedValue({ success: true });
 
-  const shell = { worldAssign, setServerConfig } as unknown as IShellPort;
+  const shell = { worldAssign, setServerConfig, worldRelease } as unknown as IShellPort;
   const worldRepo = {
     findByName: vi.fn().mockResolvedValue(
       overrides.worldExists === false
         ? null
         : { name: 'new-world', isLocked: overrides.isLocked ?? false, lockedBy: undefined }
     ),
+    getLockStatus: vi
+      .fn()
+      .mockResolvedValue(overrides.previousLock === undefined ? null : overrides.previousLock),
   } as unknown as IWorldRepository;
   const serverRepo = {
     exists: vi.fn().mockResolvedValue(overrides.serverExists ?? true),
+    getConfig: vi
+      .fn()
+      .mockResolvedValue(
+        overrides.previousLevel
+          ? { customEnv: { LEVEL: overrides.previousLevel } }
+          : { customEnv: {} }
+      ),
   } as unknown as IServerRepository;
   const prompt = {} as IPromptPort;
 
   const useCase = new WorldManagementUseCase(prompt, shell, worldRepo, serverRepo);
-  return { useCase, worldAssign, setServerConfig };
+  return { useCase, worldAssign, setServerConfig, worldRelease };
 }
 
 describe('WorldManagementUseCase.assignWorldByName - LEVEL sync (#489)', () => {
@@ -84,5 +99,63 @@ describe('WorldManagementUseCase.assignWorldByName - LEVEL sync (#489)', () => {
     expect(result.success).toBe(false);
     expect(worldAssign).not.toHaveBeenCalled();
     expect(setServerConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('WorldManagementUseCase.assignWorldByName - superseded lock release (#489 follow-up)', () => {
+  test('releases the previous world lock when this server held it', async () => {
+    const { useCase, worldRelease } = makeUseCase({
+      previousLevel: 'old-world',
+      previousLock: { serverName: 'srv' },
+    });
+
+    const result = await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(result.success).toBe(true);
+    expect(worldRelease).toHaveBeenCalledWith('old-world');
+  });
+
+  test('does not release a previous world locked by another server', async () => {
+    const { useCase, worldRelease } = makeUseCase({
+      previousLevel: 'old-world',
+      previousLock: { serverName: 'other-srv' },
+    });
+
+    const result = await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(result.success).toBe(true);
+    expect(worldRelease).not.toHaveBeenCalled();
+  });
+
+  test('does not release when reassigning the same world', async () => {
+    const { useCase, worldRelease } = makeUseCase({
+      previousLevel: 'new-world',
+      previousLock: { serverName: 'srv' },
+    });
+
+    await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(worldRelease).not.toHaveBeenCalled();
+  });
+
+  test('does not release when the server has no previous LEVEL', async () => {
+    const { useCase, worldRelease } = makeUseCase({});
+
+    await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(worldRelease).not.toHaveBeenCalled();
+  });
+
+  test('assignment still succeeds even if releasing the old lock throws', async () => {
+    const worldRelease = vi.fn().mockRejectedValue(new Error('release boom'));
+    const { useCase } = makeUseCase({
+      worldRelease,
+      previousLevel: 'old-world',
+      previousLock: { serverName: 'srv' },
+    });
+
+    const result = await useCase.assignWorldByName('new-world', 'srv');
+
+    expect(result.success).toBe(true);
   });
 });


### PR DESCRIPTION
## 개요
#489(assign 시 LEVEL 동기화)의 후속. 서버에 다른 월드를 재할당하면 새 월드는 lock+LEVEL이 일치하지만 *이전* 월드의 lock이 남아 stale 상태로 발산하던 문제를 정리합니다.

Closes #501

## 변경 (`WorldManagementUseCase`)
- `assignWorldByName` / `assignWorld`(interactive): 새 월드 lock+LEVEL 설정 후, 서버가 이전에 쓰던 월드(LEVEL)의 lock이 **이 서버 소유**인 경우에만 release.
- 헬퍼: `getServerLevel`(이전 LEVEL 조회), `releaseSupersededWorldLock`(소유 검증 + best-effort, 예외 무시).
- 안전장치: 동일 월드 재할당/이전 LEVEL 없음/타 서버 소유 시 미해제. release 실패해도 assign은 성공(주 작업 이미 완료).

## 테스트
- `worldManagement-assign.test.ts` +5건: 해제 / 타서버 미해제 / 동일월드 미해제 / 이전없음 미해제 / 해제 실패해도 성공.
- shared 25파일 **518 통과**, `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)