### PR TITLE
chore(docker): itzg 이미지 최신 반영 (mc-router 1.43.1) 및 태그 일관성 정리 (#503)

### DIFF
--- a/docs/documentforllmagent.md
+++ b/docs/documentforllmagent.md
@@ -1971,7 +1971,7 @@ mc-router is a connection multiplexer enabling multiple Minecraft servers to sha
 ```yaml
 services:
   mc-router:
-    image: itzg/mc-router:1.42.0  # Pin to explicit version for reproducible deployments
+    image: itzg/mc-router:1.43.1  # Pin to explicit version for reproducible deployments
     command: --in-docker --auto-scale-up --auto-scale-down
     ports:
       - "25565:25565"
@@ -2063,7 +2063,7 @@ Uses annotations on services.
 ```yaml
 services:
   router:
-    image: itzg/mc-router:1.42.0  # Pin to explicit version for reproducible deployments
+    image: itzg/mc-router:1.43.1  # Pin to explicit version for reproducible deployments
     command: --in-docker --auto-scale-up --auto-scale-down
     ports:
       - "25565:25565"

--- a/docs/server-configuration-reference.md
+++ b/docs/server-configuration-reference.md
@@ -1253,9 +1253,9 @@ include:
 
 services:
   router:
-    # Pinned to v1.42.0 for production stability.
+    # Pinned to v1.43.1 for production stability.
     # Check releases: https://github.com/itzg/mc-router/releases
-    image: itzg/mc-router:1.42.0
+    image: itzg/mc-router:1.43.1
     container_name: mc-router
     restart: unless-stopped
     environment:

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -55,9 +55,9 @@ services:
   # No MAPPING environment variable needed with --in-docker mode
   # ===========================================================================
   router:
-    # Pinned to v1.42.0 for production stability.
+    # Pinned to v1.43.1 for production stability.
     # Check releases: https://github.com/itzg/mc-router/releases
-    image: itzg/mc-router:1.42.0
+    image: itzg/mc-router:1.43.1
     container_name: mc-router
     restart: unless-stopped
     environment:

--- a/platform/services/cli/templates/docker-compose.yml
+++ b/platform/services/cli/templates/docker-compose.yml
@@ -49,7 +49,9 @@ services:
   # No MAPPING environment variable needed with --in-docker mode
   # ===========================================================================
   router:
-    image: itzg/mc-router
+    # Pinned to v1.43.1 for production stability.
+    # Check releases: https://github.com/itzg/mc-router/releases
+    image: itzg/mc-router:1.43.1
     container_name: mc-router
     restart: unless-stopped
     environment:

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -49,7 +49,9 @@ services:
   # No MAPPING environment variable needed with --in-docker mode
   # ===========================================================================
   router:
-    image: itzg/mc-router
+    # Pinned to v1.43.1 for production stability.
+    # Check releases: https://github.com/itzg/mc-router/releases
+    image: itzg/mc-router:1.43.1
     container_name: mc-router
     restart: unless-stopped
     environment:

--- a/templates/servers/_template/docker-compose.yml
+++ b/templates/servers/_template/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   # Example: mc-template -> mc-ironwood
   # ---------------------------------------------------------------------------
   mc-template:
-    image: itzg/minecraft-server:java21
+    image: itzg/minecraft-server:java25
     container_name: mc-template
     restart: "no"
     tty: true


### PR DESCRIPTION
## Summary
itzg Docker 이미지 최신 정보를 플랫폼에 반영합니다. **버전 범프 + 이미지 태그 일관성 정리**(저위험, breaking change 없음).

Closes #503

## Changes
**Config (commit 1):**
- `platform/docker-compose.yml`: `itzg/mc-router:1.42.0` → `1.43.1`
- `platform/services/cli/templates/docker-compose.yml`, `templates/docker-compose.yml`: 무핀 `itzg/mc-router` → `1.43.1` 핀
- `templates/servers/_template/docker-compose.yml`: `minecraft-server:java21` → `java25` (CLI 번들 템플릿·`platform/servers/_template`과 일치, `McVersion` LATEST 기본값과 정합)

**Docs (commit 2):**
- `docs/server-configuration-reference.md`, `docs/documentforllmagent.md`(x2): `mc-router:1.42.0` → `1.43.1`

## Analysis 요약
- **minecraft-server**: 날짜 버전 핀이 아닌 MC 버전→Java 태그 매핑 전략. `McVersion.ts`/`update.ts` 로직이 이미 최신(`java25`)과 정합 → 핵심 변경 불필요. 2026.5.x~6.0 릴리즈는 버그 수정/의존성 위주, 새 TYPE·env 스키마 변경 없음.
- **mc-router 1.42.0→1.43.1**: `--in-docker` 라벨 기반 auto-scale에 설정 변경/breaking change 없음. 이벤트 기반 Docker 폴링·TZ 지원·`--log-level` 등 개선 포함.

## Test
- `grep -rn "mc-router:1.42" docs/ platform/ templates/` → 0건 ✅
- 무핀 `image: itzg/mc-router` → 0건 ✅
- CLI 이미지 관련 테스트 22/22 통과 (`upgrade-image-tags`, `docker-image-pull`) ✅

## Note (out of scope)
- `pnpm lint`이 `@minecraft-docker/mcctl`(cli) 패키지에서 실패하나, **본 PR과 무관한 기존 문제**입니다 — cli 패키지에 ESLint config 파일이 없어 clean develop에서도 동일하게 실패. 본 변경은 TS 소스(`src`)를 건드리지 않고 템플릿/문서만 수정. 별도 이슈로 분리 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
