### PR TITLE
chore(lint): cli 패키지 ESLint 설정 추가 및 위반 정리 (#505)

### DIFF
--- a/platform/services/cli/.eslintrc.json
+++ b/platform/services/cli/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended"],
+  "ignorePatterns": ["dist/", "node_modules/", "*.js", "*.cjs"],
+  "rules": {
+    "no-unused-vars": "off",
+    "no-undef": "off",
+    "no-control-regex": "off"
+  }
+}

--- a/platform/services/cli/src/commands/console/service.ts
+++ b/platform/services/cli/src/commands/console/service.ts
@@ -572,11 +572,12 @@ export async function consoleServiceCommand(options: ConsoleServiceOptions): Pro
       case 'logs':
         return await showLogs(paths, pm2Adapter, options);
 
-      default:
+      default: {
         // Default: show status
         const status = await getConsoleServiceStatus(pm2Adapter, apiPort, consolePort);
         formatStatus(status, options.json ?? false);
         return 0;
+      }
     }
   } finally {
     pm2Adapter.disconnect();

--- a/platform/services/cli/src/commands/player.ts
+++ b/platform/services/cli/src/commands/player.ts
@@ -202,7 +202,7 @@ async function handleInteractiveMode(options: PlayerCommandOptions): Promise<num
     const containerName = getContainerName(serverName);
 
     // Main interaction loop
-    while (true) {
+    for (;;) {
       // Step 2: Select player
       const selectedPlayer = await selectPlayer({
         containerName,

--- a/platform/services/cli/src/lib/pm2-utils.ts
+++ b/platform/services/cli/src/lib/pm2-utils.ts
@@ -52,18 +52,13 @@ export function checkPm2Installation(): { installed: boolean; path?: string; ver
     };
   }
 
-  // Check if pm2 module can be imported (local installation via npm)
-  // The pm2 programmatic API works without global installation
-  try {
-    // We already have pm2 as a dependency, so it's always available
-    // Just return true - the actual PM2 operations will work via the API
-    return {
-      installed: true,
-      version: 'local',
-    };
-  } catch {
-    return { installed: false };
-  }
+  // Check if pm2 module can be imported (local installation via npm).
+  // The pm2 programmatic API works without global installation, and pm2 is a
+  // declared dependency, so it's always available via the API.
+  return {
+    installed: true,
+    version: 'local',
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
`@minecraft-docker/mcctl`(cli) 패키지에 ESLint 설정 파일이 없어 `pnpm lint`가 실패하던 문제를 해결합니다. `platform/services/shared/.eslintrc.json`과 동일한 구성을 추가하고, 그로 인해 드러난 lint 위반 3건을 정리합니다.

Closes #505

## Changes
**commit 1 — config 추가:**
- `platform/services/cli/.eslintrc.json` 신규 생성 (shared와 동일 구성). `eslint`/`@typescript-eslint`는 루트 hoisting되어 devDep 추가 불필요.

**commit 2 — config가 드러낸 위반 정리 (동작 변경 없음):**
- `console/service.ts`: `default:` 케이스 본문을 블록으로 감쌈 (`no-case-declarations`)
- `player.ts`: 메인 루프 `while (true)` → `for (;;)` (`no-constant-condition`)
- `pm2-utils.ts`: try 본문이 리터럴 객체만 반환해 던질 수 없는 **도달 불가 try/catch 제거** (`no-unreachable`), 상태 객체를 직접 반환

## Test
- `pnpm --filter @minecraft-docker/mcctl lint` → 정상 (config not found 해소) ✅
- 워크스페이스 전체 `pnpm lint` → 통과 (mcctl-console은 기존 warning만, 에러 아님) ✅
- cli 전체 테스트 **325/325 통과**, `tsc` build 통과 ✅

## Note (out of scope / 기존 문제)
- cli 테스트에서 `domain/value-objects/ServerType.test.ts`, `WorldOptions.test.ts` 등이 `No test suite found`로 실패하나, **clean develop에서도 동일 재현되는 기존 문제**(본 변경과 무관). 별도 이슈로 분리 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
