### PR TITLE
docs: itzg 이미지 변경 문서 후속 동기화 (#507)

### DIFF
--- a/docs/advanced/networking.ko.md
+++ b/docs/advanced/networking.ko.md
@@ -165,6 +165,12 @@ avahi-daemon --check
 
 mc-router는 호스트네임 기반 라우팅과 자동 스케일링을 처리합니다.
 
+!!! info "고정된 버전"
+    플랫폼은 재현 가능한 배포를 위해 `docker-compose.yml`에서 `itzg/mc-router`를 `1.43.1`로 고정합니다.
+    `1.42.0` 대비 이 릴리스는 이벤트 기반 Docker 폴링(자동 스케일 반응성 향상),
+    타임존(`TZ`) 지원, `--log-level` 옵션을 추가했습니다. 호환성을 깨는 변경(breaking change)은 없으며,
+    여기서 사용하는 라벨 기반 `--in-docker` 자동 스케일 방식은 설정 변경이 필요하지 않습니다.
+
 ### mcctl로 라우터 관리
 
 ```bash

--- a/docs/advanced/networking.md
+++ b/docs/advanced/networking.md
@@ -165,6 +165,12 @@ avahi-daemon --check
 
 mc-router handles hostname-based routing and auto-scaling.
 
+!!! info "Pinned version"
+    The platform pins `itzg/mc-router` to `1.43.1` in `docker-compose.yml` for reproducible deployments.
+    Compared to `1.42.0`, this release adds event-based Docker polling (faster auto-scale reactions),
+    timezone (`TZ`) support, and a `--log-level` option. There are no breaking changes, and the
+    label-based `--in-docker` auto-scale workflow used here needs no configuration changes.
+
 ### Router Management with mcctl
 
 ```bash

--- a/docs/documentforllmagent.md
+++ b/docs/documentforllmagent.md
@@ -1,7 +1,7 @@
 # mcctl - Docker Minecraft Server Management CLI
 
-> **Version**: 2.20.3
-> **Last Updated**: 2026-05-03
+> **Version**: 2.22.0
+> **Last Updated**: 2026-06-21
 > **Purpose**: Comprehensive knowledge base for LLM agents (ChatGPT, Gemini, Claude, NotebookLM) to answer all mcctl questions
 
 ---
@@ -2830,6 +2830,16 @@ A: `mcctl update` updates the CLI and service packages to newer versions. `mcctl
 ---
 
 ## 16. Version History
+
+### Version 2.22.0 (2026-06-21) - itzg Image Refresh
+
+**Changed:**
+- **mc-router Image Pin** - Bump `itzg/mc-router` pin from `1.42.0` to `1.43.1` in `platform/docker-compose.yml` and pin the two previously-unpinned mc-router compose templates to `1.43.1` (#503, #504)
+- **Server Template Java Tag** - Align the `_template` `itzg/minecraft-server` image tag from `java21` to `java25`, matching the McVersion LATEST default and the bundled CLI templates (#503, #504)
+
+**Notes:**
+- mc-router `1.43.1` introduces event-based Docker polling (faster auto-scale reactions), timezone (`TZ`) support, and a `--log-level` option. There are no breaking changes versus `1.42.0`, and the label-based `--in-docker` auto-scale workflow used here requires no configuration changes.
+- The platform maps a Minecraft version to a Java image tag rather than pinning to a date-based image tag (see `McVersion`): MC 26+/LATEST → `java25`, 1.21+ → `java21`, 1.18-1.20.x → `java17`.
 
 ### Version 2.20.3 (2026-05-03) - mc-router Stability
 


### PR DESCRIPTION
## Summary
#503/#504(itzg 이미지 최신 반영)의 문서 후속 동기화. 코드/설정은 이미 머지됐고, 본 PR은 누락된 문서 갱신을 보강합니다.

Closes #507
Refs #503, #504

## Changes
- `docs/documentforllmagent.md`: KB 헤더 `2.20.3 → 2.22.0` / 날짜 갱신, **`Version 2.22.0` 변경이력 항목 추가** (mc-router 1.43.1 핀, `_template` java25 통일, 1.43.1 개선점, McVersion Java 매핑 전략)
- `docs/advanced/networking.md` (EN), `networking.ko.md` (KO): mc-router `1.43.1` 핀 및 1.42.0 대비 개선점(이벤트 기반 Docker 폴링·`TZ`·`--log-level`, breaking change 없음) `!!! info` 노트 추가

## Notes
- `documentforllmagent.md`의 v2.20.3 이력 항목은 "1.42.0 핀 최초 도입 시점" 역사 기록이라 의도적으로 유지.
- `server-configuration-reference.md` Java 매트릭스는 이미 McVersion 로직과 일치 → 변경 없음.

## Out of Scope (후속)
- `networking.ko.md:204` `DOCKER_TIMEOUT=120` vs EN `120s` 불일치 (Go duration 파싱 오류) — 별도 처리 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
