### PR TITLE
feat(cli): mcctl update 기본 전체 업데이트 + --cli-only (#509)

### DIFF
--- a/docs/cli/commands.ko.md
+++ b/docs/cli/commands.ko.md
@@ -312,10 +312,16 @@ mcctl update [options]
 
 | 옵션 | 설명 |
 |--------|-------------|
+| `--cli-only` | mcctl CLI 바이너리만 업데이트 (전체 업데이트 opt-out) |
 | `--check` | 업데이트만 확인 (설치하지 않음) |
 | `--yes` | 확인 프롬프트 없이 자동 업데이트 |
 | `--force` | 캐시를 무시하고 강제 버전 확인 |
-| `--all` | CLI 및 설치된 모든 서비스 업데이트 |
+| `--all` | Deprecated 별칭 — 기본 동작과 동일 (하위 호환용) |
+
+!!! note "기본 동작 변경"
+    `mcctl update`는 이제 기본적으로 CLI **와 함께** 설치된 모든 서비스(API, Console, `shared`) 및
+    서버 이미지 태그/Docker 이미지까지 업데이트합니다(기존 `--all` 동작). CLI 바이너리만 업데이트하려면
+    `--cli-only`를 사용하세요.
 
 **예제:**
 
@@ -342,9 +348,9 @@ mcctl update [options]
     You are up to date.
     ```
 
-=== "CLI 업데이트"
+=== "CLI만 업데이트"
     ```bash
-    mcctl update
+    mcctl update --cli-only
     ```
 
     **출력:**
@@ -360,9 +366,9 @@ mcctl update [options]
     ✓ mcctl updated to 2.12.1
     ```
 
-=== "모든 서비스 업데이트"
+=== "전체 업데이트 (기본)"
     ```bash
-    mcctl update --all
+    mcctl update
     ```
 
     **출력:**
@@ -393,9 +399,12 @@ mcctl update [options]
 
 - **업데이트 확인 캐시**: 버전 확인은 `~/.mcctl-update-check.json`에 24시간 동안 캐시됩니다. 일반 CLI 사용 중에는 백그라운드에서 비차단 업데이트 확인이 자동으로 실행됩니다.
 - **`--check` 종료 코드**: 업데이트가 가능하면 종료 코드 `1`, 최신 버전이면 `0`을 반환합니다. 스크립팅에 유용합니다.
-- **`--all` 플래그**: CLI 업데이트 후 설치된 서비스도 업데이트합니다:
+- **기본 동작 (전체 업데이트)**: CLI 업데이트 후 설치된 서비스와 이미지까지 갱신합니다:
     - `mcctl-api` 및 `mcctl-console`: 최신 버전 설치 후 PM2 서비스 재시작
     - `shared` 라이브러리: 최신 버전 설치 (재시작 불필요)
+    - 각 서버 `docker-compose.yml`의 이미지 태그를 권장 Java 태그로 정렬한 뒤 Docker 이미지 pull
+    - CLI가 이미 최신이어도 서비스는 갱신됩니다
+- **`--cli-only` 플래그**: mcctl CLI 바이너리만 업데이트하고 서비스/이미지는 건너뜁니다.
 
 !!! tip "스크립트에서 --check 활용"
     `--check`를 스크립트에서 사용하여 조건부 업데이트를 실행할 수 있습니다:

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -312,10 +312,16 @@ mcctl update [options]
 
 | Option | Description |
 |--------|-------------|
+| `--cli-only` | Update only the mcctl CLI binary (opt out of the full update) |
 | `--check` | Check for updates only (does not install) |
 | `--yes` | Auto-confirm update without prompt |
 | `--force` | Force fresh version check (ignore cache) |
-| `--all` | Update CLI and all installed services |
+| `--all` | Deprecated alias — same as the default (kept for backward compatibility) |
+
+!!! note "Default behavior changed"
+    `mcctl update` now updates the CLI **and** all installed services (API, Console, `shared`) plus
+    server image tags / Docker images by default — the previous `--all` behavior. Use `--cli-only`
+    to update just the CLI binary.
 
 **Examples:**
 
@@ -342,9 +348,9 @@ mcctl update [options]
     You are up to date.
     ```
 
-=== "Update CLI"
+=== "Update CLI Only"
     ```bash
-    mcctl update
+    mcctl update --cli-only
     ```
 
     **Output:**
@@ -360,9 +366,9 @@ mcctl update [options]
     ✓ mcctl updated to 2.12.1
     ```
 
-=== "Update All Services"
+=== "Update Everything (default)"
     ```bash
-    mcctl update --all
+    mcctl update
     ```
 
     **Output:**
@@ -393,9 +399,12 @@ mcctl update [options]
 
 - **Update check cache**: Version checks are cached for 24 hours at `~/.mcctl-update-check.json`. During normal CLI usage, a non-blocking update check runs automatically in the background.
 - **`--check` exit codes**: Returns exit code `1` if an update is available, `0` if up to date. Useful for scripting.
-- **`--all` flag**: After updating the CLI, also updates installed services:
+- **Default (full update)**: After updating the CLI, also updates installed services and refreshes images:
     - `mcctl-api` and `mcctl-console`: Installs latest version and restarts the PM2 service
     - `shared` library: Installs latest version (no restart needed)
+    - Server `docker-compose.yml` image tags aligned to the recommended Java tag, then Docker images pulled
+    - Services are updated even when the CLI is already up to date
+- **`--cli-only` flag**: Updates only the mcctl CLI binary and skips services/images.
 
 !!! tip "Scripting with --check"
     Use `--check` in scripts to conditionally trigger updates:

--- a/platform/services/cli/src/commands/update.ts
+++ b/platform/services/cli/src/commands/update.ts
@@ -241,7 +241,15 @@ export interface UpdateCommandOptions {
   check?: boolean;
   force?: boolean;
   yes?: boolean;
+  /**
+   * Backward-compatible alias. Updating CLI + services is now the default,
+   * so this flag is a no-op kept so existing `--all` invocations keep working.
+   */
   all?: boolean;
+  /**
+   * Opt out of the full update and only update the CLI binary.
+   */
+  cliOnly?: boolean;
   root?: string;
 }
 
@@ -717,8 +725,8 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<numb
   // Print version info
   printVersionInfo(currentVersion, latestVersion, hasUpdate);
 
-  // If --check with --all, show service info too
-  if (options.check && options.all) {
+  // By default the check also covers services (unless --cli-only)
+  if (options.check && !options.cliOnly) {
     const rootDir = new Paths(options.root).root;
     await updateServices(rootDir, { check: true });
     return hasUpdate ? 1 : 0;
@@ -731,8 +739,8 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<numb
 
   // If no update available for CLI, skip CLI update
   if (!hasUpdate) {
-    // But still update services if --all
-    if (options.all) {
+    // But still update services by default (unless --cli-only)
+    if (!options.cliOnly) {
       const rootDir = new Paths(options.root).root;
       return updateServices(rootDir, { yes: options.yes });
     }
@@ -767,8 +775,8 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<numb
     // Clear cache after successful update
     clearCache();
 
-    // Update services if --all
-    if (options.all) {
+    // Update services by default (unless --cli-only)
+    if (!options.cliOnly) {
       const rootDir = new Paths(options.root).root;
       return updateServices(rootDir, { yes: options.yes });
     }

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -291,11 +291,12 @@ ${colors.cyan('Migration:')}
   ${colors.bold('migrate worlds')} --dry-run   Preview changes without applying
 
 ${colors.cyan('Self Update:')}
-  ${colors.bold('update')}                     Check and update mcctl to latest version
+  ${colors.bold('update')}                     Update CLI and all installed services (default)
+  ${colors.bold('update')} --cli-only          Update only the mcctl CLI binary
   ${colors.bold('update')} --check             Check for updates only (no install)
   ${colors.bold('update')} --force             Force check (ignore cache)
   ${colors.bold('update')} --yes               Auto-confirm update
-  ${colors.bold('update')} --all               Update CLI and all installed services
+  ${colors.bold('update')} --all               Deprecated alias (same as default)
 
 ${colors.cyan('Platform Upgrade:')}
   ${colors.bold('upgrade')}                    Sync .env and templates with latest CLI version
@@ -986,6 +987,7 @@ async function main(): Promise<void> {
           force: flags['force'] === true,
           yes: flags['yes'] === true,
           all: flags['all'] === true,
+          cliOnly: flags['cli-only'] === true,
           root: rootDir,
         });
         break;

--- a/platform/services/cli/tests/unit/commands/update.test.ts
+++ b/platform/services/cli/tests/unit/commands/update.test.ts
@@ -113,17 +113,16 @@ describe('update command', () => {
     consoleLogSpy.mockRestore();
   });
 
-  describe('without --all flag', () => {
-    it('should not call checkServiceAvailability', async () => {
-      await updateCommand({ check: false, force: false, yes: false });
+  describe('default (no flag) = full update', () => {
+    it('should call checkServiceAvailability by default (services included)', async () => {
+      await updateCommand({ check: false, force: false, yes: true });
 
-      expect(mockCheckServiceAvailability).not.toHaveBeenCalled();
+      expect(mockCheckServiceAvailability).toHaveBeenCalled();
     });
-  });
 
-  describe('with --all flag', () => {
-    it('should call checkServiceAvailability when --all is set', async () => {
-      await updateCommand({ all: true, yes: true });
+    it('should update services even when CLI is already up to date', async () => {
+      // beforeEach sets isUpdateAvailable = false (CLI already latest)
+      await updateCommand({ yes: true });
 
       expect(mockCheckServiceAvailability).toHaveBeenCalled();
     });
@@ -134,7 +133,7 @@ describe('update command', () => {
         console: { available: false },
       });
 
-      const exitCode = await updateCommand({ all: true, yes: true });
+      const exitCode = await updateCommand({ yes: true });
 
       expect(exitCode).toBe(0);
       expect(mockCheckServiceAvailability).toHaveBeenCalled();
@@ -145,7 +144,7 @@ describe('update command', () => {
       expect(serviceInstallCalls.length).toBe(0);
     });
 
-    it('should show service versions with --check --all without installing', async () => {
+    it('should show service versions with --check by default without installing', async () => {
       mockCheckServiceAvailability.mockReturnValue({
         api: { available: true, path: '/tmp/node_modules/@minecraft-docker/mcctl-api/dist/index.js' },
         console: { available: false },
@@ -164,7 +163,7 @@ describe('update command', () => {
         return false;
       });
 
-      await updateCommand({ check: true, all: true, yes: false });
+      await updateCommand({ check: true, yes: false });
 
       expect(mockCheckServiceAvailability).toHaveBeenCalled();
       // npm install should NOT be called (check-only mode)
@@ -172,6 +171,28 @@ describe('update command', () => {
         (call: any[]) => call[0] === 'npm' && call[1]?.[0] === 'install'
       );
       expect(installCalls.length).toBe(0);
+    });
+  });
+
+  describe('--cli-only flag (opt-out)', () => {
+    it('should NOT call checkServiceAvailability when --cli-only is set', async () => {
+      await updateCommand({ cliOnly: true, yes: true });
+
+      expect(mockCheckServiceAvailability).not.toHaveBeenCalled();
+    });
+
+    it('should not check services with --check --cli-only', async () => {
+      await updateCommand({ check: true, cliOnly: true, yes: false });
+
+      expect(mockCheckServiceAvailability).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('--all flag (backward-compatible alias for default)', () => {
+    it('should still call checkServiceAvailability when --all is set', async () => {
+      await updateCommand({ all: true, yes: true });
+
+      expect(mockCheckServiceAvailability).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
`mcctl update`의 기본 동작을 **전체 업데이트**(CLI + 서비스 + 서버 이미지 태그 정리 + docker pull)로 변경하고, CLI만 갱신하는 `--cli-only` opt-out을 추가합니다. 사용자가 `--all`을 기억하지 않아도 콘솔/API/이미지까지 한 번에 최신으로 맞춰집니다.

Closes #509

## Changes (TDD)
**feat (`update.ts`, `index.ts`):**
- `mcctl update` 무플래그 = 기존 `--all` 동작 (서비스 PM2 재시작 + 이미지 정리/pull 포함)
- **CLI가 이미 최신이어도 서비스는 갱신** (지금 발생한 혼란 해소)
- `--cli-only` 추가: CLI 바이너리만 갱신
- `--all`: 하위호환 no-op 별칭으로 유지
- `--check`: 기본적으로 서비스 버전까지 표시, `--check --cli-only`는 CLI만
- 도움말 텍스트 갱신

**docs:** `docs/cli/commands.md` / `.ko.md` update 항목 갱신 (기본 동작 변경 note + `--cli-only`)

## Test
- TDD Red→Green: `update.test.ts` 기본 동작/`--cli-only`/`--all` 별칭 케이스 추가·수정 → **14/14 통과**
- `tsc` build, `pnpm lint` (cli) 통과

## Notes
- **E2E 미추가**: `mcctl update`는 실제 npm 설치·네트워크·PM2 재시작 부작용이 있어 e2e가 비실용적/위험. 플래그 라우팅 동작은 단위 테스트(모킹)로 커버.
- 시작 시 24시간 캐시 자동 알림(`checkForUpdates`)은 현행 유지(범위 제외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
