### PR TITLE
feat: 모드팩 loader/version 호환성 콤보박스 + 검증 (#511)

### DIFF
--- a/platform/scripts/create-server.sh
+++ b/platform/scripts/create-server.sh
@@ -490,6 +490,13 @@ if [ -f "$CONFIG_FILE" ]; then
     if [ -n "$MC_VERSION" ]; then
         sed -i "s/^VERSION=.*/VERSION=$MC_VERSION/" "$CONFIG_FILE"
         echo "   Version: $MC_VERSION"
+    elif [[ "$SERVER_TYPE" =~ ^(MODRINTH|AUTO_CURSEFORGE)$ ]]; then
+        # For modpack types, the template's default VERSION (e.g. 1.20.4) must
+        # NOT leak: an incompatible VERSION makes itzg fail with
+        # "No files available". When no version is supplied, let the modpack
+        # determine the Minecraft version by neutralizing the template VERSION.
+        sed -i "s/^VERSION=.*/# VERSION omitted: determined by modpack/" "$CONFIG_FILE"
+        echo "   Version: (determined by modpack)"
     fi
 
     # Apply world options

--- a/platform/services/mcctl-api/src/routes/servers.ts
+++ b/platform/services/mcctl-api/src/routes/servers.ts
@@ -17,7 +17,11 @@ import {
   WorldRepository,
   ServerRepository,
   Paths,
+  ModSourceFactory,
+  buildModpackCompatibilityMatrix,
+  isModpackCompatible,
 } from '@minecraft-docker/shared';
+import '@minecraft-docker/mod-source-modrinth';
 import {
   ServerListResponseSchema,
   ServerDetailResponseSchema,
@@ -608,6 +612,35 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         error: 'BadRequest',
         message: `Modpack slug is required for ${type} server type`,
       });
+    }
+
+    // Validate modpack loader/Minecraft-version compatibility for MODRINTH.
+    // An incompatible (loader, version) pair makes itzg fail with
+    // "No files available", so reject it up-front with a 400.
+    // Only enforced when both a loader and an explicit version are supplied;
+    // if the modpack metadata can't be fetched we fail open (do not block).
+    if (type === 'MODRINTH' && modpack && modLoader && version) {
+      try {
+        const source = ModSourceFactory.get('modrinth');
+        const versions = await source.getVersions(modpack);
+        if (versions && versions.length > 0) {
+          const matrix = buildModpackCompatibilityMatrix(versions);
+          if (!isModpackCompatible(matrix, modLoader, version)) {
+            const supported = matrix.byLoader[modLoader.toLowerCase()]?.gameVersions ?? [];
+            const hint = supported.length > 0
+              ? ` Loader '${modLoader}' supports: ${supported.join(', ')}.`
+              : ` Loader '${modLoader}' is not available for modpack '${modpack}'.`;
+            return reply.code(400).send({
+              error: 'BadRequest',
+              message:
+                `Modpack '${modpack}' has no '${modLoader}' release for Minecraft ${version}.${hint}`,
+            });
+          }
+        }
+      } catch (error) {
+        // Fail open: a transient metadata-fetch failure should not block creation.
+        fastify.log.warn(error, 'Modpack compatibility check skipped (metadata fetch failed)');
+      }
     }
 
     // World options are mutually exclusive (seed / worldUrl / worldName).

--- a/platform/services/mcctl-api/src/routes/servers/mods.ts
+++ b/platform/services/mcctl-api/src/routes/servers/mods.ts
@@ -1,6 +1,11 @@
 import { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
 import fp from 'fastify-plugin';
-import { serverExists, AuditActionEnum, ModSourceFactory } from '@minecraft-docker/shared';
+import {
+  serverExists,
+  AuditActionEnum,
+  ModSourceFactory,
+  buildModpackCompatibilityMatrix,
+} from '@minecraft-docker/shared';
 import '@minecraft-docker/mod-source-modrinth';
 import { writeAuditLog } from '../../services/audit-log-service.js';
 import { createModConfigService } from '../../services/ModConfigService.js';
@@ -25,11 +30,16 @@ interface RemoveModRoute {
 }
 
 interface SearchModsRoute {
-  Querystring: { q: string; limit?: number; offset?: number };
+  Querystring: { q: string; limit?: number; offset?: number; type?: string };
 }
 
 interface GetProjectsRoute {
   Querystring: { slugs: string; source?: string };
+}
+
+interface ModVersionsRoute {
+  Params: { slug: string };
+  Querystring: { source?: string };
 }
 
 // ============================================================
@@ -283,7 +293,7 @@ const modsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       },
     },
   }, async (request: FastifyRequest<SearchModsRoute>, reply: FastifyReply) => {
-    const { q, limit, offset } = request.query;
+    const { q, limit, offset, type } = request.query;
 
     try {
       if (!q || !q.trim()) {
@@ -294,12 +304,57 @@ const modsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       const result = await source.search(q, {
         limit: limit != null ? Number(limit) : 10,
         offset: offset != null ? Number(offset) : 0,
+        // Restrict to modpacks when requested (used by Create Server autocomplete)
+        ...(type === 'modpack' ? { projectType: 'modpack' as const } : {}),
       });
 
       return reply.send(result);
     } catch (error) {
       fastify.log.error(error, 'Failed to search mods');
       return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to search mods' });
+    }
+  });
+
+  /**
+   * GET /api/mods/:slug/versions
+   * Return a loader -> game-version compatibility matrix for a modpack/mod.
+   * Used by the Create Server dialog to offer only valid (loader, MC version)
+   * combinations and prevent the "No files available" failure.
+   */
+  fastify.get<ModVersionsRoute>('/api/mods/:slug/versions', {
+    schema: {
+      description: 'Get loader/Minecraft-version compatibility matrix for a modpack',
+      tags: ['mods'],
+      response: {
+        404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<ModVersionsRoute>, reply: FastifyReply) => {
+    const { slug } = request.params;
+    const { source: sourceName } = request.query;
+
+    try {
+      if (!slug || !slug.trim()) {
+        return reply.code(400).send({ error: 'BadRequest', message: 'Path parameter "slug" is required' });
+      }
+
+      const source = ModSourceFactory.get(sourceName || 'modrinth');
+      const versions = await source.getVersions(slug);
+
+      if (!versions || versions.length === 0) {
+        return reply.code(404).send({
+          error: 'NotFound',
+          message: `No versions found for modpack '${slug}'`,
+        });
+      }
+
+      const matrix = buildModpackCompatibilityMatrix(versions);
+
+      return reply.send({ slug, ...matrix });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to get mod versions');
+      return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get mod versions' });
     }
   });
 };

--- a/platform/services/mcctl-api/src/schemas/server.ts
+++ b/platform/services/mcctl-api/src/schemas/server.ts
@@ -156,6 +156,10 @@ export const CreateServerRequestSchema = Type.Object({
   autoStart: Type.Optional(Type.Boolean({ default: true })),
   sudoPassword: Type.Optional(Type.String({ writeOnly: true })),
   modpack: Type.Optional(Type.String({
+    // Restrict to Modrinth slug/ID/URL characters. Excludes shell
+    // metacharacters (quotes, ;, spaces, $, backticks, etc.) to harden the
+    // non-SSE create path that interpolates args into a shell command.
+    pattern: '^[A-Za-z0-9_./:-]+$',
     description: 'Modrinth modpack slug, ID, or URL (required for MODRINTH/AUTO_CURSEFORGE)',
   })),
   modpackVersion: Type.Optional(Type.String({

--- a/platform/services/mcctl-api/tests/server-mods.test.ts
+++ b/platform/services/mcctl-api/tests/server-mods.test.ts
@@ -347,5 +347,149 @@ MEMORY=4G
 
       expect(adapter.search).toHaveBeenCalledWith('test', { limit: 5, offset: 5 });
     });
+
+    it('should pass modpack projectType filter to search when type=modpack', async () => {
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.search as any).mockResolvedValue({ hits: [], totalHits: 0, offset: 0, limit: 10 });
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/mods/search?q=cobblemon&type=modpack',
+      });
+
+      expect(adapter.search).toHaveBeenCalledWith(
+        'cobblemon',
+        expect.objectContaining({ projectType: 'modpack' })
+      );
+    });
+  });
+
+  // ============================================================
+  // GET /api/mods/:slug/versions
+  // ============================================================
+
+  describe('GET /api/mods/:slug/versions', () => {
+    const sampleVersions = [
+      {
+        id: 'v-neoforge',
+        projectId: 'proj-1',
+        name: 'NeoForge 2.0',
+        versionNumber: '2.0.0',
+        versionType: 'release',
+        gameVersions: ['1.21.1'],
+        loaders: ['neoforge'],
+        files: [],
+        dependencies: [],
+        downloads: 100,
+        datePublished: '2024-06-01T00:00:00Z',
+      },
+      {
+        id: 'v-forge',
+        projectId: 'proj-1',
+        name: 'Forge 1.0',
+        versionNumber: '1.0.0',
+        versionType: 'release',
+        gameVersions: ['1.19.2'],
+        loaders: ['forge'],
+        files: [],
+        dependencies: [],
+        downloads: 50,
+        datePublished: '2024-01-01T00:00:00Z',
+      },
+    ];
+
+    it('should return a compatibility matrix for a modpack slug', async () => {
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.getVersions as any).mockResolvedValue(sampleVersions);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/mods/cobblemon/versions',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.slug).toBe('cobblemon');
+      expect(body.loaders.sort()).toEqual(['forge', 'neoforge']);
+      expect(body.byLoader.neoforge.gameVersions).toEqual(['1.21.1']);
+      expect(body.byLoader.neoforge.recommended['1.21.1']).toBe('2.0.0');
+      expect(body.byLoader.forge.gameVersions).toEqual(['1.19.2']);
+    });
+
+    it('should return 404 when project has no versions (unknown slug)', async () => {
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.getVersions as any).mockResolvedValue([]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/mods/does-not-exist/versions',
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  // ============================================================
+  // POST /api/servers - modpack compatibility validation
+  // ============================================================
+
+  describe('POST /api/servers modpack validation', () => {
+    const compatVersions = [
+      {
+        id: 'v-neoforge',
+        projectId: 'proj-1',
+        name: 'NeoForge 2.0',
+        versionNumber: '2.0.0',
+        versionType: 'release',
+        gameVersions: ['1.21.1'],
+        loaders: ['neoforge'],
+        files: [],
+        dependencies: [],
+        downloads: 100,
+        datePublished: '2024-06-01T00:00:00Z',
+      },
+    ];
+
+    it('should return 400 when modLoader+version combination is incompatible', async () => {
+      mockedServerExists.mockReturnValue(false);
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.getVersions as any).mockResolvedValue(compatVersions);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/servers',
+        payload: {
+          name: 'mc-bad',
+          type: 'MODRINTH',
+          modpack: 'cobblemon',
+          modLoader: 'forge',
+          version: '1.21.1',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('BadRequest');
+    });
+
+    it('should allow a compatible modLoader+version combination', async () => {
+      mockedServerExists.mockReturnValue(false);
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.getVersions as any).mockResolvedValue(compatVersions);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/servers',
+        payload: {
+          name: 'mc-good',
+          type: 'MODRINTH',
+          modpack: 'cobblemon',
+          modLoader: 'neoforge',
+          version: '1.21.1',
+        },
+      });
+
+      expect(response.statusCode).not.toBe(400);
+    });
   });
 });

--- a/platform/services/mcctl-api/tests/server-mods.test.ts
+++ b/platform/services/mcctl-api/tests/server-mods.test.ts
@@ -491,5 +491,41 @@ MEMORY=4G
 
       expect(response.statusCode).not.toBe(400);
     });
+
+    it('should return 400 when modpack slug contains shell metacharacters', async () => {
+      mockedServerExists.mockReturnValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/servers',
+        payload: {
+          name: 'mc-inject',
+          type: 'MODRINTH',
+          // Quotes/semicolons must be rejected by schema before reaching the shell.
+          modpack: 'cobblemon"; rm -rf / #',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should accept a modpack URL form (slug/id/url pattern)', async () => {
+      mockedServerExists.mockReturnValue(false);
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.getVersions as any).mockResolvedValue([]);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/servers',
+        payload: {
+          name: 'mc-url',
+          type: 'MODRINTH',
+          modpack: 'https://modrinth.com/modpack/cobblemon',
+        },
+      });
+
+      // URL form passes schema validation; not a 400 from pattern rejection.
+      expect(response.statusCode).not.toBe(400);
+    });
   });
 });

--- a/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
+++ b/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
@@ -45,6 +45,7 @@ import {
   RemoveModResponse,
   ModSearchResponse,
   ModProjectsResponse,
+  ModVersionsResponse,
   FileListResponse,
   FileContentResponse,
   FileWriteResponse,
@@ -533,8 +534,9 @@ export class McctlApiAdapter implements IMcctlApiClient {
     );
   }
 
-  async searchMods(query: string, limit: number = 10, offset: number = 0): Promise<ModSearchResponse> {
+  async searchMods(query: string, limit: number = 10, offset: number = 0, type?: string): Promise<ModSearchResponse> {
     const params = new URLSearchParams({ q: query, limit: String(limit), offset: String(offset) });
+    if (type) params.set('type', type);
     return this.fetch<ModSearchResponse>(`/api/mods/search?${params}`);
   }
 
@@ -542,6 +544,15 @@ export class McctlApiAdapter implements IMcctlApiClient {
     const params = new URLSearchParams({ slugs: slugs.join(',') });
     if (source) params.set('source', source);
     return this.fetch<ModProjectsResponse>(`/api/mods/projects?${params}`);
+  }
+
+  async getModVersions(slug: string, source?: string): Promise<ModVersionsResponse> {
+    const params = new URLSearchParams();
+    if (source) params.set('source', source);
+    const qs = params.toString();
+    return this.fetch<ModVersionsResponse>(
+      `/api/mods/${encodeURIComponent(slug)}/versions${qs ? `?${qs}` : ''}`
+    );
   }
 
   // ============================================================

--- a/platform/services/mcctl-console/src/app/api/mods/[slug]/versions/route.ts
+++ b/platform/services/mcctl-console/src/app/api/mods/[slug]/versions/route.ts
@@ -1,6 +1,9 @@
 /**
- * Mod Search API Route
- * GET /api/mods/search?q=...&limit=...&offset=...
+ * Mod Versions API Route
+ * GET /api/mods/:slug/versions?source=...
+ *
+ * Returns a loader -> Minecraft-version compatibility matrix for a modpack,
+ * used by the Create Server dialog to offer only valid combinations.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -11,33 +14,28 @@ import { headers } from 'next/headers';
 export const dynamic = 'force-dynamic';
 
 /**
- * GET /api/mods/search
- * Search for mods on Modrinth
+ * GET /api/mods/:slug/versions
+ * Get the loader/version compatibility matrix for a modpack.
  */
-export async function GET(request: NextRequest) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
   try {
     await requireAuth(await headers());
 
-    const searchParams = request.nextUrl.searchParams;
-    const q = searchParams.get('q');
-    const limit = searchParams.get('limit');
-    const offset = searchParams.get('offset');
-    const type = searchParams.get('type');
+    const { slug } = await params;
+    const source = request.nextUrl.searchParams.get('source');
 
-    if (!q) {
+    if (!slug) {
       return NextResponse.json(
-        { error: 'BadRequest', message: 'Query parameter "q" is required' },
+        { error: 'BadRequest', message: 'Path parameter "slug" is required' },
         { status: 400 }
       );
     }
 
     const client = createMcctlApiClient();
-    const data = await client.searchMods(
-      q,
-      limit ? parseInt(limit, 10) : undefined,
-      offset ? parseInt(offset, 10) : undefined,
-      type ?? undefined
-    );
+    const data = await client.getModVersions(slug, source ?? undefined);
 
     return NextResponse.json(data);
   } catch (error) {
@@ -54,9 +52,9 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    console.error('Failed to search mods:', error);
+    console.error('Failed to get mod versions:', error);
     return NextResponse.json(
-      { error: 'InternalServerError', message: 'Failed to search mods' },
+      { error: 'InternalServerError', message: 'Failed to get mod versions' },
       { status: 500 }
     );
   }

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
@@ -490,6 +490,126 @@ describe('CreateServerDialog', () => {
         expect(arg.modpackVersion).toBe('2.0.0');
       });
     });
+
+    it('should disable Create while the compatibility matrix is loading', async () => {
+      mockUseModVersions.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /modpack/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByLabelText(/server name/i);
+      fireEvent.change(nameInput, { target: { value: 'loading-server' } });
+
+      const slugInput = screen.getByRole('combobox', { name: /modpack/i });
+      fireEvent.change(slugInput, { target: { value: 'cobblemon' } });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled();
+      });
+    });
+
+    it('should not submit while the matrix is loading even if Create is forced', async () => {
+      mockUseModVersions.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+      const onSubmit = vi.fn();
+
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /modpack/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/server name/i), {
+        target: { value: 'loading-server' },
+      });
+      fireEvent.change(screen.getByRole('combobox', { name: /modpack/i }), {
+        target: { value: 'cobblemon' },
+      });
+
+      // Submit the form directly (bypasses the disabled button).
+      fireEvent.submit(screen.getByRole('combobox', { name: /modpack/i }).closest('form')!);
+
+      // handleSubmit guards: no incomplete modpack request goes out.
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should reset loader and version when the modpack slug is re-typed', async () => {
+      // Two modpacks share the "fabric" loader but support different MC versions.
+      const firstMatrix = {
+        data: {
+          slug: 'pack-a',
+          loaders: ['fabric'],
+          byLoader: { fabric: { gameVersions: ['1.20.1'], recommended: { '1.20.1': 'a1' } } },
+        },
+        isLoading: false,
+        isError: false,
+      };
+      const secondMatrix = {
+        data: {
+          slug: 'pack-b',
+          loaders: ['fabric'],
+          byLoader: { fabric: { gameVersions: ['1.21.4'], recommended: { '1.21.4': 'b1' } } },
+        },
+        isLoading: false,
+        isError: false,
+      };
+
+      mockUseModVersions.mockReturnValue(firstMatrix);
+      const onSubmit = vi.fn();
+
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /modpack/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/server name/i), {
+        target: { value: 'pack-server' },
+      });
+
+      // Choose first modpack -> version auto-selects 1.20.1
+      fireEvent.change(screen.getByRole('combobox', { name: /modpack/i }), {
+        target: { value: 'pack-a' },
+      });
+      await waitFor(() => {
+        expect(screen.getByLabelText(/minecraft version/i)).toBeInTheDocument();
+      });
+
+      // Re-type a different modpack; matrix now returns pack-b versions.
+      mockUseModVersions.mockReturnValue(secondMatrix);
+      fireEvent.change(screen.getByRole('combobox', { name: /modpack/i }), {
+        target: { value: 'pack-b' },
+      });
+
+      // The version must follow the new modpack, not stay stale on 1.20.1.
+      await waitFor(() => {
+        const createButton = screen.getByRole('button', { name: /^create$/i });
+        expect(createButton).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        const arg = onSubmit.mock.calls[0][0];
+        expect(arg.modpack).toBe('pack-b');
+        expect(arg.version).toBe('1.21.4');
+        expect(arg.modpackVersion).toBe('b1');
+      });
+    });
   });
 
   describe('Accessibility', () => {

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@/theme';
 import { CreateServerDialog } from './CreateServerDialog';
@@ -18,11 +18,46 @@ vi.mock('@/hooks/useMcctl', () => ({
   })),
 }));
 
+// Mock modpack hooks (search autocomplete + compatibility matrix)
+interface SearchResult { data: unknown; isLoading: boolean }
+interface MatrixResult { data: unknown; isLoading: boolean; isError: boolean }
+
+const mockUseModpackSearch = vi.fn(
+  (): SearchResult => ({ data: undefined, isLoading: false })
+);
+const mockUseModVersions = vi.fn(
+  (): MatrixResult => ({ data: undefined, isLoading: false, isError: false })
+);
+
+vi.mock('@/hooks/useMods', () => ({
+  useModpackSearch: () => mockUseModpackSearch(),
+  useModVersions: () => mockUseModVersions(),
+}));
+
+// Compatibility matrix for cobblemon-like modpack: neoforge -> 1.21.1, forge -> 1.19.2
+const cobblemonMatrix = {
+  data: {
+    slug: 'cobblemon',
+    loaders: ['forge', 'neoforge'],
+    byLoader: {
+      neoforge: { gameVersions: ['1.21.1'], recommended: { '1.21.1': '2.0.0' } },
+      forge: { gameVersions: ['1.19.2'], recommended: { '1.19.2': '1.0.0' } },
+    },
+  },
+  isLoading: false,
+  isError: false,
+};
+
 const renderWithTheme = (component: React.ReactNode) => {
   return render(<ThemeProvider>{component}</ThemeProvider>);
 };
 
 describe('CreateServerDialog', () => {
+  beforeEach(() => {
+    mockUseModpackSearch.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseModVersions.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+  });
+
   it('should render when open is true', () => {
     renderWithTheme(
       <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
@@ -323,27 +358,11 @@ describe('CreateServerDialog', () => {
 
       // Wait for Collapse animation
       await waitFor(() => {
-        // Modpack fields should be visible
-        expect(screen.getByLabelText(/modpack slug/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/mod loader/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/modpack version/i)).toBeInTheDocument();
+        // Modpack search field (Autocomplete combobox) should be visible
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
 
-        // Standard fields should not be visible
+        // Standard server-type field should not be visible
         expect(screen.queryByLabelText(/server type/i)).not.toBeInTheDocument();
-        expect(screen.queryByLabelText(/minecraft version/i)).not.toBeInTheDocument();
-      });
-    });
-
-    it('should show info alert about auto-detected version in Modpack mode', async () => {
-      renderWithTheme(
-        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
-      );
-
-      const modpackButton = screen.getByRole('button', { name: /modpack/i });
-      fireEvent.click(modpackButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/minecraft version is automatically determined by the modpack/i)).toBeInTheDocument();
       });
     });
   });
@@ -404,7 +423,7 @@ describe('CreateServerDialog', () => {
       fireEvent.click(modpackButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText(/modpack slug/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
       });
 
       // Fill only server name
@@ -417,11 +436,14 @@ describe('CreateServerDialog', () => {
 
       await waitFor(() => {
         expect(onSubmit).not.toHaveBeenCalled();
-        expect(screen.getByText(/modpack slug is required/i)).toBeInTheDocument();
+        expect(screen.getByText(/modpack is required/i)).toBeInTheDocument();
       });
     });
 
-    it('should submit successfully with valid modpack data', async () => {
+    it('should submit modLoader and selected Minecraft version once a modpack is chosen', async () => {
+      // Once a slug is typed, the matrix resolves and loader/version selects appear.
+      mockUseModVersions.mockReturnValue(cobblemonMatrix);
+
       const onSubmit = vi.fn();
       renderWithTheme(
         <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
@@ -431,75 +453,41 @@ describe('CreateServerDialog', () => {
       fireEvent.click(modpackButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText(/modpack slug/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
       });
 
-      // Fill modpack form
       const nameInput = screen.getByLabelText(/server name/i);
       fireEvent.change(nameInput, { target: { value: 'cobblemon-server' } });
 
-      const slugInput = screen.getByLabelText(/modpack slug/i);
+      // Type a modpack slug into the autocomplete (freeSolo)
+      const slugInput = screen.getByRole('combobox', { name: /modpack/i });
       fireEvent.change(slugInput, { target: { value: 'cobblemon' } });
 
+      // Loader + Minecraft version selects appear; default loader = first (forge)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/mod loader/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/minecraft version/i)).toBeInTheDocument();
+      });
+
+      // Select neoforge loader
+      fireEvent.mouseDown(screen.getByLabelText(/mod loader/i));
+      const neoforgeOption = await screen.findByRole('option', { name: 'neoforge' });
+      fireEvent.click(neoforgeOption);
+
       // Submit
-      const createButton = screen.getByRole('button', { name: /create/i });
+      const createButton = screen.getByRole('button', { name: /^create$/i });
       fireEvent.click(createButton);
 
       await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith({
-          name: 'cobblemon-server',
-          type: 'MODRINTH',
-          modpack: 'cobblemon',
-          memory: '6G',
-          autoStart: false,
-          sudoPassword: '',
-        });
-      });
-    });
-
-    it('should include optional modpack fields when provided', async () => {
-      const onSubmit = vi.fn();
-      renderWithTheme(
-        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
-      );
-
-      const modpackButton = screen.getByRole('button', { name: /modpack/i });
-      fireEvent.click(modpackButton);
-
-      await waitFor(() => {
-        expect(screen.getByLabelText(/modpack slug/i)).toBeInTheDocument();
-      });
-
-      // Fill all modpack fields
-      const nameInput = screen.getByLabelText(/server name/i);
-      fireEvent.change(nameInput, { target: { value: 'test-server' } });
-
-      const slugInput = screen.getByLabelText(/modpack slug/i);
-      fireEvent.change(slugInput, { target: { value: 'adrenaserver' } });
-
-      const versionInput = screen.getByLabelText(/modpack version/i);
-      fireEvent.change(versionInput, { target: { value: '1.0.0' } });
-
-      const loaderInput = screen.getByLabelText(/mod loader/i);
-      fireEvent.mouseDown(loaderInput);
-      const forgeOption = await screen.findByRole('option', { name: 'forge' });
-      fireEvent.click(forgeOption);
-
-      // Submit
-      const createButton = screen.getByRole('button', { name: /create/i });
-      fireEvent.click(createButton);
-
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith({
-          name: 'test-server',
-          type: 'MODRINTH',
-          modpack: 'adrenaserver',
-          modpackVersion: '1.0.0',
-          modLoader: 'forge',
-          memory: '6G',
-          autoStart: false,
-          sudoPassword: '',
-        });
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        const arg = onSubmit.mock.calls[0][0];
+        expect(arg.name).toBe('cobblemon-server');
+        expect(arg.type).toBe('MODRINTH');
+        expect(arg.modpack).toBe('cobblemon');
+        expect(arg.modLoader).toBe('neoforge');
+        expect(arg.version).toBe('1.21.1');
+        // recommended modpack version for (neoforge, 1.21.1)
+        expect(arg.modpackVersion).toBe('2.0.0');
       });
     });
   });
@@ -516,7 +504,7 @@ describe('CreateServerDialog', () => {
       // Wait for Collapse animation (300ms) + focus delay
       await waitFor(
         () => {
-          const slugInput = screen.getByLabelText(/modpack slug/i);
+          const slugInput = screen.getByRole('combobox', { name: /modpack/i });
           expect(slugInput).toHaveFocus();
         },
         { timeout: 1000 }

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
@@ -258,6 +258,11 @@ export function CreateServerDialog({
         setErrors({ modpack: slugError });
         return;
       }
+      // Block submission while compatibility data is still loading.
+      if (matrixLoading) {
+        setErrors({ modpack: 'Loading modpack compatibility — please wait a moment' });
+        return;
+      }
       // Once a matrix is available, require a compatible loader + version.
       if (matrix && availableLoaders.length > 0) {
         if (!selectedLoader) {
@@ -314,6 +319,16 @@ export function CreateServerDialog({
     // Submit
     onSubmit(submitData);
   };
+
+  // In modpack mode, Create stays disabled until a modpack is chosen and its
+  // compatible loader + Minecraft version are resolved (or the matrix failed,
+  // in which case we let the backend's secondary validation respond).
+  const modpackSelectionIncomplete =
+    category === 'modpack' &&
+    !!modpackSlug &&
+    !matrixError &&
+    (matrixLoading ||
+      (availableLoaders.length > 0 && (!selectedLoader || !selectedGameVersion)));
 
   return (
     <Dialog open={open} onClose={isCreating ? undefined : onClose} maxWidth="sm" fullWidth fullScreen={isSmallScreen}>
@@ -480,6 +495,12 @@ export function CreateServerDialog({
                         setModpackSearchInput(newInput);
                         // Typing also sets the slug (supports direct slug entry).
                         setModpackSlug(newInput.trim());
+                        // Reset dependent selections so they re-populate from the
+                        // new modpack's matrix. Without this, a loader name shared
+                        // by the previous modpack would not trigger the auto-select
+                        // Effect, leaving a stale (loader, version) pair.
+                        setSelectedLoader('');
+                        setSelectedGameVersion('');
                         if (errors.modpack) {
                           setErrors((prev) => ({ ...prev, modpack: '' }));
                         }
@@ -695,7 +716,7 @@ export function CreateServerDialog({
               <Button
                 type="submit"
                 variant="contained"
-                disabled={isCreating}
+                disabled={isCreating || modpackSelectionIncomplete}
                 startIcon={isCreating ? <CircularProgress size={16} /> : null}
               >
                 {isCreating ? 'Creating...' : 'Create'}

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Dialog from '@mui/material/Dialog';
@@ -27,7 +27,9 @@ import Collapse from '@mui/material/Collapse';
 import Alert from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
+import Autocomplete from '@mui/material/Autocomplete';
 import { useWorlds } from '@/hooks/useMcctl';
+import { useModpackSearch, useModVersions } from '@/hooks/useMods';
 import type { CreateServerRequest } from '@/ports/api/IMcctlApiClient';
 import type { CreateServerStatus } from '@/hooks/useCreateServerSSE';
 
@@ -42,8 +44,6 @@ interface CreateServerDialogProps {
 }
 
 const STANDARD_SERVER_TYPES = ['VANILLA', 'PAPER', 'FABRIC', 'FORGE', 'NEOFORGE'];
-const MODPACK_PLATFORMS = ['MODRINTH'];
-const MOD_LOADERS = ['', 'forge', 'fabric', 'neoforge', 'quilt'];
 
 type ServerCategory = 'standard' | 'modpack';
 
@@ -54,17 +54,6 @@ const DEFAULT_FORM_VALUES: CreateServerRequest = {
   memory: '4G',
   autoStart: false,
   sudoPassword: '',
-};
-
-const DEFAULT_MODPACK_VALUES: CreateServerRequest = {
-  name: '',
-  type: 'MODRINTH',
-  memory: '6G',
-  autoStart: false,
-  sudoPassword: '',
-  modpack: '',
-  modpackVersion: '',
-  modLoader: '',
 };
 
 const PROGRESS_STEPS = [
@@ -93,6 +82,12 @@ export function CreateServerDialog({
   const [worldMode, setWorldMode] = useState<'none' | 'seed' | 'existingWorld'>('none');
   const [selectedWorldName, setSelectedWorldName] = useState('');
 
+  // Modpack selection state
+  const [modpackSlug, setModpackSlug] = useState('');
+  const [modpackSearchInput, setModpackSearchInput] = useState('');
+  const [selectedLoader, setSelectedLoader] = useState('');
+  const [selectedGameVersion, setSelectedGameVersion] = useState('');
+
   // Refs for accessibility
   const firstModpackFieldRef = useRef<HTMLInputElement>(null);
   const liveRegionRef = useRef<HTMLDivElement>(null);
@@ -107,6 +102,44 @@ export function CreateServerDialog({
     (w) => (!w.servers || w.servers.length === 0) && !w.isLocked
   );
 
+  // Modpack search autocomplete (only when in modpack mode)
+  const { data: modpackSearchData, isLoading: modpackSearchLoading } = useModpackSearch(
+    modpackSearchInput,
+    { enabled: category === 'modpack' && modpackSearchInput.trim().length >= 2 }
+  );
+  const modpackOptions = modpackSearchData?.hits ?? [];
+
+  // Compatibility matrix for the chosen modpack slug
+  const {
+    data: matrix,
+    isLoading: matrixLoading,
+    isError: matrixError,
+  } = useModVersions(modpackSlug, {
+    enabled: category === 'modpack' && modpackSlug.trim().length > 0,
+  });
+  const availableLoaders = useMemo(() => matrix?.loaders ?? [], [matrix]);
+  const availableGameVersions = useMemo(
+    () =>
+      selectedLoader && matrix?.byLoader[selectedLoader]
+        ? matrix.byLoader[selectedLoader].gameVersions
+        : [],
+    [matrix, selectedLoader]
+  );
+
+  // Auto-select the first loader once the matrix resolves.
+  useEffect(() => {
+    if (availableLoaders.length > 0 && !availableLoaders.includes(selectedLoader)) {
+      setSelectedLoader(availableLoaders[0]);
+    }
+  }, [availableLoaders, selectedLoader]);
+
+  // Auto-select the newest compatible Minecraft version when loader/matrix changes.
+  useEffect(() => {
+    if (availableGameVersions.length > 0 && !availableGameVersions.includes(selectedGameVersion)) {
+      setSelectedGameVersion(availableGameVersions[0]);
+    }
+  }, [availableGameVersions, selectedGameVersion]);
+
   // Reset form when dialog closes
   useEffect(() => {
     if (!open) {
@@ -116,6 +149,10 @@ export function CreateServerDialog({
       setMemoryTouched(false);
       setWorldMode('none');
       setSelectedWorldName('');
+      setModpackSlug('');
+      setModpackSearchInput('');
+      setSelectedLoader('');
+      setSelectedGameVersion('');
     }
   }, [open]);
 
@@ -131,7 +168,7 @@ export function CreateServerDialog({
 
   const validateModpackSlug = (slug: string): string | null => {
     if (!slug) {
-      return 'Modpack slug is required';
+      return 'Modpack is required';
     }
     return null;
   };
@@ -214,12 +251,23 @@ export function CreateServerDialog({
       return;
     }
 
-    // Validate modpack slug if in modpack mode
+    // Validate modpack selection if in modpack mode
     if (category === 'modpack') {
-      const slugError = validateModpackSlug(formData.modpack || '');
+      const slugError = validateModpackSlug(modpackSlug);
       if (slugError) {
         setErrors({ modpack: slugError });
         return;
+      }
+      // Once a matrix is available, require a compatible loader + version.
+      if (matrix && availableLoaders.length > 0) {
+        if (!selectedLoader) {
+          setErrors({ modpack: 'Please select a mod loader' });
+          return;
+        }
+        if (!selectedGameVersion) {
+          setErrors({ modpack: 'Please select a Minecraft version' });
+          return;
+        }
       }
     }
 
@@ -236,14 +284,19 @@ export function CreateServerDialog({
       submitData.type = formData.type;
       submitData.version = formData.version;
     } else {
-      // Modpack: include modpack fields
+      // Modpack: include modpack fields with a validated (loader, version) pair.
       submitData.type = 'MODRINTH';
-      submitData.modpack = formData.modpack;
-      if (formData.modpackVersion) {
-        submitData.modpackVersion = formData.modpackVersion;
+      submitData.modpack = modpackSlug;
+      if (selectedLoader) {
+        submitData.modLoader = selectedLoader;
       }
-      if (formData.modLoader) {
-        submitData.modLoader = formData.modLoader;
+      if (selectedGameVersion) {
+        submitData.version = selectedGameVersion;
+        // Use the modpack release recommended for this (loader, version) pair.
+        const recommended = matrix?.byLoader[selectedLoader]?.recommended[selectedGameVersion];
+        if (recommended) {
+          submitData.modpackVersion = recommended;
+        }
       }
     }
 
@@ -406,47 +459,114 @@ export function CreateServerDialog({
                 <Collapse in={category === 'modpack'} unmountOnExit>
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
                     <Alert severity="info">
-                      Minecraft version is automatically determined by the modpack
+                      Select a modpack, then a loader and a compatible Minecraft version.
                     </Alert>
 
-                    <TextField
-                      label="Modpack Slug"
-                      value={formData.modpack || ''}
-                      onChange={handleChange('modpack')}
-                      error={!!errors.modpack}
-                      helperText={
-                        errors.modpack || 'e.g., cobblemon, adrenaserver (from modrinth.com/modpacks/SLUG)'
+                    {/* Modpack search autocomplete (freeSolo allows typing a slug directly) */}
+                    <Autocomplete
+                      freeSolo
+                      options={modpackOptions}
+                      loading={modpackSearchLoading}
+                      filterOptions={(x) => x}
+                      getOptionLabel={(option) =>
+                        typeof option === 'string' ? option : option.slug
                       }
-                      fullWidth
+                      isOptionEqualToValue={(option, value) =>
+                        (typeof option === 'string' ? option : option.slug) ===
+                        (typeof value === 'string' ? value : value.slug)
+                      }
+                      inputValue={modpackSearchInput}
+                      onInputChange={(_, newInput) => {
+                        setModpackSearchInput(newInput);
+                        // Typing also sets the slug (supports direct slug entry).
+                        setModpackSlug(newInput.trim());
+                        if (errors.modpack) {
+                          setErrors((prev) => ({ ...prev, modpack: '' }));
+                        }
+                      }}
+                      onChange={(_, value) => {
+                        const slug =
+                          typeof value === 'string' ? value : value?.slug ?? '';
+                        setModpackSlug(slug.trim());
+                        setModpackSearchInput(slug);
+                        // Reset dependent selections; they re-populate from the matrix.
+                        setSelectedLoader('');
+                        setSelectedGameVersion('');
+                      }}
+                      renderOption={(props, option) => (
+                        <li {...props} key={typeof option === 'string' ? option : option.slug}>
+                          {typeof option === 'string' ? option : `${option.title} (${option.slug})`}
+                        </li>
+                      )}
                       disabled={isCreating}
-                      inputRef={firstModpackFieldRef}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Modpack"
+                          error={!!errors.modpack}
+                          helperText={
+                            errors.modpack ||
+                            'Search modrinth.com modpacks, or type a slug (e.g., cobblemon)'
+                          }
+                          inputRef={firstModpackFieldRef}
+                        />
+                      )}
                     />
 
-                    <TextField
-                      label="Mod Loader"
-                      select
-                      value={formData.modLoader || ''}
-                      onChange={handleChange('modLoader')}
-                      helperText="Leave empty to auto-detect from modpack"
-                      fullWidth
-                      disabled={isCreating}
-                    >
-                      <MenuItem value="">Auto-detect</MenuItem>
-                      {MOD_LOADERS.filter((l) => l).map((loader) => (
-                        <MenuItem key={loader} value={loader}>
-                          {loader}
-                        </MenuItem>
-                      ))}
-                    </TextField>
+                    {/* Loader + Minecraft version selects (driven by compatibility matrix) */}
+                    {modpackSlug && matrixLoading && (
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <CircularProgress size={18} />
+                        <Typography variant="body2" color="text.secondary">
+                          Loading compatible loaders and versions…
+                        </Typography>
+                      </Box>
+                    )}
 
-                    <TextField
-                      label="Modpack Version"
-                      value={formData.modpackVersion || ''}
-                      onChange={handleChange('modpackVersion')}
-                      helperText="Leave empty for latest"
-                      fullWidth
-                      disabled={isCreating}
-                    />
+                    {modpackSlug && matrixError && (
+                      <Alert severity="warning">
+                        Could not load modpack compatibility. Check the slug and try again.
+                      </Alert>
+                    )}
+
+                    {modpackSlug && !matrixLoading && !matrixError && availableLoaders.length > 0 && (
+                      <>
+                        <TextField
+                          label="Mod Loader"
+                          select
+                          value={selectedLoader}
+                          onChange={(e) => {
+                            setSelectedLoader(e.target.value);
+                            setSelectedGameVersion('');
+                          }}
+                          helperText="Only loaders supported by this modpack"
+                          fullWidth
+                          disabled={isCreating}
+                        >
+                          {availableLoaders.map((loader) => (
+                            <MenuItem key={loader} value={loader}>
+                              {loader}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+
+                        <TextField
+                          label="Minecraft Version"
+                          select
+                          value={selectedGameVersion}
+                          onChange={(e) => setSelectedGameVersion(e.target.value)}
+                          helperText="Only versions compatible with the selected loader"
+                          fullWidth
+                          disabled={isCreating || availableGameVersions.length === 0}
+                        >
+                          {availableGameVersions.map((gv) => (
+                            <MenuItem key={gv} value={gv}>
+                              {gv}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                      </>
+                    )}
                   </Box>
                 </Collapse>
               </Box>

--- a/platform/services/mcctl-console/src/hooks/useMods.ts
+++ b/platform/services/mcctl-console/src/hooks/useMods.ts
@@ -6,6 +6,7 @@ import type {
   RemoveModResponse,
   ModSearchResponse,
   ModProjectsResponse,
+  ModVersionsResponse,
 } from '@/ports/api/IMcctlApiClient';
 
 // ============================================================
@@ -40,6 +41,51 @@ export function useModSearch(
     queryKey: ['mods', 'search', query, options?.limit, options?.offset],
     queryFn: () => apiFetch<ModSearchResponse>(`/api/mods/search?${params}`),
     enabled: options?.enabled !== false && !!query.trim(),
+  });
+}
+
+/**
+ * Hook to search modpacks on Modrinth (project_type=modpack).
+ * Used by the Create Server dialog autocomplete.
+ */
+export function useModpackSearch(
+  query: string,
+  options?: { limit?: number; enabled?: boolean }
+) {
+  const params = new URLSearchParams();
+  if (query) params.set('q', query);
+  params.set('type', 'modpack');
+  if (options?.limit != null) params.set('limit', String(options.limit));
+
+  return useQuery<ModSearchResponse, Error>({
+    queryKey: ['mods', 'search', 'modpack', query, options?.limit],
+    queryFn: () => apiFetch<ModSearchResponse>(`/api/mods/search?${params}`),
+    enabled: options?.enabled !== false && !!query.trim(),
+    staleTime: 60 * 1000,
+  });
+}
+
+/**
+ * Hook to fetch the loader/Minecraft-version compatibility matrix for a modpack.
+ */
+export function useModVersions(
+  slug: string,
+  options?: { source?: string; enabled?: boolean }
+) {
+  const params = new URLSearchParams();
+  if (options?.source) params.set('source', options.source);
+  const qs = params.toString();
+
+  return useQuery<ModVersionsResponse, Error>({
+    queryKey: ['mods', slug, 'versions', options?.source],
+    queryFn: () =>
+      apiFetch<ModVersionsResponse>(
+        `/api/mods/${encodeURIComponent(slug)}/versions${qs ? `?${qs}` : ''}`
+      ),
+    enabled: options?.enabled !== false && !!slug.trim(),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: false,
   });
 }
 

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -430,6 +430,21 @@ export interface ModSearchResponse {
   limit: number;
 }
 
+export interface LoaderCompatibility {
+  /** Minecraft versions supported by this loader, newest-first. */
+  gameVersions: string[];
+  /** Recommended modpack version number per game version. */
+  recommended: Record<string, string>;
+}
+
+export interface ModVersionsResponse {
+  slug: string;
+  /** Supported mod loaders, sorted alphabetically. */
+  loaders: string[];
+  /** Per-loader compatibility info. */
+  byLoader: Record<string, LoaderCompatibility>;
+}
+
 // ============================================================
 // File Management Types
 // ============================================================
@@ -811,8 +826,9 @@ export interface IMcctlApiClient {
   getServerMods(serverName: string): Promise<ModListResponse>;
   addServerMods(serverName: string, slugs: string[], source?: string): Promise<AddModsResponse>;
   removeServerMod(serverName: string, slug: string): Promise<RemoveModResponse>;
-  searchMods(query: string, limit?: number, offset?: number): Promise<ModSearchResponse>;
+  searchMods(query: string, limit?: number, offset?: number, type?: string): Promise<ModSearchResponse>;
   getModProjects(slugs: string[], source?: string): Promise<ModProjectsResponse>;
+  getModVersions(slug: string, source?: string): Promise<ModVersionsResponse>;
 
   // Playit.gg operations
   getPlayitStatus(): Promise<PlayitAgentStatus>;

--- a/platform/services/mod-source-modrinth/src/ModrinthAdapter.ts
+++ b/platform/services/mod-source-modrinth/src/ModrinthAdapter.ts
@@ -65,6 +65,9 @@ export class ModrinthAdapter implements IModSourcePort {
     if (options?.loaders?.length) {
       facets.push(options.loaders.map(l => `categories:${l}`));
     }
+    if (options?.projectType) {
+      facets.push([`project_type:${options.projectType}`]);
+    }
 
     const raw = await this.apiClient.search({
       query,

--- a/platform/services/shared/src/domain/mod/index.ts
+++ b/platform/services/shared/src/domain/mod/index.ts
@@ -20,3 +20,13 @@ export type { ModVersion } from './ModVersion.js';
 export type { ModFile, ModFileHashes } from './ModFile.js';
 export type { ModDependency } from './ModDependency.js';
 export type { ModSearchResult } from './ModSearchResult.js';
+
+// Compatibility matrix utilities
+export {
+  buildModpackCompatibilityMatrix,
+  isModpackCompatible,
+} from './modpackCompatibility.js';
+export type {
+  ModpackCompatibilityMatrix,
+  LoaderCompatibility,
+} from './modpackCompatibility.js';

--- a/platform/services/shared/src/domain/mod/modpackCompatibility.ts
+++ b/platform/services/shared/src/domain/mod/modpackCompatibility.ts
@@ -1,0 +1,134 @@
+/**
+ * Modpack compatibility matrix - Domain utility
+ *
+ * Aggregates a list of {@link ModVersion} (e.g. from a Modrinth modpack project)
+ * into a loader → game-version compatibility matrix. This lets the UI present
+ * only valid (loader, Minecraft version) combinations and lets the API validate
+ * server creation requests, preventing the "No files available" failure that
+ * occurs when an incompatible VERSION/MODRINTH_LOADER pair is passed to itzg.
+ *
+ * Pure domain logic: no external dependencies, no I/O.
+ */
+
+import type { ModVersion } from './ModVersion.js';
+
+/**
+ * Compatibility information for a single mod loader.
+ */
+export interface LoaderCompatibility {
+  /** Minecraft versions supported by this loader, sorted newest-first. */
+  gameVersions: string[];
+  /**
+   * Recommended modpack version number for each game version
+   * (the newest modpack release supporting that game version).
+   * Keyed by Minecraft game version.
+   */
+  recommended: Record<string, string>;
+}
+
+/**
+ * Loader → compatibility matrix for a modpack project.
+ */
+export interface ModpackCompatibilityMatrix {
+  /** Supported mod loaders, sorted alphabetically. */
+  loaders: string[];
+  /** Per-loader compatibility info. */
+  byLoader: Record<string, LoaderCompatibility>;
+}
+
+/**
+ * Compare two Minecraft game-version strings, newest-first.
+ *
+ * Standard release versions ("1.21.1", "1.20.4") sort numerically by
+ * their dotted components in descending order. Non-standard versions
+ * (snapshots like "24w14a", "1.21-rc1") are pushed to the end so the
+ * UI surfaces stable releases first.
+ */
+function compareGameVersionsDesc(a: string, b: string): number {
+  const isStandard = (v: string) => /^\d+(\.\d+)*$/.test(v);
+  const aStd = isStandard(a);
+  const bStd = isStandard(b);
+
+  if (aStd && !bStd) return -1;
+  if (!aStd && bStd) return 1;
+  if (!aStd && !bStd) return a < b ? 1 : a > b ? -1 : 0;
+
+  const aParts = a.split('.').map(Number);
+  const bParts = b.split('.').map(Number);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    const av = aParts[i] ?? 0;
+    const bv = bParts[i] ?? 0;
+    if (av !== bv) return bv - av; // descending
+  }
+  return 0;
+}
+
+/**
+ * Build a loader → game-version compatibility matrix from modpack versions.
+ *
+ * Versions are expected to be supplied newest-first (as Modrinth returns them),
+ * so for each (loader, game version) cell the first version encountered is
+ * treated as the recommended/latest one.
+ *
+ * Versions with no loaders are ignored.
+ *
+ * @param versions - Modpack project versions
+ * @returns Aggregated compatibility matrix
+ */
+export function buildModpackCompatibilityMatrix(
+  versions: ModVersion[]
+): ModpackCompatibilityMatrix {
+  const byLoader: Record<string, LoaderCompatibility> = {};
+
+  for (const version of versions) {
+    for (const rawLoader of version.loaders) {
+      const loader = rawLoader.toLowerCase();
+      let entry = byLoader[loader];
+      if (!entry) {
+        entry = { gameVersions: [], recommended: {} };
+        byLoader[loader] = entry;
+      }
+
+      for (const gameVersion of version.gameVersions) {
+        if (!entry.gameVersions.includes(gameVersion)) {
+          entry.gameVersions.push(gameVersion);
+        }
+        // First-seen wins (input is newest-first).
+        if (!(gameVersion in entry.recommended)) {
+          entry.recommended[gameVersion] = version.versionNumber;
+        }
+      }
+    }
+  }
+
+  // Sort game versions newest-first for each loader.
+  for (const entry of Object.values(byLoader)) {
+    entry.gameVersions.sort(compareGameVersionsDesc);
+  }
+
+  return {
+    loaders: Object.keys(byLoader).sort(),
+    byLoader,
+  };
+}
+
+/**
+ * Check whether a (loader, game version) combination is supported by the matrix.
+ *
+ * Loader comparison is case-insensitive.
+ *
+ * @param matrix - Compatibility matrix from {@link buildModpackCompatibilityMatrix}
+ * @param loader - Mod loader name (e.g. "neoforge")
+ * @param gameVersion - Minecraft version (e.g. "1.21.1")
+ * @returns true if the modpack has a release for this combination
+ */
+export function isModpackCompatible(
+  matrix: ModpackCompatibilityMatrix,
+  loader: string,
+  gameVersion: string
+): boolean {
+  const entry = matrix.byLoader[loader.toLowerCase()];
+  if (!entry) return false;
+  return entry.gameVersions.includes(gameVersion);
+}

--- a/platform/services/shared/src/domain/mod/types.ts
+++ b/platform/services/shared/src/domain/mod/types.ts
@@ -37,6 +37,8 @@ export interface ModSearchOptions {
   gameVersions?: string[];
   loaders?: string[];
   index?: ModSearchIndex;
+  /** Restrict results to a specific project type (e.g. 'modpack', 'mod'). */
+  projectType?: ModProjectType;
 }
 
 /**

--- a/platform/services/shared/src/index.ts
+++ b/platform/services/shared/src/index.ts
@@ -158,6 +158,16 @@ export type {
   ModSearchResult,
 } from './domain/mod/index.js';
 
+// Re-export modpack compatibility matrix utilities (value + types)
+export {
+  buildModpackCompatibilityMatrix,
+  isModpackCompatible,
+} from './domain/mod/index.js';
+export type {
+  ModpackCompatibilityMatrix,
+  LoaderCompatibility,
+} from './domain/mod/index.js';
+
 // Re-export ModSourceFactory
 export { ModSourceFactory } from './infrastructure/factories/index.js';
 

--- a/platform/services/shared/tests/modpackCompatibility.test.ts
+++ b/platform/services/shared/tests/modpackCompatibility.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect } from 'vitest';
+import {
+  buildModpackCompatibilityMatrix,
+  isModpackCompatible,
+} from '../src/domain/mod/modpackCompatibility.js';
+import type { ModVersion } from '../src/domain/mod/index.js';
+
+/**
+ * Helper to build a minimal ModVersion for tests.
+ */
+function makeVersion(partial: Partial<ModVersion> & Pick<ModVersion, 'id'>): ModVersion {
+  return {
+    projectId: 'proj-1',
+    name: partial.name ?? partial.id,
+    versionNumber: partial.versionNumber ?? '1.0.0',
+    versionType: partial.versionType ?? 'release',
+    gameVersions: partial.gameVersions ?? [],
+    loaders: partial.loaders ?? [],
+    files: partial.files ?? [],
+    dependencies: partial.dependencies ?? [],
+    downloads: partial.downloads ?? 0,
+    datePublished: partial.datePublished ?? '2024-01-01T00:00:00Z',
+    ...partial,
+  };
+}
+
+describe('buildModpackCompatibilityMatrix', () => {
+  test('빈 버전 목록이면 빈 매트릭스를 반환한다', () => {
+    const matrix = buildModpackCompatibilityMatrix([]);
+    expect(matrix.loaders).toEqual([]);
+    expect(matrix.byLoader).toEqual({});
+  });
+
+  test('단일 로더/게임버전 조합을 집계한다', () => {
+    const versions = [
+      makeVersion({
+        id: 'v1',
+        versionNumber: '1.0.0',
+        loaders: ['neoforge'],
+        gameVersions: ['1.21.1'],
+      }),
+    ];
+
+    const matrix = buildModpackCompatibilityMatrix(versions);
+
+    expect(matrix.loaders).toEqual(['neoforge']);
+    expect(matrix.byLoader.neoforge.gameVersions).toEqual(['1.21.1']);
+    expect(matrix.byLoader.neoforge.recommended['1.21.1']).toBe('1.0.0');
+  });
+
+  test('로더별로 호환 게임버전을 분리 집계한다', () => {
+    const versions = [
+      makeVersion({ id: 'v1', loaders: ['neoforge'], gameVersions: ['1.21.1'] }),
+      makeVersion({ id: 'v2', loaders: ['forge'], gameVersions: ['1.19.2'] }),
+    ];
+
+    const matrix = buildModpackCompatibilityMatrix(versions);
+
+    expect(matrix.loaders.sort()).toEqual(['forge', 'neoforge']);
+    expect(matrix.byLoader.neoforge.gameVersions).toEqual(['1.21.1']);
+    expect(matrix.byLoader.forge.gameVersions).toEqual(['1.19.2']);
+  });
+
+  test('하나의 버전이 여러 로더/게임버전을 지원하면 모두 집계한다', () => {
+    const versions = [
+      makeVersion({
+        id: 'v1',
+        loaders: ['fabric', 'quilt'],
+        gameVersions: ['1.20.1', '1.20.4'],
+      }),
+    ];
+
+    const matrix = buildModpackCompatibilityMatrix(versions);
+
+    expect(matrix.loaders.sort()).toEqual(['fabric', 'quilt']);
+    expect(matrix.byLoader.fabric.gameVersions.sort()).toEqual(['1.20.1', '1.20.4']);
+    expect(matrix.byLoader.quilt.gameVersions.sort()).toEqual(['1.20.1', '1.20.4']);
+  });
+
+  test('동일 (로더, 게임버전)에 여러 modpack 버전이 있으면 최신(첫 등장)을 추천한다', () => {
+    // Modrinth returns versions newest-first. The first one encountered wins.
+    const versions = [
+      makeVersion({
+        id: 'v-new',
+        versionNumber: '2.0.0',
+        loaders: ['neoforge'],
+        gameVersions: ['1.21.1'],
+        datePublished: '2024-06-01T00:00:00Z',
+      }),
+      makeVersion({
+        id: 'v-old',
+        versionNumber: '1.0.0',
+        loaders: ['neoforge'],
+        gameVersions: ['1.21.1'],
+        datePublished: '2024-01-01T00:00:00Z',
+      }),
+    ];
+
+    const matrix = buildModpackCompatibilityMatrix(versions);
+
+    expect(matrix.byLoader.neoforge.recommended['1.21.1']).toBe('2.0.0');
+  });
+
+  test('게임버전 목록은 내림차순(최신 우선)으로 정렬된다', () => {
+    const versions = [
+      makeVersion({ id: 'v1', loaders: ['fabric'], gameVersions: ['1.20.1'] }),
+      makeVersion({ id: 'v2', loaders: ['fabric'], gameVersions: ['1.21.1'] }),
+      makeVersion({ id: 'v3', loaders: ['fabric'], gameVersions: ['1.20.4'] }),
+    ];
+
+    const matrix = buildModpackCompatibilityMatrix(versions);
+
+    expect(matrix.byLoader.fabric.gameVersions).toEqual(['1.21.1', '1.20.4', '1.20.1']);
+  });
+
+  test('snapshot 등 비표준 게임버전은 정렬 시 뒤로 보낸다', () => {
+    const versions = [
+      makeVersion({ id: 'v1', loaders: ['fabric'], gameVersions: ['1.21.1'] }),
+      makeVersion({ id: 'v2', loaders: ['fabric'], gameVersions: ['24w14a'] }),
+    ];
+
+    const matrix = buildModpackCompatibilityMatrix(versions);
+
+    expect(matrix.byLoader.fabric.gameVersions[0]).toBe('1.21.1');
+  });
+
+  test('로더가 없는 버전(데이터팩 등)은 무시한다', () => {
+    const versions = [
+      makeVersion({ id: 'v1', loaders: [], gameVersions: ['1.21.1'] }),
+      makeVersion({ id: 'v2', loaders: ['neoforge'], gameVersions: ['1.21.1'] }),
+    ];
+
+    const matrix = buildModpackCompatibilityMatrix(versions);
+
+    expect(matrix.loaders).toEqual(['neoforge']);
+  });
+});
+
+describe('isModpackCompatible', () => {
+  const matrix = buildModpackCompatibilityMatrix([
+    makeVersion({ id: 'v1', loaders: ['neoforge'], gameVersions: ['1.21.1'] }),
+    makeVersion({ id: 'v2', loaders: ['forge'], gameVersions: ['1.19.2'] }),
+  ]);
+
+  test('호환되는 (로더, 게임버전) 조합이면 true', () => {
+    expect(isModpackCompatible(matrix, 'neoforge', '1.21.1')).toBe(true);
+    expect(isModpackCompatible(matrix, 'forge', '1.19.2')).toBe(true);
+  });
+
+  test('비호환 조합이면 false', () => {
+    // forge + 1.21.1 is the bug scenario (no files available)
+    expect(isModpackCompatible(matrix, 'forge', '1.21.1')).toBe(false);
+    expect(isModpackCompatible(matrix, 'neoforge', '1.20.4')).toBe(false);
+  });
+
+  test('알 수 없는 로더면 false', () => {
+    expect(isModpackCompatible(matrix, 'fabric', '1.21.1')).toBe(false);
+  });
+
+  test('로더 비교는 대소문자를 구분하지 않는다', () => {
+    expect(isModpackCompatible(matrix, 'NeoForge', '1.21.1')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #511

## 요약

모드팩 서버 생성 시 loader/version 호환성을 콤보박스로 선택·검증하여 "No files available" 에러를 근본 해결합니다.

### 근본 원인
Console 모드팩 생성 시 version이 전송되지 않아 `create-server.sh`가 템플릿(`_template/config.env`의 `VERSION=1.20.4`) 기본값을 잔류시켰고, itzg가 `VERSION` + `MODRINTH_LOADER` 조합으로 모드팩 파일을 해석할 때 비호환 조합(예: forge + 1.20.4)이 되어 실패했습니다.

## 변경 사항 (레이어별)

### shared (도메인)
- `buildModpackCompatibilityMatrix` / `isModpackCompatible` 추가 — `ModVersion[]`을 loader → game-version 호환성 매트릭스로 집계하는 순수 도메인 유틸 (외부 의존성 없음). loader별 호환 게임버전 목록(최신순 정렬) 및 (loader, gameVersion)별 추천 modpack 버전 산출.
- `ModSearchOptions.projectType` 추가.

### mod-source-modrinth (어댑터)
- `ModrinthAdapter.search`가 `projectType`을 `project_type` facet으로 적용.

### mcctl-api (백엔드)
- `GET /api/mods/:slug/versions` — 모드팩 호환성 매트릭스 반환 (버전 없으면 404).
- `GET /api/mods/search`에 `type=modpack` 필터 추가 (자동완성용).
- `POST /api/servers` — MODRINTH의 (modLoader, version) 비호환 조합을 400으로 거부. 메타데이터 조회 실패 시 fail-open(생성을 막지 않음).

### mcctl-console (프론트엔드)
- `CreateServerDialog` 모드팩 영역을 가이드형 검증 UI로 교체:
  - 모드팩 입력 → 검색 Autocomplete (`project_type=modpack`, freeSolo로 직접 slug 입력도 허용).
  - 모드팩 확정 시 호환성 매트릭스 조회 → 지원 loader만, 선택 loader 호환 MC 버전만(최신 자동 선택) 제공.
  - 제출에 검증된 (loader, MC version) 쌍과 추천 modpack 릴리즈 포함.
- `getModVersions` API 클라이언트/포트, `/api/mods/[slug]/versions` BFF 라우트, `useModpackSearch` / `useModVersions` 훅 추가.

### scripts (devops)
- `create-server.sh` — 모드팩 타입에서 버전 미지정 시 템플릿 VERSION 누수를 차단(주석 처리하여 모드팩이 버전을 결정). 표준 서버 타입은 영향 없음.

## 개발 원칙 준수
- **TDD**: 각 레이어(호환성 집계 유틸, API 엔드포인트/검증, 프론트 옵션 필터링)에 테스트 선작성 → 구현.
- **Tidy First / Clean·Hexagonal Architecture**: 도메인은 외부 의존성 없음, I/O는 어댑터 경유. 레이어별 논리 커밋 분리.

## 검증 결과

| 패키지 | test | lint | build/type-check |
|--------|------|------|------------------|
| shared | ✅ 530 passed | ✅ | ✅ |
| mod-source-modrinth | (테스트 러너 미설정) | (lint 스크립트 없음) | ✅ tsc |
| mcctl-api | ✅ 459 passed / 1 skipped | ✅ | ✅ |
| mcctl-console | ✅ 868 passed | ✅ (신규 경고 0) | ✅ type-check + next build |

🤖 Generated with [Claude Code](https://claude.com/claude-code)