### PR TITLE
feat(console): 모드팩 검색 드롭다운 리치 카드 UI (#516)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
@@ -26,7 +26,10 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Collapse from '@mui/material/Collapse';
 import Alert from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
+import Avatar from '@mui/material/Avatar';
 import CloseIcon from '@mui/icons-material/Close';
+import DownloadIcon from '@mui/icons-material/Download';
+import Inventory2Icon from '@mui/icons-material/Inventory2';
 import Autocomplete from '@mui/material/Autocomplete';
 import { useWorlds } from '@/hooks/useMcctl';
 import { useModpackSearch, useModVersions } from '@/hooks/useMods';
@@ -44,6 +47,12 @@ interface CreateServerDialogProps {
 }
 
 const STANDARD_SERVER_TYPES = ['VANILLA', 'PAPER', 'FABRIC', 'FORGE', 'NEOFORGE'];
+
+function formatDownloads(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
 
 type ServerCategory = 'standard' | 'modpack';
 
@@ -514,11 +523,70 @@ export function CreateServerDialog({
                         setSelectedLoader('');
                         setSelectedGameVersion('');
                       }}
-                      renderOption={(props, option) => (
-                        <li {...props} key={typeof option === 'string' ? option : option.slug}>
-                          {typeof option === 'string' ? option : `${option.title} (${option.slug})`}
-                        </li>
-                      )}
+                      renderOption={(props, option) => {
+                        if (typeof option === 'string') {
+                          return (
+                            <li {...props} key={option}>
+                              {option}
+                            </li>
+                          );
+                        }
+                        return (
+                          <li {...props} key={option.slug}>
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                gap: 1.5,
+                                alignItems: 'flex-start',
+                                width: '100%',
+                                minWidth: 0,
+                              }}
+                            >
+                              <Avatar
+                                src={option.iconUrl || undefined}
+                                variant="rounded"
+                                sx={{ width: 40, height: 40, bgcolor: 'action.hover', flexShrink: 0 }}
+                              >
+                                <Inventory2Icon />
+                              </Avatar>
+                              <Box sx={{ flex: 1, minWidth: 0 }}>
+                                <Typography variant="subtitle2" noWrap>
+                                  {option.title}
+                                </Typography>
+                                {option.description && (
+                                  <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                    sx={{
+                                      mt: 0.25,
+                                      overflow: 'hidden',
+                                      textOverflow: 'ellipsis',
+                                      display: '-webkit-box',
+                                      WebkitLineClamp: 2,
+                                      WebkitBoxOrient: 'vertical',
+                                    }}
+                                  >
+                                    {option.description}
+                                  </Typography>
+                                )}
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
+                                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                                    <DownloadIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+                                    <Typography variant="caption" color="text.disabled">
+                                      {formatDownloads(option.downloads)}
+                                    </Typography>
+                                  </Box>
+                                  {option.author && (
+                                    <Typography variant="caption" color="text.disabled">
+                                      by {option.author}
+                                    </Typography>
+                                  )}
+                                </Box>
+                              </Box>
+                            </Box>
+                          </li>
+                        );
+                      }}
                       disabled={isCreating}
                       renderInput={(params) => (
                         <TextField


### PR DESCRIPTION
## Summary

Create Server 다이얼로그의 모드팩 검색 Autocomplete 드롭다운을 리치 카드 형태로 개선합니다.

## Changes

- 모드팩 아이콘(`iconUrl`) 표시 (없으면 `Inventory2Icon` fallback)
- 모드팩 설명(`description`) 2줄 클램프 표시
- 다운로드 수(`downloads`) K/M 단위 포맷 + 작성자(`author`) 표시
- `formatDownloads(n)` 헬퍼 추가

## Test

- type-check ✅
- lint ✅ (기존 무관 경고만)
- CreateServerDialog 단위 테스트 35개 통과 ✅

Closes #516