### PR TITLE
feat(modpack): 클라이언트 전용 모드 제외 옵션 (--exclude-files) (#515)

### DIFF
--- a/docs/mods-and-plugins/modpacks.ko.md
+++ b/docs/mods-and-plugins/modpacks.ko.md
@@ -201,6 +201,32 @@ mcctl config modded MODRINTH_FORCE_INCLUDE_FILES "some-server-mod"
 mcctl config modded MODRINTH_FORCE_SYNCHRONIZE "true"
 ```
 
+### 클라이언트 전용 모드 제외
+
+일부 모드팩은 데디케이티드 서버에서 크래시를 일으키는 **클라이언트 전용 모드**
+(Status Effect Bars 같은 HUD/UI 모드)를 포함합니다. 이 경우 다음과 같은 오류가
+발생합니다.
+
+```
+java.lang.BootstrapMethodError: Attempted to load class
+net/minecraft/client/gui/screens/Screen for invalid dist DEDICATED_SERVER
+→ Failed to start the minecraft server
+```
+
+모드팩이 클라이언트 모드를 서버 호환으로 잘못 표시하면 이미지의 자동 클라이언트
+모드 필터링이 동작하지 않습니다. 서버 생성 시 (부분) 파일명으로 해당 모드를
+제외하세요.
+
+```bash
+# 클라이언트 전용 모드를 콤마로 구분해 제외
+mcctl create myserver -t MODRINTH --modpack create-plus \
+  --mod-loader neoforge --exclude-files statuseffectbars
+```
+
+웹 콘솔에서는 Create Server 다이얼로그의 모드팩 섹션에 있는 **Exclude mods**
+필드를 사용합니다. 입력값은 서버의 `config.env`에 `MODRINTH_EXCLUDE_FILES`
+(CurseForge는 `CF_EXCLUDE_MODS`)로 기록됩니다.
+
 ### 전체 예제
 
 ```bash

--- a/docs/mods-and-plugins/modpacks.md
+++ b/docs/mods-and-plugins/modpacks.md
@@ -201,6 +201,31 @@ mcctl config modded MODRINTH_FORCE_INCLUDE_FILES "some-server-mod"
 mcctl config modded MODRINTH_FORCE_SYNCHRONIZE "true"
 ```
 
+### Excluding Client-Only Mods
+
+Some modpacks bundle **client-only mods** (HUD/UI mods such as Status Effect Bars)
+that crash a dedicated server with an error like:
+
+```
+java.lang.BootstrapMethodError: Attempted to load class
+net/minecraft/client/gui/screens/Screen for invalid dist DEDICATED_SERVER
+→ Failed to start the minecraft server
+```
+
+This happens when the modpack incorrectly marks a client mod as server-compatible,
+so the image's automatic client-mod filtering does not catch it. Exclude such mods
+by (partial) file name when creating the server:
+
+```bash
+# Exclude one or more client-only mods (comma-separated)
+mcctl create myserver -t MODRINTH --modpack create-plus \
+  --mod-loader neoforge --exclude-files statuseffectbars
+```
+
+In the Web Console, use the **Exclude mods** field in the Create Server dialog's
+modpack section. The values are written to `MODRINTH_EXCLUDE_FILES`
+(or `CF_EXCLUDE_MODS` for CurseForge) in the server's `config.env`.
+
 ### Complete Example
 
 ```bash

--- a/platform/scripts/create-server.sh
+++ b/platform/scripts/create-server.sh
@@ -20,6 +20,7 @@
 #   -w, --world NAME     Use existing world from worlds/ directory (creates symlink)
 #   --modpack SLUG       Modpack slug (required for MODRINTH/AUTO_CURSEFORGE)
 #   --modpack-version VER  Modpack version (optional)
+#   --exclude-files LIST Mods to exclude from modpack, comma-separated (optional)
 #   --mod-loader LOADER  Mod loader: fabric, forge, neoforge, quilt (optional)
 #   -m, --memory SIZE    Memory allocation (e.g., 1G, 2G, 4G)
 #   --no-whitelist       Disable whitelist (whitelist is enabled by default)
@@ -240,6 +241,7 @@ WORLD_NAME=""
 MODPACK_SLUG=""
 MODPACK_VERSION=""
 MOD_LOADER=""
+MODPACK_EXCLUDE_FILES=""
 ENABLE_WHITELIST="true"
 WHITELIST_PLAYERS=""
 START_SERVER="true"
@@ -262,6 +264,7 @@ show_usage() {
     echo "  --modpack SLUG       Modpack slug (required for MODRINTH/AUTO_CURSEFORGE)"
     echo "  --modpack-version VER  Modpack version (optional)"
     echo "  --mod-loader LOADER  Mod loader: fabric, forge, neoforge, quilt (optional)"
+    echo "  --exclude-files LIST Mods to exclude from modpack (comma-separated, e.g. client-only mods)"
     echo "  -m, --memory SIZE    Memory allocation (e.g., 1G, 2G, 4G)"
     echo "  --no-whitelist       Disable whitelist (whitelist is enabled by default)"
     echo "  --whitelist PLAYERS  Initial whitelist players (comma-separated)"
@@ -328,6 +331,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --mod-loader)
             MOD_LOADER="$2"
+            shift 2
+            ;;
+        --exclude-files)
+            MODPACK_EXCLUDE_FILES="$2"
             shift 2
             ;;
         -m|--memory)
@@ -542,6 +549,10 @@ if [ -f "$CONFIG_FILE" ]; then
                 echo "MODRINTH_LOADER=$MOD_LOADER" >> "$CONFIG_FILE"
                 echo "   Mod loader: $MOD_LOADER"
             fi
+            if [ -n "$MODPACK_EXCLUDE_FILES" ]; then
+                echo "MODRINTH_EXCLUDE_FILES=$MODPACK_EXCLUDE_FILES" >> "$CONFIG_FILE"
+                echo "   Excluded mods: $MODPACK_EXCLUDE_FILES"
+            fi
         elif [[ "$SERVER_TYPE" == "AUTO_CURSEFORGE" ]]; then
             echo "CF_SLUG=$MODPACK_SLUG" >> "$CONFIG_FILE"
             echo "   Modpack: $MODPACK_SLUG (CurseForge)"
@@ -552,6 +563,10 @@ if [ -f "$CONFIG_FILE" ]; then
             if [ -n "$MOD_LOADER" ]; then
                 echo "CF_LOADER=$MOD_LOADER" >> "$CONFIG_FILE"
                 echo "   Mod loader: $MOD_LOADER"
+            fi
+            if [ -n "$MODPACK_EXCLUDE_FILES" ]; then
+                echo "CF_EXCLUDE_MODS=$MODPACK_EXCLUDE_FILES" >> "$CONFIG_FILE"
+                echo "   Excluded mods: $MODPACK_EXCLUDE_FILES"
             fi
         fi
     fi

--- a/platform/services/cli/src/commands/create.ts
+++ b/platform/services/cli/src/commands/create.ts
@@ -25,6 +25,7 @@ export interface CreateCommandOptions {
   modpack?: string;
   modpackVersion?: string;
   modLoader?: string;
+  excludeFiles?: string;
   playitDomain?: string;
   noPlayitDomain?: boolean;
 }
@@ -95,6 +96,9 @@ async function createWithArguments(
       modpackSlug: options.modpack,
       modpackVersion: options.modpackVersion,
       modLoader: options.modLoader,
+      modpackExcludeFiles: options.excludeFiles
+        ? options.excludeFiles.split(',').map((f) => f.trim()).filter(Boolean)
+        : undefined,
       enableWhitelist: !options.noWhitelist,
       whitelistPlayers: options.whitelist
         ? options.whitelist.split(',').map((p) => p.trim()).filter(Boolean)
@@ -116,6 +120,9 @@ async function createWithArguments(
       }
       if (server.modpackOptions.loader) {
         console.log(`  Mod Loader: ${server.modpackOptions.loader}`);
+      }
+      if (server.modpackOptions.excludeFiles && server.modpackOptions.excludeFiles.length > 0) {
+        console.log(`  Excluded Mods: ${server.modpackOptions.excludeFiles.join(', ')}`);
       }
     } else {
       console.log(`  Version: ${server.version.value}`);

--- a/platform/services/cli/src/index.ts
+++ b/platform/services/cli/src/index.ts
@@ -342,6 +342,7 @@ ${colors.cyan('Create Options:')}
   --modpack SLUG             Modrinth modpack slug (required for MODRINTH type)
   --modpack-version VERSION  Modpack version (optional, default: latest)
   --mod-loader LOADER        Mod loader (auto/fabric/forge/quilt, default: auto)
+  --exclude-files LIST       Mods to exclude from modpack, comma-separated (e.g. client-only mods)
   --playit-domain DOMAIN     Register playit.gg external domain (e.g., aa.example.com)
   --no-playit-domain         Skip playit domain registration (explicit)
 
@@ -579,6 +580,7 @@ async function main(): Promise<void> {
           modpack: flags['modpack'] as string | undefined,
           modpackVersion: flags['modpack-version'] as string | undefined,
           modLoader: flags['mod-loader'] as string | undefined,
+          excludeFiles: flags['exclude-files'] as string | undefined,
           playitDomain: flags['playit-domain'] as string | undefined,
           noPlayitDomain: flags['no-playit-domain'] === true,
         });

--- a/platform/services/cli/src/infrastructure/adapters/ClackPromptAdapter.ts
+++ b/platform/services/cli/src/infrastructure/adapters/ClackPromptAdapter.ts
@@ -620,6 +620,28 @@ export class ClackPromptAdapter implements IPromptPort {
     return result === 'auto' ? undefined : (result as string);
   }
 
+  async promptModpackExcludeFiles(): Promise<string[] | undefined> {
+    const result = await p.text({
+      message: 'Exclude mods (comma-separated, e.g. client-only mods):',
+      placeholder: 'leave empty to install all',
+      defaultValue: '',
+    });
+
+    if (this.isCancel(result)) {
+      this.handleCancel();
+    }
+
+    const value = (result as string).trim();
+    if (value === '') {
+      return undefined;
+    }
+    const files = value
+      .split(',')
+      .map((f) => f.trim())
+      .filter((f) => f.length > 0);
+    return files.length > 0 ? files : undefined;
+  }
+
   // ========================================
   // Status Display
   // ========================================

--- a/platform/services/cli/tests/mocks/MockPromptAdapter.ts
+++ b/platform/services/cli/tests/mocks/MockPromptAdapter.ts
@@ -35,6 +35,7 @@ export interface MockPromptValues {
   modpackSlug?: string;
   modpackVersion?: string;
   modpackLoader?: string;
+  modpackExcludeFiles?: string[];
   whitelistPlayers?: string[];
 }
 
@@ -249,6 +250,13 @@ export class MockPromptAdapter implements IPromptPort {
       throw new MockCancelError();
     }
     return this.values.modpackLoader;
+  }
+
+  async promptModpackExcludeFiles(): Promise<string[] | undefined> {
+    if (this._cancelled) {
+      throw new MockCancelError();
+    }
+    return this.values.modpackExcludeFiles;
   }
 
   // ========================================

--- a/platform/services/cli/tests/unit/commands/create.test.ts
+++ b/platform/services/cli/tests/unit/commands/create.test.ts
@@ -91,6 +91,46 @@ describe('create command - MODRINTH modpack support', () => {
       });
     });
 
+    it('should split --exclude-files into modpackExcludeFiles array', async () => {
+      // ARRANGE
+      const options: CreateCommandOptions = {
+        name: 'myserver',
+        type: 'MODRINTH',
+        modpack: 'create-plus',
+        modLoader: 'neoforge',
+        excludeFiles: 'statuseffectbars, jei ,',
+        noStart: false,
+      };
+
+      const mockServer = {
+        name: { value: 'myserver' },
+        containerName: 'mc-myserver',
+        type: { label: 'Modrinth Modpack', isModpack: true },
+        version: { value: 'LATEST' },
+        memory: { value: '6G' },
+        modpackOptions: {
+          slug: 'create-plus',
+          loader: 'neoforge',
+          excludeFiles: ['statuseffectbars', 'jei'],
+        },
+      };
+
+      mockCreateServerUseCase.executeWithConfig.mockResolvedValue(mockServer);
+
+      // ACT
+      const exitCode = await createCommand(options);
+
+      // ASSERT
+      expect(exitCode).toBe(0);
+      expect(mockCreateServerUseCase.executeWithConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modpackSlug: 'create-plus',
+          modLoader: 'neoforge',
+          modpackExcludeFiles: ['statuseffectbars', 'jei'],
+        })
+      );
+    });
+
     it('should pass only slug if version and loader are not provided', async () => {
       // ARRANGE
       const options: CreateCommandOptions = {

--- a/platform/services/mcctl-api/src/routes/servers.ts
+++ b/platform/services/mcctl-api/src/routes/servers.ts
@@ -595,7 +595,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       },
     },
   }, async (request: FastifyRequest<CreateServerRoute>, reply: FastifyReply) => {
-    const { name, type, version, memory, seed, worldUrl, worldName, autoStart, sudoPassword, modpack, modpackVersion, modLoader } = request.body;
+    const { name, type, version, memory, seed, worldUrl, worldName, autoStart, sudoPassword, modpack, modpackVersion, modLoader, excludeFiles } = request.body;
     const { follow = false } = request.query;
 
     // Check if server already exists (before SSE mode check)
@@ -719,6 +719,9 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     if (modLoader) {
       args.push('--mod-loader', modLoader);
     }
+    if (excludeFiles && excludeFiles.length > 0) {
+      args.push('--exclude-files', excludeFiles.join(','));
+    }
     if (autoStart === false) {
       args.push('--no-start');
     }
@@ -839,6 +842,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
               modpack: modpack ?? null,
               modpackVersion: modpackVersion ?? null,
               modLoader: modLoader ?? null,
+              excludeFiles: excludeFiles && excludeFiles.length > 0 ? excludeFiles.join(',') : null,
             },
             errorMessage: null,
           });
@@ -923,6 +927,7 @@ const serversPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
           modpack: modpack ?? null,
           modpackVersion: modpackVersion ?? null,
           modLoader: modLoader ?? null,
+          excludeFiles: excludeFiles && excludeFiles.length > 0 ? excludeFiles.join(',') : null,
         },
         errorMessage: null,
       });

--- a/platform/services/mcctl-api/src/schemas/server.ts
+++ b/platform/services/mcctl-api/src/schemas/server.ts
@@ -171,6 +171,20 @@ export const CreateServerRequestSchema = Type.Object({
     Type.Literal('neoforge'),
     Type.Literal('quilt'),
   ], { description: 'Mod loader override' })),
+  excludeFiles: Type.Optional(Type.Array(
+    Type.String({
+      // Partial file names (Modrinth) or project IDs/slugs (CurseForge).
+      // Restricted to safe characters to harden the non-SSE create path that
+      // interpolates args into a shell command. No commas (the join delimiter),
+      // quotes, spaces, or other shell metacharacters allowed.
+      pattern: '^[A-Za-z0-9_.-]+$',
+      minLength: 1,
+    }),
+    {
+      maxItems: 100,
+      description: 'Mods to exclude from the modpack (e.g. client-only mods that crash a dedicated server). Maps to MODRINTH_EXCLUDE_FILES / CF_EXCLUDE_MODS.',
+    }
+  )),
 });
 
 // Create Server Query Schema (for SSE streaming support)

--- a/platform/services/mcctl-api/tests/servers.test.ts
+++ b/platform/services/mcctl-api/tests/servers.test.ts
@@ -741,6 +741,45 @@ describe('POST /api/servers - Modrinth Modpack Support', () => {
       expect(args).not.toContain('--modpack-version');
       expect(args).not.toContain('--mod-loader');
     });
+
+    it('should pass --exclude-files (comma-joined) when excludeFiles provided', async () => {
+      mockedServerExists.mockReturnValue(false);
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/servers?follow=true',
+        payload: {
+          name: 'modpack-exclude',
+          type: 'MODRINTH',
+          modpack: 'create-plus',
+          modLoader: 'neoforge',
+          excludeFiles: ['statuseffectbars', 'jei'],
+        },
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['--exclude-files', 'statuseffectbars,jei']),
+        expect.any(Object)
+      );
+    });
+
+    it('should reject excludeFiles entries with shell metacharacters (400)', async () => {
+      mockedServerExists.mockReturnValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/servers?follow=true',
+        payload: {
+          name: 'modpack-bad-exclude',
+          type: 'MODRINTH',
+          modpack: 'create-plus',
+          excludeFiles: ['statuseffectbars; rm -rf /'],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
   });
 
   describe('Audit Logging', () => {

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
@@ -491,6 +491,45 @@ describe('CreateServerDialog', () => {
       });
     });
 
+    it('should submit excludeFiles parsed from the Exclude mods field', async () => {
+      mockUseModVersions.mockReturnValue(cobblemonMatrix);
+
+      const onSubmit = vi.fn();
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /modpack/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/server name/i), {
+        target: { value: 'exclude-server' },
+      });
+      fireEvent.change(screen.getByRole('combobox', { name: /modpack/i }), {
+        target: { value: 'cobblemon' },
+      });
+
+      // Exclude mods field appears once a modpack slug is set
+      await waitFor(() => {
+        expect(screen.getByLabelText(/exclude mods/i)).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/exclude mods/i), {
+        target: { value: 'statuseffectbars, jei ,' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        const arg = onSubmit.mock.calls[0][0];
+        expect(arg.excludeFiles).toEqual(['statuseffectbars', 'jei']);
+      });
+    });
+
     it('should disable Create while the compatibility matrix is loading', async () => {
       mockUseModVersions.mockReturnValue({ data: undefined, isLoading: true, isError: false });
 

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
@@ -96,6 +96,8 @@ export function CreateServerDialog({
   const [modpackSearchInput, setModpackSearchInput] = useState('');
   const [selectedLoader, setSelectedLoader] = useState('');
   const [selectedGameVersion, setSelectedGameVersion] = useState('');
+  // Comma-separated list of mods to exclude from the modpack (e.g. client-only mods)
+  const [excludeFilesInput, setExcludeFilesInput] = useState('');
 
   // Refs for accessibility
   const firstModpackFieldRef = useRef<HTMLInputElement>(null);
@@ -162,6 +164,7 @@ export function CreateServerDialog({
       setModpackSearchInput('');
       setSelectedLoader('');
       setSelectedGameVersion('');
+      setExcludeFilesInput('');
     }
   }, [open]);
 
@@ -311,6 +314,14 @@ export function CreateServerDialog({
         if (recommended) {
           submitData.modpackVersion = recommended;
         }
+      }
+      // Exclude client-only mods that would crash a dedicated server.
+      const excludeFiles = excludeFilesInput
+        .split(',')
+        .map((f) => f.trim())
+        .filter((f) => f.length > 0);
+      if (excludeFiles.length > 0) {
+        submitData.excludeFiles = excludeFiles;
       }
     }
 
@@ -655,6 +666,18 @@ export function CreateServerDialog({
                           ))}
                         </TextField>
                       </>
+                    )}
+
+                    {modpackSlug && (
+                      <TextField
+                        label="Exclude mods (optional)"
+                        value={excludeFilesInput}
+                        onChange={(e) => setExcludeFilesInput(e.target.value)}
+                        placeholder="e.g. statuseffectbars, jei"
+                        helperText="Comma-separated. Use this to drop client-only mods that crash a dedicated server."
+                        fullWidth
+                        disabled={isCreating}
+                      />
                     )}
                   </Box>
                 </Collapse>

--- a/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
+++ b/platform/services/mcctl-console/src/ports/api/IMcctlApiClient.ts
@@ -57,6 +57,11 @@ export interface CreateServerRequest {
   modpack?: string;
   modpackVersion?: string;
   modLoader?: string;
+  /**
+   * Mods to exclude from modpack installation (e.g. client-only mods that crash
+   * a dedicated server). Maps to MODRINTH_EXCLUDE_FILES / CF_EXCLUDE_MODS.
+   */
+  excludeFiles?: string[];
 }
 
 export interface CreateServerResponse {

--- a/platform/services/shared/src/application/ports/inbound/ICreateServerUseCase.ts
+++ b/platform/services/shared/src/application/ports/inbound/ICreateServerUseCase.ts
@@ -34,6 +34,11 @@ export interface CreateServerConfig {
   modpackSlug?: string;
   modpackVersion?: string;
   modLoader?: string;
+  /**
+   * Mods to exclude from modpack installation (client-only mods that crash a
+   * dedicated server). Maps to MODRINTH_EXCLUDE_FILES / CF_EXCLUDE_MODS.
+   */
+  modpackExcludeFiles?: string[];
   enableWhitelist?: boolean;
   whitelistPlayers?: string[];
   playitDomain?: string;

--- a/platform/services/shared/src/application/ports/outbound/IPromptPort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IPromptPort.ts
@@ -120,6 +120,13 @@ export interface IPromptPort {
    */
   promptModpackLoader(availableLoaders?: string[]): Promise<string | undefined>;
 
+  /**
+   * Prompt for mods to exclude from the modpack (optional).
+   * Used to drop client-only mods that crash a dedicated server.
+   * Returns undefined when nothing is excluded.
+   */
+  promptModpackExcludeFiles(): Promise<string[] | undefined>;
+
   // ========================================
   // Status Display
   // ========================================

--- a/platform/services/shared/src/application/ports/outbound/IShellPort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IShellPort.ts
@@ -145,6 +145,11 @@ export interface CreateServerOptions {
   modpackSlug?: string;
   modpackVersion?: string;
   modLoader?: string;
+  /**
+   * Mods to exclude from modpack installation (e.g. client-only mods that
+   * crash a dedicated server). Maps to MODRINTH_EXCLUDE_FILES / CF_EXCLUDE_MODS.
+   */
+  modpackExcludeFiles?: string[];
   enableWhitelist?: boolean;
   whitelistPlayers?: string[];
   playitDomain?: string;

--- a/platform/services/shared/src/application/use-cases/CreateServerUseCase.ts
+++ b/platform/services/shared/src/application/use-cases/CreateServerUseCase.ts
@@ -65,6 +65,7 @@ export class CreateServerUseCase implements ICreateServerUseCase {
       let modpackSlug: string | undefined;
       let modpackVersion: string | undefined;
       let modLoader: string | undefined;
+      let modpackExcludeFiles: string[] | undefined;
 
       if (type.isModpack) {
         modpackSlug = await this.prompt.promptModpackSlug();
@@ -90,6 +91,7 @@ export class CreateServerUseCase implements ICreateServerUseCase {
 
         modLoader = await this.prompt.promptModpackLoader(availableLoaders);
         modpackVersion = await this.prompt.promptModpackVersion();
+        modpackExcludeFiles = await this.prompt.promptModpackExcludeFiles();
       }
 
       // Prompt for Minecraft version (skip for modpack servers)
@@ -160,6 +162,7 @@ export class CreateServerUseCase implements ICreateServerUseCase {
           ? ModpackOptions.modrinth(modpackSlug, {
               version: modpackVersion,
               loader: modLoader,
+              excludeFiles: modpackExcludeFiles,
             })
           : undefined;
 
@@ -187,6 +190,7 @@ export class CreateServerUseCase implements ICreateServerUseCase {
         modpackSlug,
         modpackVersion,
         modLoader,
+        modpackExcludeFiles: modpackOptions?.excludeFiles,
         enableWhitelist: true,
         whitelistPlayers,
         playitDomain,
@@ -293,6 +297,7 @@ export class CreateServerUseCase implements ICreateServerUseCase {
         ? ModpackOptions.modrinth(config.modpackSlug, {
             version: config.modpackVersion,
             loader: config.modLoader,
+            excludeFiles: config.modpackExcludeFiles,
           })
         : undefined;
 
@@ -316,6 +321,7 @@ export class CreateServerUseCase implements ICreateServerUseCase {
       modpackSlug: config.modpackSlug,
       modpackVersion: config.modpackVersion,
       modLoader: config.modLoader,
+      modpackExcludeFiles: modpackOptions?.excludeFiles,
       enableWhitelist: config.enableWhitelist !== false,
       whitelistPlayers: config.whitelistPlayers,
       playitDomain: config.playitDomain,

--- a/platform/services/shared/src/domain/value-objects/ModpackOptions.ts
+++ b/platform/services/shared/src/domain/value-objects/ModpackOptions.ts
@@ -8,6 +8,25 @@ export type ModpackSource = 'MODRINTH' | 'CURSEFORGE';
 export interface ModpackConfig {
   version?: string;
   loader?: string;
+  /**
+   * Partial file names (Modrinth) or project IDs/slugs (CurseForge) of mods to
+   * exclude from the modpack installation. Used to drop client-only mods that
+   * the modpack incorrectly marks as server-compatible and would otherwise
+   * crash a dedicated server.
+   */
+  excludeFiles?: string[];
+}
+
+/**
+ * Normalize an exclude list: trim entries and drop empty ones.
+ * Returns undefined when nothing remains so callers can omit the field.
+ */
+function normalizeExcludeFiles(excludeFiles?: string[]): string[] | undefined {
+  if (!excludeFiles) {
+    return undefined;
+  }
+  const cleaned = excludeFiles.map((f) => f.trim()).filter((f) => f.length > 0);
+  return cleaned.length > 0 ? cleaned : undefined;
 }
 
 export class ModpackOptions {
@@ -15,7 +34,8 @@ export class ModpackOptions {
     public readonly source: ModpackSource,
     public readonly slug: string,
     public readonly version?: string,
-    public readonly loader?: string
+    public readonly loader?: string,
+    public readonly excludeFiles?: string[]
   ) {
     Object.freeze(this);
   }
@@ -23,27 +43,39 @@ export class ModpackOptions {
   /**
    * Create Modrinth modpack options
    * @param slug - Modrinth modpack slug
-   * @param config - Optional version and loader
+   * @param config - Optional version, loader, and excludeFiles
    */
   static modrinth(slug: string, config?: ModpackConfig): ModpackOptions {
     const trimmedSlug = slug.trim();
     if (!trimmedSlug) {
       throw new Error('Modpack slug cannot be empty');
     }
-    return new ModpackOptions('MODRINTH', trimmedSlug, config?.version, config?.loader);
+    return new ModpackOptions(
+      'MODRINTH',
+      trimmedSlug,
+      config?.version,
+      config?.loader,
+      normalizeExcludeFiles(config?.excludeFiles)
+    );
   }
 
   /**
    * Create CurseForge modpack options
    * @param slug - CurseForge modpack slug
-   * @param config - Optional version and loader
+   * @param config - Optional version, loader, and excludeFiles
    */
   static curseforge(slug: string, config?: ModpackConfig): ModpackOptions {
     const trimmedSlug = slug.trim();
     if (!trimmedSlug) {
       throw new Error('Modpack slug cannot be empty');
     }
-    return new ModpackOptions('CURSEFORGE', trimmedSlug, config?.version, config?.loader);
+    return new ModpackOptions(
+      'CURSEFORGE',
+      trimmedSlug,
+      config?.version,
+      config?.loader,
+      normalizeExcludeFiles(config?.excludeFiles)
+    );
   }
 
   /**
@@ -61,6 +93,9 @@ export class ModpackOptions {
       if (this.loader) {
         envVars.MODRINTH_LOADER = this.loader;
       }
+      if (this.excludeFiles && this.excludeFiles.length > 0) {
+        envVars.MODRINTH_EXCLUDE_FILES = this.excludeFiles.join(',');
+      }
     } else if (this.source === 'CURSEFORGE') {
       envVars.TYPE = 'AUTO_CURSEFORGE';
       envVars.CF_SLUG = this.slug;
@@ -69,6 +104,9 @@ export class ModpackOptions {
       }
       if (this.loader) {
         envVars.CF_LOADER = this.loader;
+      }
+      if (this.excludeFiles && this.excludeFiles.length > 0) {
+        envVars.CF_EXCLUDE_MODS = this.excludeFiles.join(',');
       }
     }
 
@@ -99,6 +137,10 @@ export class ModpackOptions {
       if (this.loader) {
         args.push('--mod-loader', this.loader);
       }
+    }
+
+    if (this.excludeFiles && this.excludeFiles.length > 0) {
+      args.push('--exclude-files', this.excludeFiles.join(','));
     }
 
     return args;

--- a/platform/services/shared/src/infrastructure/adapters/ApiPromptAdapter.ts
+++ b/platform/services/shared/src/infrastructure/adapters/ApiPromptAdapter.ts
@@ -53,6 +53,8 @@ export interface ApiPromptOptions {
   modpackVersion?: string;
   /** Mod loader (optional) */
   modLoader?: string;
+  /** Mods to exclude from modpack installation (optional) */
+  modpackExcludeFiles?: string[];
 }
 
 /**
@@ -304,6 +306,10 @@ export class ApiPromptAdapter implements IPromptPort {
 
   async promptModpackLoader(_availableLoaders?: string[]): Promise<string | undefined> {
     return this.options.modLoader;
+  }
+
+  async promptModpackExcludeFiles(): Promise<string[] | undefined> {
+    return this.options.modpackExcludeFiles;
   }
 
   // ========================================

--- a/platform/services/shared/src/infrastructure/adapters/ShellAdapter.ts
+++ b/platform/services/shared/src/infrastructure/adapters/ShellAdapter.ts
@@ -113,6 +113,9 @@ export class ShellAdapter implements IShellPort {
     if (options.modLoader) {
       args.push('--mod-loader', options.modLoader);
     }
+    if (options.modpackExcludeFiles && options.modpackExcludeFiles.length > 0) {
+      args.push('--exclude-files', options.modpackExcludeFiles.join(','));
+    }
 
     if (options.enableWhitelist === false) {
       args.push('--no-whitelist');

--- a/platform/services/shared/tests/ModpackOptions.test.ts
+++ b/platform/services/shared/tests/ModpackOptions.test.ts
@@ -100,6 +100,44 @@ describe('ModpackOptions', () => {
         CF_VERSION: '2.0.0',
       });
     });
+
+    test('should convert Modrinth excludeFiles to MODRINTH_EXCLUDE_FILES (comma-joined)', () => {
+      const options = ModpackOptions.modrinth('create-plus', {
+        loader: 'neoforge',
+        excludeFiles: ['statuseffectbars', 'jei'],
+      });
+      const envVars = options.toEnvVars();
+
+      expect(envVars).toEqual({
+        TYPE: 'MODRINTH',
+        MODRINTH_MODPACK: 'create-plus',
+        MODRINTH_LOADER: 'neoforge',
+        MODRINTH_EXCLUDE_FILES: 'statuseffectbars,jei',
+      });
+    });
+
+    test('should convert CurseForge excludeFiles to CF_EXCLUDE_MODS', () => {
+      const options = ModpackOptions.curseforge('forge-example', {
+        excludeFiles: ['1284599'],
+      });
+      const envVars = options.toEnvVars();
+
+      expect(envVars).toEqual({
+        TYPE: 'AUTO_CURSEFORGE',
+        CF_SLUG: 'forge-example',
+        CF_EXCLUDE_MODS: '1284599',
+      });
+    });
+
+    test('should omit exclude env var when excludeFiles is empty', () => {
+      const options = ModpackOptions.modrinth('create-plus', { excludeFiles: [] });
+      const envVars = options.toEnvVars();
+
+      expect(envVars).toEqual({
+        TYPE: 'MODRINTH',
+        MODRINTH_MODPACK: 'create-plus',
+      });
+    });
   });
 
   describe('toCliArgs', () => {
@@ -137,6 +175,36 @@ describe('ModpackOptions', () => {
         '--modpack-slug', 'forge-example',
         '--modpack-version', '2.0.0',
       ]);
+    });
+
+    test('should convert excludeFiles to --exclude-files CLI arg (comma-joined)', () => {
+      const options = ModpackOptions.modrinth('create-plus', {
+        loader: 'neoforge',
+        excludeFiles: ['statuseffectbars', 'jei'],
+      });
+      const args = options.toCliArgs();
+
+      expect(args).toEqual([
+        '--type', 'MODRINTH',
+        '--modpack-slug', 'create-plus',
+        '--mod-loader', 'neoforge',
+        '--exclude-files', 'statuseffectbars,jei',
+      ]);
+    });
+  });
+
+  describe('excludeFiles normalization', () => {
+    test('should trim and drop empty entries', () => {
+      const options = ModpackOptions.modrinth('create-plus', {
+        excludeFiles: ['  statuseffectbars  ', '', '   ', 'jei'],
+      });
+
+      expect(options.excludeFiles).toEqual(['statuseffectbars', 'jei']);
+    });
+
+    test('should default excludeFiles to undefined when not provided', () => {
+      const options = ModpackOptions.modrinth('create-plus');
+      expect(options.excludeFiles).toBe(undefined);
     });
   });
 });

--- a/platform/services/shared/tests/ShellAdapter-modpack.test.ts
+++ b/platform/services/shared/tests/ShellAdapter-modpack.test.ts
@@ -67,6 +67,20 @@ describe('ShellAdapter - Modpack Support', () => {
       expect(options.modLoader).toBe('fabric');
     });
 
+    test('should accept modpackExcludeFiles option', () => {
+      const options: CreateServerOptions = {
+        type: ServerType.fromEnum(ServerTypeEnum.MODRINTH),
+        version: McVersion.create('1.21.1'),
+        worldOptions: WorldOptions.newWorld(),
+        modpackSlug: 'create-plus',
+        modLoader: 'neoforge',
+        modpackExcludeFiles: ['statuseffectbars'],
+        autoStart: false,
+      };
+
+      expect(options.modpackExcludeFiles).toEqual(['statuseffectbars']);
+    });
+
     test('should work for AUTO_CURSEFORGE type', () => {
       const options: CreateServerOptions = {
         type: ServerType.fromEnum(ServerTypeEnum.AUTO_CURSEFORGE),


### PR DESCRIPTION
## Summary

모드팩(Modrinth/CurseForge) 기반 서버 생성 시 **클라이언트 전용 모드를 제외**할 수 있는 기능을 추가합니다. `Create Plus` 모드팩의 `statuseffectbars`(Status Effect Bars Reforged)처럼 모드팩이 클라이언트 전용 모드를 서버 호환으로 잘못 표시한 경우, 데디케이티드 서버에서 `ModLoadingException`으로 크래시하던 문제를 사용자가 직접 해결할 수 있습니다.

Closes #515

## Root Cause

- itzg 이미지는 `env.server: unsupported` 모드를 자동 제외하지만, 모드팩이 클라이언트 모드를 잘못 표시하거나 `overrides/`에 강제 포함하면 자동 제외가 실패함
- 기존 매니저는 `MODRINTH_EXCLUDE_FILES` / `CF_EXCLUDE_MODS`를 노출하지 않아 사용자가 제외할 방법이 없었음

## Changes (layer by layer)

| Layer | 변경 |
|-------|------|
| **shared (도메인)** | `ModpackOptions.excludeFiles` 추가 → `MODRINTH_EXCLUDE_FILES`/`CF_EXCLUDE_MODS`(env), `--exclude-files`(CLI args)로 변환. 포트(`IShellPort`, `ICreateServerUseCase`, `IPromptPort`)·어댑터(`ShellAdapter`, `ApiPromptAdapter`, `ClackPromptAdapter`)·`CreateServerUseCase` 인터랙티브/비인터랙티브 경로 배선 |
| **scripts** | `create-server.sh`에 `--exclude-files` 파싱 + `config.env` 기록 |
| **cli** | `mcctl create --exclude-files <list>` (콤마 구분) + 결과에 Excluded Mods 표시 |
| **api** | `POST /api/servers` `excludeFiles` 배열 파라미터. 비-SSE 셸 보간 경로 대비 항목별 `^[A-Za-z0-9_.-]+$` 패턴 제한(셸 인젝션 차단) + 감사 로그 기록 |
| **console** | Create Server 다이얼로그 모드팩 섹션에 **Exclude mods** 입력 필드 |
| **docs** | EN/KO 모드팩 문서에 클라이언트 전용 모드 제외 가이드 |

## Tests (TDD)

- shared: `ModpackOptions` excludeFiles 변환/정규화 단위 테스트 (537 passed)
- cli: `--exclude-files` 분리 테스트 (vitest 329 passed)
- api: `--exclude-files` 인자 전달 + 셸 메타문자 거부(400) 테스트 (463 passed)
- console: Exclude mods 입력 → `excludeFiles` 제출 테스트 (872 passed)
- 전체 패키지 build ✅ / lint ✅

## Workaround (배포 전 기존 서버)

```bash
# platform/servers/<server>/config.env
MODRINTH_EXCLUDE_FILES=statuseffectbars
```

## Note

- "Create Plus + statuseffectbars 제외로 서버 정상 기동" 항목은 실제 런타임 검증이 필요해 코드 레벨까지 구현/테스트 완료, 실 환경 점검은 별도 권장
- 모드팩 `serverSide` 메타데이터 기반 자동 제외 후보 추천(이슈 Phase 4)은 선택 사항으로 본 PR 범위에서 제외 (후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
