### PR TITLE
fix(modpack): 모드팩 검색 입력 중 versions 500 폭주 해결 (#519)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
@@ -31,7 +31,9 @@ const mockUseModVersions = vi.fn(
 
 vi.mock('@/hooks/useMods', () => ({
   useModpackSearch: () => mockUseModpackSearch(),
-  useModVersions: () => mockUseModVersions(),
+  // Forward the slug so tests can assert which slug the matrix lookup uses
+  // (debounce behaviour). The return value still comes from the mock.
+  useModVersions: (slug: string) => mockUseModVersions(slug),
 }));
 
 // Compatibility matrix for cobblemon-like modpack: neoforge -> 1.21.1, forge -> 1.19.2
@@ -528,6 +530,34 @@ describe('CreateServerDialog', () => {
         const arg = onSubmit.mock.calls[0][0];
         expect(arg.excludeFiles).toEqual(['statuseffectbars', 'jei']);
       });
+    });
+
+    it('should debounce the compatibility lookup instead of querying every keystroke', async () => {
+      mockUseModVersions.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /modpack/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
+      });
+
+      mockUseModVersions.mockClear();
+      fireEvent.change(screen.getByRole('combobox', { name: /modpack/i }), {
+        target: { value: 'cobblemon' },
+      });
+
+      // Immediately after typing, the matrix lookup must NOT have been called with
+      // the freshly-typed slug — it stays on the debounced (empty) value.
+      expect(mockUseModVersions).not.toHaveBeenCalledWith('cobblemon');
+
+      // After the debounce window, the lookup switches to the typed slug.
+      await waitFor(
+        () => expect(mockUseModVersions).toHaveBeenCalledWith('cobblemon'),
+        { timeout: 2000 }
+      );
     });
 
     it('should disable Create while the compatibility matrix is loading', async () => {

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
@@ -33,6 +33,7 @@ import Inventory2Icon from '@mui/icons-material/Inventory2';
 import Autocomplete from '@mui/material/Autocomplete';
 import { useWorlds } from '@/hooks/useMcctl';
 import { useModpackSearch, useModVersions } from '@/hooks/useMods';
+import { useDebounce } from '@/hooks/useDebounce';
 import type { CreateServerRequest } from '@/ports/api/IMcctlApiClient';
 import type { CreateServerStatus } from '@/hooks/useCreateServerSSE';
 
@@ -120,13 +121,19 @@ export function CreateServerDialog({
   );
   const modpackOptions = modpackSearchData?.hits ?? [];
 
+  // Debounce the slug used for the compatibility lookup so we don't fire a
+  // request for every keystroke while the user types/pastes a slug. The lookup
+  // treats its input as an exact slug, so intermediate prefixes (e.g. "c",
+  // "cr", "cre") would otherwise hammer the API with not-found requests.
+  const debouncedModpackSlug = useDebounce(modpackSlug, 400);
+
   // Compatibility matrix for the chosen modpack slug
   const {
     data: matrix,
     isLoading: matrixLoading,
     isError: matrixError,
-  } = useModVersions(modpackSlug, {
-    enabled: category === 'modpack' && modpackSlug.trim().length > 0,
+  } = useModVersions(debouncedModpackSlug, {
+    enabled: category === 'modpack' && debouncedModpackSlug.trim().length > 0,
   });
   const availableLoaders = useMemo(() => matrix?.loaders ?? [], [matrix]);
   const availableGameVersions = useMemo(
@@ -136,6 +143,12 @@ export function CreateServerDialog({
         : [],
     [matrix, selectedLoader]
   );
+  // No resolved matrix yet for a chosen modpack and no error either — covers
+  // both the debounce gap (lookup not started) and the in-flight request.
+  // Treated like "loading" so the form can't be submitted with an unresolved
+  // compatibility matrix, while a failed lookup (404/error) still lets the
+  // backend's secondary validation respond.
+  const matrixUnresolved = !!modpackSlug && !matrix && !matrixError;
 
   // Auto-select the first loader once the matrix resolves.
   useEffect(() => {
@@ -270,8 +283,9 @@ export function CreateServerDialog({
         setErrors({ modpack: slugError });
         return;
       }
-      // Block submission while compatibility data is still loading.
-      if (matrixLoading) {
+      // Block submission while compatibility data is still loading (or a lookup
+      // for the just-typed slug hasn't started yet due to debounce).
+      if (matrixLoading || matrixUnresolved) {
         setErrors({ modpack: 'Loading modpack compatibility — please wait a moment' });
         return;
       }
@@ -348,6 +362,7 @@ export function CreateServerDialog({
     !!modpackSlug &&
     !matrixError &&
     (matrixLoading ||
+      matrixUnresolved ||
       (availableLoaders.length > 0 && (!selectedLoader || !selectedGameVersion)));
 
   return (
@@ -614,7 +629,7 @@ export function CreateServerDialog({
                     />
 
                     {/* Loader + Minecraft version selects (driven by compatibility matrix) */}
-                    {modpackSlug && matrixLoading && (
+                    {modpackSlug && (matrixLoading || matrixUnresolved) && (
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <CircularProgress size={18} />
                         <Typography variant="body2" color="text.secondary">

--- a/platform/services/mcctl-console/src/hooks/useDebounce.ts
+++ b/platform/services/mcctl-console/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs` of
+ * no changes. Useful to avoid firing a request on every keystroke (e.g. the
+ * modpack compatibility lookup, which treats its input as an exact slug).
+ */
+export function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
@@ -114,6 +114,14 @@ export class ModrinthApiClient {
     const url = `${this.baseUrl}/project/${slugOrId}/version${queryString ? '?' + queryString : ''}`;
     const response = await fetch(url);
 
+    // A non-existent project returns 404. Treat it as "no versions" (empty list)
+    // rather than throwing, mirroring getProject()'s 404 handling. This lets the
+    // API layer respond with a clean 404 instead of a 500 when a user types a
+    // partial/unknown slug into the modpack search.
+    if (response.status === 404) {
+      return [];
+    }
+
     if (!response.ok) {
       throw new Error(`Modrinth API error: ${response.status} ${response.statusText}`);
     }


### PR DESCRIPTION
## Summary

모드팩 검색 Autocomplete에 타이핑할 때마다 `GET /api/mods/:slug/versions`가 **500**을 반환하며 콘솔을 도배하던 문제를 해결합니다. (`create_plus`를 한 번에 붙여넣으면 정상 동작하던 것이 단서)

Closes #519

## Root Cause & Fix

**1) API — 존재하지 않는 slug에 500 (근본)**
`ModrinthApiClient.getVersions`가 Modrinth 404에서 `throw` → 라우트가 500 응답.
→ `getProject`의 404 처리와 동일하게 **404 시 빈 배열 반환**. 라우트의 기존 `versions.length === 0 → 404` 분기가 동작하여 깔끔한 **404**를 반환.

**2) Frontend — 키 입력마다 매트릭스 조회**
`onInputChange`가 입력값을 매 키 입력마다 `modpackSlug`로 설정 → prefix(`c`, `cr`, `cre`…)마다 조회.
→ 조회용 slug를 **400ms 디바운스**(`useDebounce` 신규). 매트릭스 미해결 상태(`matrixUnresolved`)에서는 생성 버튼 비활성화·제출 차단으로 디바운스 갭에 불완전 제출 방지.

## Tests

- console: `should debounce the compatibility lookup instead of querying every keystroke` 신규 + 기존 36개 통과 (873 passed)
- api: `server-mods` 20개 통과 (`[]` → 404 계약 유지)
- 전체 빌드 ✅ / 콘솔 lint ✅

**Full Changelog**: https://github.com/smallmiro/minecraft-server-manager/compare/v2.25.0...bugfix/519-modpack-versions-500
