### PR TITLE
fix(console): SSE 서버 생성 후 서버 리스트 자동 갱신 (#521)

### DIFF
--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
@@ -26,7 +26,7 @@ const mockUseModpackSearch = vi.fn(
   (): SearchResult => ({ data: undefined, isLoading: false })
 );
 const mockUseModVersions = vi.fn(
-  (): MatrixResult => ({ data: undefined, isLoading: false, isError: false })
+  (_slug?: string): MatrixResult => ({ data: undefined, isLoading: false, isError: false })
 );
 
 vi.mock('@/hooks/useMods', () => ({

--- a/platform/services/mcctl-console/src/hooks/__tests__/useCreateServerSSE.test.tsx
+++ b/platform/services/mcctl-console/src/hooks/__tests__/useCreateServerSSE.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import { useCreateServerSSE } from '../useCreateServerSSE';
 import type { CreateServerRequest } from '@/ports/api/IMcctlApiClient';
 
@@ -7,9 +9,17 @@ import type { CreateServerRequest } from '@/ports/api/IMcctlApiClient';
 const ASYNC_TIMEOUT = 10000;
 
 describe('useCreateServerSSE', () => {
+  let queryClient: QueryClient;
+  let wrapper: ({ children }: { children: ReactNode }) => JSX.Element;
+
   beforeEach(() => {
     // Mock global.fetch to avoid actual network requests
     global.fetch = vi.fn();
+    // The hook uses useQueryClient(); provide one and a wrapper for renderHook.
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
   });
 
   afterEach(() => {
@@ -17,7 +27,7 @@ describe('useCreateServerSSE', () => {
   });
 
   it('should initialize with default state', () => {
-    const { result } = renderHook(() => useCreateServerSSE());
+    const { result } = renderHook(() => useCreateServerSSE(), { wrapper });
 
     expect(result.current.status).toBe('idle');
     expect(result.current.progress).toBe(0);
@@ -27,7 +37,7 @@ describe('useCreateServerSSE', () => {
   });
 
   it('should start server creation', async () => {
-    const { result } = renderHook(() => useCreateServerSSE());
+    const { result } = renderHook(() => useCreateServerSSE(), { wrapper });
 
     const serverData: CreateServerRequest = {
       name: 'test-server',
@@ -54,7 +64,7 @@ describe('useCreateServerSSE', () => {
 
   it('should handle completion', async () => {
     const onSuccess = vi.fn();
-    const { result } = renderHook(() => useCreateServerSSE({ onSuccess }));
+    const { result } = renderHook(() => useCreateServerSSE({ onSuccess }), { wrapper });
 
     const serverData: CreateServerRequest = {
       name: 'test-server',
@@ -81,9 +91,34 @@ describe('useCreateServerSSE', () => {
     expect(onSuccess).toHaveBeenCalledWith('test-server');
   });
 
+  it('should invalidate the servers query on completion so the list refreshes', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateServerSSE(), { wrapper });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    act(() => {
+      result.current.createServer({
+        name: 'test-server',
+        type: 'PAPER',
+        version: '1.21.1',
+        memory: '4G',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('completed');
+    }, { timeout: ASYNC_TIMEOUT });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['servers'] });
+  });
+
   it('should handle network errors', async () => {
     const onError = vi.fn();
-    const { result } = renderHook(() => useCreateServerSSE({ onError }));
+    const { result } = renderHook(() => useCreateServerSSE({ onError }), { wrapper });
 
     const serverData: CreateServerRequest = {
       name: 'test-server',
@@ -110,7 +145,7 @@ describe('useCreateServerSSE', () => {
 
   it('should handle API errors', async () => {
     const onError = vi.fn();
-    const { result } = renderHook(() => useCreateServerSSE({ onError }));
+    const { result } = renderHook(() => useCreateServerSSE({ onError }), { wrapper });
 
     const serverData: CreateServerRequest = {
       name: 'test-server',
@@ -140,7 +175,7 @@ describe('useCreateServerSSE', () => {
   });
 
   it('should reset state', async () => {
-    const { result } = renderHook(() => useCreateServerSSE());
+    const { result } = renderHook(() => useCreateServerSSE(), { wrapper });
 
     const serverData: CreateServerRequest = {
       name: 'test-server',
@@ -175,7 +210,7 @@ describe('useCreateServerSSE', () => {
   });
 
   it('should not allow multiple simultaneous creations', async () => {
-    const { result } = renderHook(() => useCreateServerSSE());
+    const { result } = renderHook(() => useCreateServerSSE(), { wrapper });
 
     const serverData: CreateServerRequest = {
       name: 'test-server',
@@ -215,7 +250,7 @@ describe('useCreateServerSSE', () => {
 
   it('should call onProgress callback', async () => {
     const onProgress = vi.fn();
-    const { result } = renderHook(() => useCreateServerSSE({ onProgress }));
+    const { result } = renderHook(() => useCreateServerSSE({ onProgress }), { wrapper });
 
     const serverData: CreateServerRequest = {
       name: 'test-server',

--- a/platform/services/mcctl-console/src/hooks/useCreateServerSSE.ts
+++ b/platform/services/mcctl-console/src/hooks/useCreateServerSSE.ts
@@ -6,6 +6,7 @@
 'use client';
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import type { CreateServerRequest } from '@/ports/api/IMcctlApiClient';
 import type { ServerCreateEvent } from '@/types/events';
 
@@ -104,6 +105,7 @@ export function useCreateServerSSE(
   options: UseCreateServerSSEOptions = {}
 ): UseCreateServerSSEReturn {
   const { onSuccess, onError, onProgress } = options;
+  const queryClient = useQueryClient();
 
   const [status, setStatus] = useState<CreateServerStatus>('idle');
   const [progress, setProgress] = useState<number>(0);
@@ -193,6 +195,9 @@ export function useCreateServerSSE(
         await new Promise((resolve) => setTimeout(resolve, 500));
 
         updateProgress('completed', 'Server created successfully!', 100);
+        // Refresh the server list so the newly created server shows up without
+        // a manual reload. Other mutations (delete/start/stop) already do this.
+        queryClient.invalidateQueries({ queryKey: ['servers'] });
         onSuccess?.(data.name);
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
@@ -202,7 +207,7 @@ export function useCreateServerSSE(
         onError?.(errorMessage);
       }
     },
-    [status, updateProgress, onSuccess, onError]
+    [status, updateProgress, onSuccess, onError, queryClient]
   );
 
   // Cleanup on unmount


### PR DESCRIPTION
## Summary

Web Console에서 **새 서버 생성 후 서버 리스트가 자동 갱신되지 않던** 문제를 해결합니다. 이제 생성 완료 시 목록이 즉시 새 서버를 표시합니다.

Closes #521

## Root Cause & Fix

SSE 기반 생성 훅 `useCreateServerSSE`만 완료 후 `['servers']` 쿼리 무효화가 누락되어 있었습니다(다른 모든 뮤테이션 — delete/start/stop 등 — 은 `useMcctl.ts`에서 invalidate함).

→ `useCreateServerSSE`에 `useQueryClient` 추가, 완료 직후 `queryClient.invalidateQueries({ queryKey: ['servers'] })` 호출.

## Tests (TDD)

- `useCreateServerSSE.test.tsx`: `should invalidate the servers query on completion so the list refreshes` 신규 (Red→Green). 기존 8개 테스트는 `QueryClientProvider` wrapper로 갱신
- 콘솔 전체 874 passed, type-check ✅, lint ✅

## Note

- 별도 커밋으로 `CreateServerDialog.test.tsx`의 목 타입 시그니처도 수정 — #519에서 목이 slug를 전달하도록 바뀌며 0-인자 타입이 남아 `tsc --noEmit`가 실패하던 것을 바로잡음(vitest는 타입체크를 하지 않아 머지 시 누락됨).

**Full Changelog**: https://github.com/smallmiro/minecraft-server-manager/compare/v2.25.0...bugfix/521-server-list-refresh-after-create
