### PR TITLE
feat(modpack): 클라이언트 전용 모드 정식 메타데이터 기반 자동 감지/제외 (#524)

### DIFF
--- a/platform/services/mcctl-api/src/routes/servers/mods.ts
+++ b/platform/services/mcctl-api/src/routes/servers/mods.ts
@@ -42,6 +42,11 @@ interface ModVersionsRoute {
   Querystring: { source?: string };
 }
 
+interface ModClientOnlyRoute {
+  Params: { slug: string };
+  Querystring: { version?: string; source?: string };
+}
+
 // ============================================================
 // Plugin Definition
 // ============================================================
@@ -355,6 +360,47 @@ const modsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     } catch (error) {
       fastify.log.error(error, 'Failed to get mod versions');
       return reply.code(500).send({ error: 'InternalServerError', message: 'Failed to get mod versions' });
+    }
+  });
+
+  /**
+   * GET /api/mods/:slug/client-only
+   * Detect client-only mods (canonical server_side: unsupported) bundled in a
+   * modpack, so the Create Server flow can pre-fill them into the exclude list.
+   * Returns 502 on detection failure so the client can simply skip pre-filling.
+   */
+  fastify.get<ModClientOnlyRoute>('/api/mods/:slug/client-only', {
+    schema: {
+      description: 'Detect client-only mods bundled in a modpack (to exclude on a server)',
+      tags: ['mods'],
+      response: {
+        400: ErrorResponseSchema,
+        502: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest<ModClientOnlyRoute>, reply: FastifyReply) => {
+    const { slug } = request.params;
+    const { version, source: sourceName } = request.query;
+
+    if (!slug || !slug.trim()) {
+      return reply.code(400).send({ error: 'BadRequest', message: 'Path parameter "slug" is required' });
+    }
+
+    const source = ModSourceFactory.get(sourceName || 'modrinth');
+    if (typeof source.getModpackClientOnlyMods !== 'function') {
+      // Source doesn't support modpack inspection — nothing to detect.
+      return reply.send({ slug, clientOnly: [] });
+    }
+
+    try {
+      const clientOnly = await source.getModpackClientOnlyMods(slug, version);
+      return reply.send({ slug, clientOnly });
+    } catch (error) {
+      fastify.log.warn(error, 'Failed to detect client-only modpack mods');
+      return reply.code(502).send({
+        error: 'BadGateway',
+        message: 'Failed to detect client-only mods for this modpack',
+      });
     }
   });
 };

--- a/platform/services/mcctl-api/tests/server-mods.test.ts
+++ b/platform/services/mcctl-api/tests/server-mods.test.ts
@@ -65,6 +65,7 @@ vi.mock('@minecraft-docker/shared', async (importOriginal) => {
     search: vi.fn(),
     getProject: vi.fn(),
     getVersions: vi.fn(),
+    getModpackClientOnlyMods: vi.fn(),
     isAvailable: vi.fn().mockResolvedValue(true),
   };
 
@@ -526,6 +527,39 @@ MEMORY=4G
 
       // URL form passes schema validation; not a 400 from pattern rejection.
       expect(response.statusCode).not.toBe(400);
+    });
+  });
+
+  describe('GET /api/mods/:slug/client-only', () => {
+    it('should return the detected client-only mod names', async () => {
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.getModpackClientOnlyMods as any).mockResolvedValue([
+        'searchables-1.21.1-1.0',
+        'statuseffectbars-1.21.1',
+      ]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/mods/create-plus/client-only?version=abc123',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.slug).toBe('create-plus');
+      expect(body.clientOnly).toEqual(['searchables-1.21.1-1.0', 'statuseffectbars-1.21.1']);
+      expect(adapter.getModpackClientOnlyMods).toHaveBeenCalledWith('create-plus', 'abc123');
+    });
+
+    it('should return 502 when detection fails', async () => {
+      const adapter = ModSourceFactory.get('modrinth');
+      (adapter.getModpackClientOnlyMods as any).mockRejectedValue(new Error('download failed'));
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/mods/create-plus/client-only',
+      });
+
+      expect(response.statusCode).toBe(502);
     });
   });
 });

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.test.tsx
@@ -28,12 +28,18 @@ const mockUseModpackSearch = vi.fn(
 const mockUseModVersions = vi.fn(
   (_slug?: string): MatrixResult => ({ data: undefined, isLoading: false, isError: false })
 );
+const mockUseModpackClientOnly = vi.fn(
+  (_slug?: string, _version?: string) =>
+    ({ data: undefined, isFetching: false }) as { data: unknown; isFetching: boolean }
+);
 
 vi.mock('@/hooks/useMods', () => ({
   useModpackSearch: () => mockUseModpackSearch(),
   // Forward the slug so tests can assert which slug the matrix lookup uses
   // (debounce behaviour). The return value still comes from the mock.
   useModVersions: (slug: string) => mockUseModVersions(slug),
+  useModpackClientOnly: (slug: string, version?: string) =>
+    mockUseModpackClientOnly(slug, version),
 }));
 
 // Compatibility matrix for cobblemon-like modpack: neoforge -> 1.21.1, forge -> 1.19.2
@@ -58,6 +64,7 @@ describe('CreateServerDialog', () => {
   beforeEach(() => {
     mockUseModpackSearch.mockReturnValue({ data: undefined, isLoading: false });
     mockUseModVersions.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+    mockUseModpackClientOnly.mockReturnValue({ data: undefined, isFetching: false });
   });
 
   it('should render when open is true', () => {
@@ -558,6 +565,35 @@ describe('CreateServerDialog', () => {
         () => expect(mockUseModVersions).toHaveBeenCalledWith('cobblemon'),
         { timeout: 2000 }
       );
+    });
+
+    it('should pre-fill the exclude field with detected client-only mods', async () => {
+      mockUseModVersions.mockReturnValue(cobblemonMatrix);
+      mockUseModpackClientOnly.mockReturnValue({
+        data: { slug: 'cobblemon', clientOnly: ['searchables-1.0', 'statuseffectbars-1.0'] },
+        isFetching: false,
+      });
+
+      renderWithTheme(
+        <CreateServerDialog open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /modpack/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: /modpack/i })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByRole('combobox', { name: /modpack/i }), {
+        target: { value: 'cobblemon' },
+      });
+
+      // neoforge -> 1.21.1 is auto-selected from the matrix, enabling detection
+      const excludeField = (await screen.findByLabelText(/exclude mods/i)) as HTMLInputElement;
+      await waitFor(() => {
+        expect(excludeField.value).toContain('searchables-1.0');
+        expect(excludeField.value).toContain('statuseffectbars-1.0');
+      });
+      expect(screen.getByText(/Detected 2 client-only mods/i)).toBeInTheDocument();
     });
 
     it('should disable Create while the compatibility matrix is loading', async () => {

--- a/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
+++ b/platform/services/mcctl-console/src/components/servers/CreateServerDialog.tsx
@@ -32,7 +32,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
 import Autocomplete from '@mui/material/Autocomplete';
 import { useWorlds } from '@/hooks/useMcctl';
-import { useModpackSearch, useModVersions } from '@/hooks/useMods';
+import { useModpackSearch, useModVersions, useModpackClientOnly } from '@/hooks/useMods';
 import { useDebounce } from '@/hooks/useDebounce';
 import type { CreateServerRequest } from '@/ports/api/IMcctlApiClient';
 import type { CreateServerStatus } from '@/hooks/useCreateServerSSE';
@@ -150,6 +150,42 @@ export function CreateServerDialog({
   // backend's secondary validation respond.
   const matrixUnresolved = !!modpackSlug && !matrix && !matrixError;
 
+  // The modpack version id resolved for the chosen (loader, Minecraft version).
+  const resolvedModpackVersion =
+    selectedLoader && selectedGameVersion
+      ? matrix?.byLoader[selectedLoader]?.recommended[selectedGameVersion]
+      : undefined;
+
+  // Detect client-only mods bundled in this modpack to suggest excluding (#524).
+  const { data: clientOnlyData, isFetching: clientOnlyLoading } = useModpackClientOnly(
+    debouncedModpackSlug,
+    resolvedModpackVersion,
+    {
+      enabled:
+        category === 'modpack' &&
+        debouncedModpackSlug.trim().length > 0 &&
+        !!resolvedModpackVersion,
+    }
+  );
+  const detectedClientOnly = useMemo(
+    () => clientOnlyData?.clientOnly ?? [],
+    [clientOnlyData]
+  );
+
+  // Auto-add detected client-only mods to the exclude field (once per detection,
+  // merged with any manual entries so we don't clobber the user's input).
+  const appliedClientOnlyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (detectedClientOnly.length === 0) return;
+    const sig = `${clientOnlyData?.slug ?? ''}:${resolvedModpackVersion ?? ''}`;
+    if (appliedClientOnlyRef.current === sig) return;
+    appliedClientOnlyRef.current = sig;
+    setExcludeFilesInput((prev) => {
+      const existing = prev.split(',').map((s) => s.trim()).filter(Boolean);
+      return Array.from(new Set([...existing, ...detectedClientOnly])).join(', ');
+    });
+  }, [clientOnlyData, detectedClientOnly, resolvedModpackVersion]);
+
   // Auto-select the first loader once the matrix resolves.
   useEffect(() => {
     if (availableLoaders.length > 0 && !availableLoaders.includes(selectedLoader)) {
@@ -178,6 +214,7 @@ export function CreateServerDialog({
       setSelectedLoader('');
       setSelectedGameVersion('');
       setExcludeFilesInput('');
+      appliedClientOnlyRef.current = null;
     }
   }, [open]);
 
@@ -684,15 +721,33 @@ export function CreateServerDialog({
                     )}
 
                     {modpackSlug && (
-                      <TextField
-                        label="Exclude mods (optional)"
-                        value={excludeFilesInput}
-                        onChange={(e) => setExcludeFilesInput(e.target.value)}
-                        placeholder="e.g. statuseffectbars, jei"
-                        helperText="Comma-separated. Use this to drop client-only mods that crash a dedicated server."
-                        fullWidth
-                        disabled={isCreating}
-                      />
+                      <>
+                        {clientOnlyLoading && (
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <CircularProgress size={16} />
+                            <Typography variant="caption" color="text.secondary">
+                              Checking for client-only mods…
+                            </Typography>
+                          </Box>
+                        )}
+                        {detectedClientOnly.length > 0 && (
+                          <Alert severity="info" sx={{ py: 0 }}>
+                            Detected {detectedClientOnly.length} client-only mod
+                            {detectedClientOnly.length > 1 ? 's' : ''} and added{' '}
+                            {detectedClientOnly.length > 1 ? 'them' : 'it'} to the exclude
+                            list below. You can remove any you want to keep.
+                          </Alert>
+                        )}
+                        <TextField
+                          label="Exclude mods (optional)"
+                          value={excludeFilesInput}
+                          onChange={(e) => setExcludeFilesInput(e.target.value)}
+                          placeholder="e.g. statuseffectbars, jei"
+                          helperText="Comma-separated. Use this to drop client-only mods that crash a dedicated server."
+                          fullWidth
+                          disabled={isCreating}
+                        />
+                      </>
                     )}
                   </Box>
                 </Collapse>

--- a/platform/services/mcctl-console/src/hooks/useMods.ts
+++ b/platform/services/mcctl-console/src/hooks/useMods.ts
@@ -152,3 +152,41 @@ export function useRemoveMod() {
     },
   });
 }
+
+// ============================================================
+// Modpack client-only detection (#524)
+// ============================================================
+
+/** Response of GET /api/mods/:slug/client-only */
+export interface ModpackClientOnlyResponse {
+  slug: string;
+  clientOnly: string[];
+}
+
+/**
+ * Hook to detect client-only mods bundled in a modpack, so the Create Server
+ * dialog can pre-fill them into the exclude list. Fails quietly (no retry) — a
+ * detection failure simply means no suggestions.
+ */
+export function useModpackClientOnly(
+  slug: string,
+  version?: string,
+  options?: { enabled?: boolean; source?: string }
+) {
+  const params = new URLSearchParams();
+  if (version) params.set('version', version);
+  if (options?.source) params.set('source', options.source);
+  const qs = params.toString();
+
+  return useQuery<ModpackClientOnlyResponse, Error>({
+    queryKey: ['mods', slug, 'client-only', version, options?.source],
+    queryFn: () =>
+      apiFetch<ModpackClientOnlyResponse>(
+        `/api/mods/${encodeURIComponent(slug)}/client-only${qs ? `?${qs}` : ''}`
+      ),
+    enabled: options?.enabled !== false && !!slug.trim(),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/platform/services/mod-source-modrinth/package.json
+++ b/platform/services/mod-source-modrinth/package.json
@@ -20,17 +20,20 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
+    "test": "vitest run",
     "prepublishOnly": "pnpm build"
   },
   "engines": {
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@minecraft-docker/shared": "workspace:*"
+    "@minecraft-docker/shared": "workspace:*",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@types/node": "^22.13.1",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^2.0.0"
   },
   "keywords": [
     "minecraft",

--- a/platform/services/mod-source-modrinth/src/ModrinthAdapter.ts
+++ b/platform/services/mod-source-modrinth/src/ModrinthAdapter.ts
@@ -23,6 +23,11 @@ import type {
 
 import { ModrinthApiClient } from './infrastructure/api/index.js';
 import { ModrinthMapper } from './infrastructure/mappers/index.js';
+import {
+  extractProjectIdFromCdnUrl,
+  selectClientOnlyFilenames,
+  type ModpackIndexEntry,
+} from './modpackClientSide.js';
 
 /**
  * Modrinth adapter implementing IModSourcePort
@@ -140,6 +145,49 @@ export class ModrinthAdapter implements IModSourcePort {
     });
 
     return rawVersions.map(v => this.mapper.toVersion(v));
+  }
+
+  /**
+   * Detect client-only mods bundled in a modpack.
+   *
+   * Resolves the modpack's `.mrpack`, enumerates its mod files, and looks up
+   * each mod's *canonical* Modrinth `server_side`. Mods that are `unsupported`
+   * on the server (i.e. client-only) are returned as partial file names suitable
+   * for `MODRINTH_EXCLUDE_FILES`, regardless of how the pack itself labels them.
+   *
+   * @param slugOrId - Modpack slug or id
+   * @param versionId - Specific modpack version id (defaults to the first/latest)
+   * @returns exclude names (basename without `.jar`) of client-only mods
+   */
+  async getModpackClientOnlyMods(slugOrId: string, versionId?: string): Promise<string[]> {
+    const versions = await this.getVersions(slugOrId);
+    if (versions.length === 0) return [];
+
+    const version =
+      (versionId ? versions.find(v => v.id === versionId) : undefined) ?? versions[0];
+    if (!version) return [];
+    const mrpack =
+      version.files.find(f => f.filename.toLowerCase().endsWith('.mrpack')) ??
+      version.files.find(f => f.primary) ??
+      version.files[0];
+    if (!mrpack) return [];
+
+    const indexFiles = await this.apiClient.getModpackIndexFiles(mrpack.url);
+
+    const entries: ModpackIndexEntry[] = [];
+    for (const file of indexFiles) {
+      const url = file.downloads?.[0];
+      if (!url) continue;
+      const projectId = extractProjectIdFromCdnUrl(url);
+      if (projectId) entries.push({ path: file.path, projectId });
+    }
+    if (entries.length === 0) return [];
+
+    const projectIds = [...new Set(entries.map(e => e.projectId))];
+    const rawProjects = await this.apiClient.getProjects(projectIds);
+    const serverSideById = new Map(rawProjects.map(p => [p.id, p.server_side] as const));
+
+    return selectClientOnlyFilenames(entries, serverSideById);
   }
 
   /**

--- a/platform/services/mod-source-modrinth/src/index.ts
+++ b/platform/services/mod-source-modrinth/src/index.ts
@@ -51,6 +51,13 @@ export type { ModrinthSearchParams, ModrinthVersionParams } from './infrastructu
 // Export raw types for advanced usage
 export type * from './types.js';
 
+// Export modpack client-side detection helpers
+export {
+  extractProjectIdFromCdnUrl,
+  selectClientOnlyFilenames,
+} from './modpackClientSide.js';
+export type { ModpackIndexEntry } from './modpackClientSide.js';
+
 // Auto-register with factory
 const adapter = new ModrinthAdapter();
 ModSourceFactory.register(adapter);

--- a/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
@@ -194,7 +194,7 @@ export class ModrinthApiClient {
     const index = JSON.parse(await indexEntry.async('string')) as {
       files?: ModrinthIndexFileRaw[];
     };
-    return index.files ?? [];
+    return Array.isArray(index.files) ? index.files : [];
   }
 
   /**

--- a/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
+++ b/platform/services/mod-source-modrinth/src/infrastructure/api/ModrinthApiClient.ts
@@ -7,6 +7,7 @@
  * @see https://docs.modrinth.com/api-spec
  */
 
+import JSZip from 'jszip';
 import type {
   ModrinthProjectRaw,
   ModrinthSearchResultRaw,
@@ -15,6 +16,15 @@ import type {
 } from '../../types.js';
 
 const MODRINTH_API = 'https://api.modrinth.com/v2';
+
+/**
+ * A single file entry from a modpack's `modrinth.index.json`.
+ */
+export interface ModrinthIndexFileRaw {
+  path: string;
+  downloads: string[];
+  env?: { client?: string; server?: string };
+}
 
 /**
  * Search options for Modrinth API
@@ -160,6 +170,31 @@ export class ModrinthApiClient {
     }
 
     return response.json() as Promise<ModrinthProjectRaw[]>;
+  }
+
+  /**
+   * Download a `.mrpack` (a zip archive) and return the file entries from its
+   * `modrinth.index.json`. Used to enumerate the mods a modpack installs.
+   *
+   * @param mrpackUrl - Direct download URL of the `.mrpack` file
+   */
+  async getModpackIndexFiles(mrpackUrl: string): Promise<ModrinthIndexFileRaw[]> {
+    const response = await fetch(mrpackUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download modpack: ${response.status} ${response.statusText}`);
+    }
+
+    const buffer = await response.arrayBuffer();
+    const zip = await JSZip.loadAsync(buffer);
+    const indexEntry = zip.file('modrinth.index.json');
+    if (!indexEntry) {
+      throw new Error('modrinth.index.json not found in modpack archive');
+    }
+
+    const index = JSON.parse(await indexEntry.async('string')) as {
+      files?: ModrinthIndexFileRaw[];
+    };
+    return index.files ?? [];
   }
 
   /**

--- a/platform/services/mod-source-modrinth/src/modpackClientSide.ts
+++ b/platform/services/mod-source-modrinth/src/modpackClientSide.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure helpers for detecting client-only mods inside a Modrinth modpack.
+ *
+ * The goal is to flag mods whose *canonical* Modrinth `server_side` is
+ * `unsupported` (i.e. client-only), regardless of how the modpack's own
+ * `modrinth.index.json` labels them. A modpack that mislabels a client mod as
+ * server-compatible (or bundles it in overrides) would otherwise install it on
+ * a dedicated server and break it.
+ */
+
+import type { ModSideSupport } from '@minecraft-docker/shared';
+
+/** A single mod entry resolved from a modpack's `modrinth.index.json`. */
+export interface ModpackIndexEntry {
+  /** File path inside the pack, e.g. `mods/searchables-1.21.1-1.0.jar`. */
+  path: string;
+  /** Modrinth project id this file belongs to. */
+  projectId: string;
+}
+
+/**
+ * Extract the Modrinth project id from a `cdn.modrinth.com` download URL.
+ *
+ * URLs look like:
+ *   https://cdn.modrinth.com/data/{PROJECT_ID}/versions/{VERSION_ID}/{file}
+ *
+ * @returns the project id, or null if the URL is not a Modrinth CDN data URL.
+ */
+export function extractProjectIdFromCdnUrl(url: string): string | null {
+  const match = /\/data\/([^/]+)\//.exec(url);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Strip a directory and `.jar` extension from a pack path, yielding a partial
+ * file name suitable for `MODRINTH_EXCLUDE_FILES`.
+ */
+function toExcludeName(path: string): string {
+  const base = path.split('/').pop() ?? path;
+  return base.replace(/\.jar$/i, '');
+}
+
+/**
+ * Given modpack mod entries and a map of canonical `server_side` values keyed by
+ * project id, return the exclude names (basename without `.jar`) of the mods
+ * that are `unsupported` on the server — i.e. client-only mods to exclude.
+ *
+ * Entries whose project metadata is unknown (absent from the map) and non-`.jar`
+ * paths are skipped.
+ */
+export function selectClientOnlyFilenames(
+  entries: ModpackIndexEntry[],
+  serverSideById: Map<string, ModSideSupport>
+): string[] {
+  const result: string[] = [];
+  for (const entry of entries) {
+    if (!/\.jar$/i.test(entry.path)) continue;
+    if (serverSideById.get(entry.projectId) === 'unsupported') {
+      result.push(toExcludeName(entry.path));
+    }
+  }
+  return result;
+}

--- a/platform/services/mod-source-modrinth/tests/modpackClientSide.test.ts
+++ b/platform/services/mod-source-modrinth/tests/modpackClientSide.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest';
+import {
+  extractProjectIdFromCdnUrl,
+  selectClientOnlyFilenames,
+  type ModpackIndexEntry,
+} from '../src/modpackClientSide.js';
+
+describe('extractProjectIdFromCdnUrl', () => {
+  test('extracts the project id from a Modrinth CDN URL', () => {
+    const url =
+      'https://cdn.modrinth.com/data/AABBCCDD/versions/v1xyz/searchables-1.21.1-1.0.jar';
+    expect(extractProjectIdFromCdnUrl(url)).toBe('AABBCCDD');
+  });
+
+  test('ignores query strings and extra path segments', () => {
+    const url =
+      'https://cdn.modrinth.com/data/Pr0jId/versions/ver/file.jar?foo=bar';
+    expect(extractProjectIdFromCdnUrl(url)).toBe('Pr0jId');
+  });
+
+  test('returns null for a non-Modrinth or malformed URL', () => {
+    expect(extractProjectIdFromCdnUrl('https://example.com/mods/foo.jar')).toBeNull();
+    expect(extractProjectIdFromCdnUrl('not a url')).toBeNull();
+    expect(extractProjectIdFromCdnUrl('https://cdn.modrinth.com/data/')).toBeNull();
+  });
+});
+
+describe('selectClientOnlyFilenames', () => {
+  const entries: ModpackIndexEntry[] = [
+    { path: 'mods/searchables-1.21.1-1.0.jar', projectId: 'search01' },
+    { path: 'mods/create-6.0.jar', projectId: 'create01' },
+    { path: 'mods/statuseffectbars-1.21.1.jar', projectId: 'seb01' },
+  ];
+
+  test('returns basenames (no extension) of mods whose canonical server_side is unsupported', () => {
+    const serverSideById = new Map<string, 'required' | 'optional' | 'unsupported'>([
+      ['search01', 'unsupported'],
+      ['create01', 'required'],
+      ['seb01', 'unsupported'],
+    ]);
+
+    expect(selectClientOnlyFilenames(entries, serverSideById)).toEqual([
+      'searchables-1.21.1-1.0',
+      'statuseffectbars-1.21.1',
+    ]);
+  });
+
+  test('does not exclude mods that are optional or required on the server', () => {
+    const serverSideById = new Map<string, 'required' | 'optional' | 'unsupported'>([
+      ['search01', 'optional'],
+      ['create01', 'required'],
+      ['seb01', 'required'],
+    ]);
+
+    expect(selectClientOnlyFilenames(entries, serverSideById)).toEqual([]);
+  });
+
+  test('skips entries whose project metadata is unknown (not in the map)', () => {
+    const serverSideById = new Map<string, 'required' | 'optional' | 'unsupported'>([
+      ['seb01', 'unsupported'],
+    ]);
+
+    expect(selectClientOnlyFilenames(entries, serverSideById)).toEqual([
+      'statuseffectbars-1.21.1',
+    ]);
+  });
+
+  test('ignores non-mod paths (e.g. resourcepacks/config)', () => {
+    const mixed: ModpackIndexEntry[] = [
+      { path: 'resourcepacks/fancy.zip', projectId: 'rp01' },
+      { path: 'mods/clientmod-1.0.jar', projectId: 'cm01' },
+    ];
+    const serverSideById = new Map<string, 'required' | 'optional' | 'unsupported'>([
+      ['rp01', 'unsupported'],
+      ['cm01', 'unsupported'],
+    ]);
+
+    expect(selectClientOnlyFilenames(mixed, serverSideById)).toEqual(['clientmod-1.0']);
+  });
+});

--- a/platform/services/mod-source-modrinth/vitest.config.ts
+++ b/platform/services/mod-source-modrinth/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/platform/services/shared/src/application/ports/outbound/IModSourcePort.ts
+++ b/platform/services/shared/src/application/ports/outbound/IModSourcePort.ts
@@ -78,6 +78,16 @@ export interface IModSourcePort {
   getProjects?(slugsOrIds: string[]): Promise<Map<string, ModProject>>;
 
   /**
+   * Detect client-only mods bundled in a modpack.
+   * Optional: only sources that support modpack inspection implement this.
+   * Returns partial file names (for MODRINTH_EXCLUDE_FILES / CF_EXCLUDE_MODS) of
+   * mods whose canonical server-side support is `unsupported`.
+   * @param slugOrId - Modpack slug or ID
+   * @param versionId - Specific modpack version (defaults to latest)
+   */
+  getModpackClientOnlyMods?(slugOrId: string, versionId?: string): Promise<string[]>;
+
+  /**
    * Get the environment variable key for this source
    * Used for config.env configuration
    * @example 'MODRINTH_PROJECTS', 'CURSEFORGE_FILES', 'SPIGET_RESOURCES'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@minecraft-docker/shared':
         specifier: workspace:*
         version: link:../shared
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
     devDependencies:
       '@types/node':
         specifier: ^22.13.1
@@ -290,6 +293,9 @@ importers:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.7)(jsdom@26.1.0)
 
   platform/services/shared:
     dependencies:


### PR DESCRIPTION
## Summary

모드팩 설치 시 **클라이언트 전용 모드(정식 `server_side: unsupported`)를 자동 감지**하여 Create Server 다이얼로그의 Exclude 목록에 자동으로 채웁니다. 모드팩이 잘못 표시하거나 overrides로 포함해도 **Modrinth 정식 메타데이터**로 감지하므로, `create_plus`의 `searchables`/`statuseffectbars` 같은 클라이언트 전용 모드를 잡아냅니다.

Closes #524

## How it works

1. 모드팩 `.mrpack` 다운로드 → `modrinth.index.json` 파싱 (jszip)
2. 각 파일의 CDN URL에서 project id 추출
3. `getProjects` 배치로 각 모드의 **정식 `server_side`** 조회
4. `server_side === 'unsupported'` 모드의 파일명을 반환
5. 콘솔이 이를 Exclude 필드에 **병합 자동 채움** + 안내 Alert (사용자가 개별 해제 가능 — 오탐 대비)

## Layers

| 레이어 | 변경 |
|------|------|
| shared | `IModSourcePort.getModpackClientOnlyMods?` 옵셔널 메서드 |
| mod-source-modrinth | 어댑터 구현 + `.mrpack` 파서 + 순수 헬퍼(TDD) + jszip/vitest 추가 |
| api | `GET /api/mods/:slug/client-only` (실패 시 502 fail-open) |
| console | `useModpackClientOnly` 훅 + 다이얼로그 자동 채움 UI |

## Tests

- mod-source-modrinth: 순수 헬퍼 7개 (신규 vitest 인프라)
- api: 엔드포인트 2개 (성공/502)
- console: 자동 채움 1개 + 기존 회귀
- 전체 빌드 ✅ / type-check ✅ / lint ✅

## Note

- #515/#518(수동 제외), #523/#526(설치 모드 표시+제외)과 상호 보완. 본 PR은 **생성 시점 사전 감지**.
- `mods.ts`/`useMods.ts`는 #526과 영역이 겹쳐 머지 시 조율 필요(둘 다 append).
