### PR TITLE
feat(console): 월드 관리 화면 월드 상세 진입점 (#533)

### DIFF
--- a/platform/services/mcctl-console/src/app/(main)/worlds/page.tsx
+++ b/platform/services/mcctl-console/src/app/(main)/worlds/page.tsx
@@ -20,6 +20,7 @@ import PublicIcon from '@mui/icons-material/Public';
 import { WorldList } from '@/components/worlds/WorldList';
 import { CreateWorldDialog } from '@/components/worlds/CreateWorldDialog';
 import { AssignWorldDialog } from '@/components/worlds/AssignWorldDialog';
+import { WorldInfoPanel } from '@/components/worlds/WorldInfoPanel';
 import {
   useWorlds,
   useCreateWorld,
@@ -38,6 +39,7 @@ export default function WorldsPage() {
   const [assignDialogWorld, setAssignDialogWorld] = useState<string | null>(null);
   const [deleteConfirmWorld, setDeleteConfirmWorld] = useState<string | null>(null);
   const [deleteConfirmInput, setDeleteConfirmInput] = useState('');
+  const [infoWorld, setInfoWorld] = useState<string | null>(null);
   const [loadingWorlds, setLoadingWorlds] = useState<string[]>([]);
 
   // Data fetching
@@ -220,6 +222,7 @@ export default function WorldsPage() {
           onAssign={(worldName) => setAssignDialogWorld(worldName)}
           onRelease={handleReleaseWorld}
           onDelete={handleDeleteClick}
+          onViewInfo={(worldName) => setInfoWorld(worldName)}
           onCreate={() => setCreateDialogOpen(true)}
           loadingWorlds={loadingWorlds}
         />
@@ -243,6 +246,23 @@ export default function WorldsPage() {
         onSubmit={handleAssignWorld}
         loading={assignWorld.isPending}
       />
+
+      {/* World Info Dialog */}
+      <Dialog
+        open={!!infoWorld}
+        onClose={() => setInfoWorld(null)}
+        maxWidth="md"
+        fullWidth
+        fullScreen={isSmallScreen}
+      >
+        <DialogTitle>World Details</DialogTitle>
+        <DialogContent dividers>
+          {infoWorld && <WorldInfoPanel worldName={infoWorld} />}
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setInfoWorld(null)}>Close</Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Delete Confirmation Dialog */}
       <Dialog

--- a/platform/services/mcctl-console/src/components/worlds/WorldCard.test.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldCard.test.tsx
@@ -141,4 +141,27 @@ describe('WorldCard', () => {
     renderWithTheme(<WorldCard world={worldNoServers} />);
     expect(screen.getByText('No servers')).toBeInTheDocument();
   });
+
+  it('calls onViewInfo when the card body is clicked', () => {
+    const onViewInfo = vi.fn();
+    renderWithTheme(<WorldCard world={mockAvailableWorld} onViewInfo={onViewInfo} />);
+    fireEvent.click(screen.getByTestId('world-card-view-info'));
+    expect(onViewInfo).toHaveBeenCalledWith('survival-world');
+  });
+
+  it('does not trigger onViewInfo when an action button is clicked', () => {
+    const onViewInfo = vi.fn();
+    const onDelete = vi.fn();
+    renderWithTheme(
+      <WorldCard world={mockAvailableWorld} onViewInfo={onViewInfo} onDelete={onDelete} />
+    );
+    fireEvent.click(screen.getByLabelText('Delete world'));
+    expect(onDelete).toHaveBeenCalledWith('survival-world');
+    expect(onViewInfo).not.toHaveBeenCalled();
+  });
+
+  it('is not clickable when onViewInfo is not provided', () => {
+    renderWithTheme(<WorldCard world={mockAvailableWorld} />);
+    expect(screen.queryByTestId('world-card-view-info')).toBeNull();
+  });
 });

--- a/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldCard.tsx
@@ -21,10 +21,12 @@ interface WorldCardProps {
   onAssign?: (worldName: string) => void;
   onRelease?: (worldName: string) => void;
   onDelete?: (worldName: string) => void;
+  /** Open the world info panel for this world. */
+  onViewInfo?: (worldName: string) => void;
   loading?: boolean;
 }
 
-export function WorldCard({ world, onAssign, onRelease, onDelete, loading = false }: WorldCardProps) {
+export function WorldCard({ world, onAssign, onRelease, onDelete, onViewInfo, loading = false }: WorldCardProps) {
   const handleActionClick = (
     e: React.MouseEvent,
     action: (worldName: string) => void
@@ -60,7 +62,13 @@ export function WorldCard({ world, onAssign, onRelease, onDelete, loading = fals
         },
       }}
     >
-      <CardContent sx={{ flex: 1, pb: 1 }}>
+      <CardContent
+        sx={{ flex: 1, pb: 1, cursor: onViewInfo ? 'pointer' : 'default' }}
+        onClick={onViewInfo ? () => onViewInfo(world.name) : undefined}
+        data-testid={onViewInfo ? 'world-card-view-info' : undefined}
+        role={onViewInfo ? 'button' : undefined}
+        aria-label={onViewInfo ? `View ${world.name} details` : undefined}
+      >
         {/* Header: Name + Lock Status */}
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
           <Typography

--- a/platform/services/mcctl-console/src/components/worlds/WorldList.tsx
+++ b/platform/services/mcctl-console/src/components/worlds/WorldList.tsx
@@ -19,6 +19,7 @@ interface WorldListProps {
   onAssign?: (worldName: string) => void;
   onRelease?: (worldName: string) => void;
   onDelete?: (worldName: string) => void;
+  onViewInfo?: (worldName: string) => void;
   onCreate?: () => void;
   loadingWorlds?: string[];
 }
@@ -30,6 +31,7 @@ export function WorldList({
   onAssign,
   onRelease,
   onDelete,
+  onViewInfo,
   onCreate,
   loadingWorlds = [],
 }: WorldListProps) {
@@ -154,6 +156,7 @@ export function WorldList({
                 onAssign={onAssign}
                 onRelease={onRelease}
                 onDelete={onDelete}
+                onViewInfo={onViewInfo}
                 loading={loadingWorlds.includes(world.name)}
               />
             </Grid>


### PR DESCRIPTION
## Summary

#525 Phase 1에서 유보했던 **월드 관리 화면 진입점**을 추가합니다. `/worlds` 페이지의 `WorldCard` 본문을 클릭하면 `WorldInfoPanel`을 담은 Dialog가 열려, 서버에 할당되지 않은 월드도 상세 정보(시드/스폰/플레이어 마지막 위치 등)를 조회할 수 있습니다.

Closes #533

## 변경 사항
- `WorldCard`: `onViewInfo` prop 추가, CardContent 클릭 시 호출 (액션 버튼은 `stopPropagation`으로 충돌 없음, a11y role/aria-label 부여)
- `WorldList`: `onViewInfo` 콜백 전달
- `/worlds` page: 선택 상태 + `WorldInfoPanel` Dialog (serverName 없이 호출 → 오프라인 위치만 표시, 기존 컴포넌트 재사용)

## 테스트
- WorldCard: 클릭 시 onViewInfo 호출 / 액션 버튼 클릭 시 미호출 / 미제공 시 비클릭 (3건 추가)
- type-check / lint / build / 전체 console 테스트 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
