### PR TITLE
fix(console): 서버 World 탭 실시간 플레이어 위치 미표시 (#538)

### DIFF
--- a/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
+++ b/platform/services/mcctl-console/src/adapters/McctlApiAdapter.ts
@@ -247,6 +247,12 @@ export class McctlApiAdapter implements IMcctlApiClient {
     return this.fetch<PlayerLocationsResponse>(`/api/worlds/${encodeURIComponent(name)}/players`);
   }
 
+  async getLivePlayers(serverName: string): Promise<PlayerLocationsResponse> {
+    return this.fetch<PlayerLocationsResponse>(
+      `/api/servers/${encodeURIComponent(serverName)}/players/live`
+    );
+  }
+
   async getWorldMapStatus(name: string): Promise<MapStatusResponse> {
     return this.fetch<MapStatusResponse>(`/api/worlds/${encodeURIComponent(name)}/map/status`);
   }

--- a/platform/services/mcctl-console/src/app/api/servers/[name]/players/live/route.ts
+++ b/platform/services/mcctl-console/src/app/api/servers/[name]/players/live/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createMcctlApiClient, McctlApiError, UserContext } from '@/adapters/McctlApiAdapter';
+import { requireAuth, AuthError } from '@/lib/auth-utils';
+import { headers } from 'next/headers';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ name: string }>;
+}
+
+function getUserContext(session: { user: { name?: string | null; email: string; role?: string | null } }): UserContext {
+  return {
+    username: session.user.name || session.user.email,
+    role: session.user.role || 'user',
+  };
+}
+
+/**
+ * GET /api/servers/:name/players/live
+ * Proxy to mcctl-api: live player locations via RCON (#525/#538). Gracefully
+ * returns an empty list when the server is stopped. Without this BFF route the
+ * World tab's live query 404s and falls back to offline-only locations.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await requireAuth(await headers());
+    const { name } = await params;
+    const client = createMcctlApiClient(getUserContext(session));
+    const data = await client.getLivePlayers(name);
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: 'Unauthorized', message: error.message }, { status: error.statusCode });
+    }
+    if (error instanceof McctlApiError) {
+      return NextResponse.json({ error: error.error, message: error.message }, { status: error.statusCode });
+    }
+    console.error('Failed to fetch live players:', error);
+    return NextResponse.json({ error: 'InternalServerError', message: 'Failed to fetch live players' }, { status: 500 });
+  }
+}

--- a/platform/services/mcctl-console/src/app/api/servers/__tests__/players-live-route.test.ts
+++ b/platform/services/mcctl-console/src/app/api/servers/__tests__/players-live-route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue(new Headers({ cookie: 'session=test' })),
+}));
+
+vi.mock('@/lib/auth-utils', () => {
+  class AuthError extends Error {
+    statusCode: number;
+    constructor(message: string, statusCode = 401) {
+      super(message);
+      this.name = 'AuthError';
+      this.statusCode = statusCode;
+    }
+  }
+  return { requireAuth: vi.fn(), AuthError };
+});
+
+const mockGetLivePlayers = vi.fn();
+
+vi.mock('@/adapters/McctlApiAdapter', () => {
+  class McctlApiError extends Error {
+    statusCode: number;
+    error: string;
+    constructor(statusCode: number, error: string, message: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.error = error;
+    }
+  }
+  return {
+    createMcctlApiClient: vi.fn(() => ({ getLivePlayers: mockGetLivePlayers })),
+    McctlApiError,
+    UserContext: undefined,
+  };
+});
+
+import { requireAuth, AuthError } from '@/lib/auth-utils';
+import { GET as getLive } from '../[name]/players/live/route';
+
+const session = { user: { name: 'admin', email: 'a@b.c', role: 'admin' } };
+const ctx = (name: string) => ({ params: Promise.resolve({ name }) });
+
+describe('GET /api/servers/:name/players/live BFF proxy (#538)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (requireAuth as ReturnType<typeof vi.fn>).mockResolvedValue(session);
+  });
+
+  it('proxies live player locations from mcctl-api', async () => {
+    mockGetLivePlayers.mockResolvedValue({
+      players: [{ uuid: '', name: 'Lachphlnn', x: 594, y: 68, z: 904, dimension: 'overworld', online: true }],
+    });
+    const res = await getLive(
+      new NextRequest('http://localhost/api/servers/survival/players/live'),
+      ctx('survival')
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.players[0].name).toBe('Lachphlnn');
+    expect(body.players[0].online).toBe(true);
+    expect(mockGetLivePlayers).toHaveBeenCalledWith('survival');
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    (requireAuth as ReturnType<typeof vi.fn>).mockRejectedValue(new AuthError('No session'));
+    const res = await getLive(
+      new NextRequest('http://localhost/api/servers/survival/players/live'),
+      ctx('survival')
+    );
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

서버 상세 **World 탭**에서 플레이어가 온라인인데도 "No players online — showing last known (offline) locations" 배너와 오프라인 위치만 표시되던 버그를 수정합니다.

## Root Cause

mcctl-console은 generic `/api` 프록시가 없어 엔드포인트마다 App Router BFF 라우트가 필요합니다. Phase 1(#525)에서 추가된 `GET /api/servers/:name/players/live`(Fastify)에 대응하는 **콘솔 BFF 라우트가 누락**되어, `useLivePlayers`의 fetch가 404 → 쿼리 에러 → `live=[]` → 오프라인 폴백/배너로 이어졌습니다. (Fastify 엔드포인트·RCON 경로는 정상)

## Fix

- `src/app/api/servers/[name]/players/live/route.ts` 추가 (GET → mcctl-api 프록시, 인증 게이트)
- `McctlApiAdapter.getLivePlayers(name)` 추가
- BFF 프록시 테스트 2건

## 검증

- 신규 BFF 라우트 테스트 통과, 콘솔 919 테스트 전부 통과, lint/build 통과.
- 라우트 등록 확인: `ƒ /api/servers/[name]/players/live`.

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)