### PR TITLE
fix(api): BlueMap 지도 gzip 저장 파일 정적 서빙 (#540)

### DIFF
--- a/platform/services/mcctl-api/src/routes/worlds.ts
+++ b/platform/services/mcctl-api/src/routes/worlds.ts
@@ -71,6 +71,7 @@ import { config } from '../config/index.js';
 import { resolveScriptPath } from '../lib/script-resolver.js';
 import { resolve as resolvePath, sep, extname } from 'node:path';
 import { existsSync, statSync, createReadStream } from 'node:fs';
+import { createGunzip } from 'node:zlib';
 import { stat as statAsync, readdir } from 'node:fs/promises';
 
 // Route generic interfaces for type-safe request handling
@@ -575,13 +576,26 @@ const worldsPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       return reply.code(403).send({ error: 'Forbidden', message: 'Invalid path' });
     }
 
-    if (!existsSync(target) || !statSync(target).isFile()) {
-      return reply.code(404).send({ error: 'NotFound', message: 'File not found' });
+    const isFile = (p: string) => existsSync(p) && statSync(p).isFile();
+    // Content-type is derived from the REQUESTED (uncompressed) name.
+    const contentType = MAP_CONTENT_TYPES[extname(target).toLowerCase()] || 'application/octet-stream';
+
+    if (isFile(target)) {
+      reply.header('Content-Type', contentType);
+      return reply.send(createReadStream(target));
     }
 
-    const contentType = MAP_CONTENT_TYPES[extname(target).toLowerCase()] || 'application/octet-stream';
-    reply.header('Content-Type', contentType);
-    return reply.send(createReadStream(target));
+    // BlueMap stores map data gzip-compressed (`<file>.gz`, e.g. textures.json,
+    // hires `*.prbm`) but the webapp requests the uncompressed name. Transparently
+    // decompress the `.gz` and serve plain bytes (no Content-Encoding, so the
+    // console BFF proxy hop forwards it unchanged). (#540)
+    const gz = `${target}.gz`;
+    if (isFile(gz)) {
+      reply.header('Content-Type', contentType);
+      return reply.send(createReadStream(gz).pipe(createGunzip()));
+    }
+
+    return reply.code(404).send({ error: 'NotFound', message: 'File not found' });
   });
 
   /**

--- a/platform/services/mcctl-api/tests/world-map.test.ts
+++ b/platform/services/mcctl-api/tests/world-map.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { FastifyInstance } from 'fastify';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'fs';
+import { gzipSync } from 'zlib';
 import { join } from 'path';
 
 const TEST_PLATFORM_PATH = join(import.meta.dirname, '.tmp-world-map-test');
@@ -104,6 +105,22 @@ describe('World Map API (#529)', () => {
       });
       expect(res.statusCode).not.toBe(200);
       expect(res.body).not.toContain('top-secret');
+    });
+
+    it('transparently serves gzip-stored files (BlueMap .gz) decompressed (#540)', async () => {
+      seedRenderedMap('survival');
+      const web = join(TEST_PLATFORM_PATH, 'maps', 'survival', 'web');
+      const payload = JSON.stringify([{ resourcePath: 'bluemap:block/stone' }]);
+      // Only the .gz exists on disk (as BlueMap stores it).
+      writeFileSync(join(web, 'maps', 'nether', 'textures.json.gz'), gzipSync(Buffer.from(payload)));
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/worlds/survival/map/web/maps/nether/textures.json',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toContain('application/json');
+      expect(res.body).toBe(payload); // decompressed, not raw gzip bytes
     });
   });
 


### PR DESCRIPTION
## Summary

지도에서 차원 전환 시 "Failed to load map: nether"가 나고 텍스처/하이레스 타일이 안 보이던 버그를 수정합니다.

\`\`\`
GET /api/worlds/factory/map/web/maps/nether/textures.json 404 (Not Found)
\`\`\`

## Root Cause

BlueMap은 storage \`compression: gzip\`로 맵 데이터를 \`<file>.gz\`로 저장합니다(\`textures.json.gz\`, 하이레스 \`*.prbm.gz\`). 웹앱은 비압축 이름을 요청하는데, 정적 서빙 라우트(#529)가 정확한 경로만 찾아 → 404. (lowres \`.png\`는 평문이라 overworld 윤곽은 표시됨)

## Fix

요청 파일이 없을 때 \`<path>.gz\` 폴백 → gunzip 스트림으로 **압축 해제된 바이트**를 base content-type으로 서빙(Content-Encoding 미사용 → 콘솔 BFF 프록시가 그대로 전달). 기존 gzip 렌더와 호환되어 **재렌더 불필요**.

## 검증

- 신규 테스트: \`.gz\`만 있는 \`textures.json\` 요청 → 200 + 압축 해제 json. 실제 BlueMap \`.gz\` gunzip 유효성 확인.
- api 501 테스트 통과, lint/build 통과.

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)