### PR TITLE
fix(scripts): 스테일 분리레이아웃 위성 폴더 우선 선택 버그 수정 (#542)

### DIFF
--- a/platform/scripts/render-map.sh
+++ b/platform/scripts/render-map.sh
@@ -126,6 +126,11 @@ ensure_image() {
     docker build -t "$IMAGE" "$DOCKER_DIR" >&2
 }
 
+# When sourced (e.g. by tests) expose the helper functions above without running
+# the CLI flow below. `return` only succeeds while being sourced; on direct
+# execution the `|| true` keeps `set -e` happy and we fall through to main.
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0 2>/dev/null || true
+
 # =============================================================================
 # Argument parsing
 # =============================================================================

--- a/platform/scripts/render-map.sh
+++ b/platform/scripts/render-map.sh
@@ -83,6 +83,43 @@ has_region_data() {
     compgen -G "$dir/*.mca" > /dev/null 2>&1
 }
 
+# Echo the newest *.mca modification time (epoch seconds) in a region dir,
+# or 0 when the directory is missing or holds no region files.
+newest_region_mtime() {
+    local dir="$1"
+    [[ -d "$dir" ]] || { echo 0; return; }
+    local newest
+    newest="$(find "$dir" -maxdepth 1 -name '*.mca' -printf '%T@\n' 2>/dev/null \
+        | cut -d. -f1 | sort -rn | head -n1)"
+    echo "${newest:-0}"
+}
+
+# Choose between a split-layout (satellite) candidate and a single-folder
+# candidate for one dimension. When BOTH hold region data — e.g. a world that
+# migrated from Paper (split) to a single-folder server type leaves a stale
+# satellite behind — pick whichever was written most recently, i.e. the layout
+# the server is actually using. Echoes the chosen world-save root, or nothing.
+# Args: <split_region_dir> <split_root> <single_region_dir> <single_root>
+pick_dimension_root() {
+    local split_region="$1" split_root="$2" single_region="$3" single_root="$4"
+    local split_ok=false single_ok=false
+    has_region_data "$split_region" && split_ok=true
+    has_region_data "$single_region" && single_ok=true
+    if $split_ok && $single_ok; then
+        # Tie favours the satellite (the historical default) — only relevant
+        # when both layouts share an identical newest mtime, which is unlikely.
+        if (( $(newest_region_mtime "$split_region") >= $(newest_region_mtime "$single_region") )); then
+            echo "$split_root"
+        else
+            echo "$single_root"
+        fi
+    elif $split_ok; then
+        echo "$split_root"
+    elif $single_ok; then
+        echo "$single_root"
+    fi
+}
+
 # Resolve the world-save root that holds a dimension's region data, handling
 # both vanilla (single folder: DIM-1/DIM1) and Paper/Spigot (split folders:
 # <world>_nether/<world>_the_end) layouts. Echoes the host path, or nothing.
@@ -93,18 +130,14 @@ resolve_dimension_root() {
             has_region_data "$world_root/region" && echo "$world_root"
             ;;
         nether)
-            if has_region_data "${world_root}_nether/DIM-1/region"; then
-                echo "${world_root}_nether"
-            elif has_region_data "$world_root/DIM-1/region"; then
-                echo "$world_root"
-            fi
+            pick_dimension_root \
+                "${world_root}_nether/DIM-1/region" "${world_root}_nether" \
+                "$world_root/DIM-1/region" "$world_root"
             ;;
         end)
-            if has_region_data "${world_root}_the_end/DIM1/region"; then
-                echo "${world_root}_the_end"
-            elif has_region_data "$world_root/DIM1/region"; then
-                echo "$world_root"
-            fi
+            pick_dimension_root \
+                "${world_root}_the_end/DIM1/region" "${world_root}_the_end" \
+                "$world_root/DIM1/region" "$world_root"
             ;;
     esac
 }

--- a/platform/scripts/tests/resolve-dimension-root.test.sh
+++ b/platform/scripts/tests/resolve-dimension-root.test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# =============================================================================
+# Tests for render-map.sh resolve_dimension_root()
+# =============================================================================
+# Verifies that the active dimension layout is chosen correctly, especially
+# when a world migrated from Paper (split folders) to a single-folder server
+# type leaves a STALE satellite folder behind (issue #542).
+#
+# Run: bash platform/scripts/tests/resolve-dimension-root.test.sh
+# =============================================================================
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$TEST_DIR")"
+
+# Source the script under test (CLI flow is skipped via its source-guard).
+# shellcheck source=../render-map.sh
+source "$SCRIPTS_DIR/render-map.sh"
+set +eu  # keep the harness lenient regardless of the script's `set -euo`
+
+FAILED=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  ok   - $desc"
+    else
+        echo "  FAIL - $desc"
+        echo "         expected: '$expected'"
+        echo "         actual:   '$actual'"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+# Create a region dir holding one .mca file stamped at a given date.
+mk_region() {
+    local dir="$1" date="$2"
+    mkdir -p "$dir"
+    : > "$dir/r.0.0.mca"
+    touch -d "$date" "$dir/r.0.0.mca"
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Nether ------------------------------------------------------------------
+
+# Stale split satellite (old) shadows the active single-folder data (new).
+# This is the issue #542 scenario: must pick the single-folder root.
+W="$WORK/w1"
+mk_region "$W/DIM-1/region" "2026-06-28 12:00:00"          # active (new)
+mk_region "${W}_nether/DIM-1/region" "2026-02-02 12:00:00" # stale satellite (old)
+assert_eq "nether: stale satellite + newer single-folder -> single-folder" \
+    "$W" "$(resolve_dimension_root "$W" nether)"
+
+# Genuine Paper world: only the split satellite exists -> use it (no regression).
+W="$WORK/w2"
+mk_region "${W}_nether/DIM-1/region" "2026-06-28 12:00:00"
+assert_eq "nether: only split satellite -> satellite" \
+    "${W}_nether" "$(resolve_dimension_root "$W" nether)"
+
+# Single-folder only -> use it.
+W="$WORK/w3"
+mk_region "$W/DIM-1/region" "2026-06-28 12:00:00"
+assert_eq "nether: only single-folder -> single-folder" \
+    "$W" "$(resolve_dimension_root "$W" nether)"
+
+# Both present but the split satellite is the newer one -> prefer satellite.
+W="$WORK/w4"
+mk_region "$W/DIM-1/region" "2026-02-02 12:00:00"
+mk_region "${W}_nether/DIM-1/region" "2026-06-28 12:00:00"
+assert_eq "nether: newer split satellite -> satellite" \
+    "${W}_nether" "$(resolve_dimension_root "$W" nether)"
+
+# Neither present -> empty.
+W="$WORK/w5"
+mkdir -p "$W"
+assert_eq "nether: no region data -> empty" \
+    "" "$(resolve_dimension_root "$W" nether)"
+
+# --- End ---------------------------------------------------------------------
+
+# Stale _the_end satellite shadows active single-folder DIM1 data.
+W="$WORK/e1"
+mk_region "$W/DIM1/region" "2026-06-28 12:00:00"
+mk_region "${W}_the_end/DIM1/region" "2026-02-02 12:00:00"
+assert_eq "end: stale satellite + newer single-folder -> single-folder" \
+    "$W" "$(resolve_dimension_root "$W" end)"
+
+# --- Overworld ---------------------------------------------------------------
+
+W="$WORK/o1"
+mk_region "$W/region" "2026-06-28 12:00:00"
+assert_eq "overworld: region present -> world root" \
+    "$W" "$(resolve_dimension_root "$W" overworld)"
+
+# -----------------------------------------------------------------------------
+echo ""
+if [[ $FAILED -eq 0 ]]; then
+    echo "All tests passed."
+    exit 0
+else
+    echo "$FAILED test(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

BlueMap 전체 지도에서 **네더·엔드가 빈 화면**으로 렌더되던 버그(#542)를 수정합니다.

`render-map.sh`의 `resolve_dimension_root()`가 분리(split) 레이아웃 위성 폴더(`<world>_nether`/`<world>_the_end`)를 **무조건 먼저** 선택해, Paper→단일폴더(NeoForge 등) 전환 월드에 남은 **스테일 위성**이 실제 데이터를 가렸습니다. BlueMap이 비어있는 차원을 렌더 → hires 타일(`tiles/0`) 0개.

## Root Cause

`has_region_data`는 `*.mca` 존재 여부만 검사하고, 분리 레이아웃 분기가 항상 먼저 평가됨. 실측: factory(NEOFORGE 1.21.1)에서 활성 `factory/DIM-1`(19M, 최신) 대신 스테일 `factory_nether`(2.3M, 2/2)가 선택됨.

## Changes

- `newest_region_mtime()` 헬퍼 추가 — 리전 디렉토리의 최신 `*.mca` mtime(epoch) 반환
- `pick_dimension_root()` 추가 — 위성/단일폴더 둘 다 데이터가 있으면 **최신 mtime(=서버가 실제 쓰는 활성 레이아웃)** 선택
- `resolve_dimension_root()` nether/end 분기에 적용 (overworld·단일 레이아웃 동작 불변)
- `render-map.sh`를 테스트용으로 source 가능하게 (source-guard, 직접 실행 동작 불변)
- `platform/scripts/tests/resolve-dimension-root.test.sh` 추가

## Test (TDD: Red → Green)

```
bash platform/scripts/tests/resolve-dimension-root.test.sh   # All tests passed
```

커버: 스테일 위성+최신 단일폴더 / 위성만(정상 Paper) / 단일폴더만 / 위성이 최신 / 데이터 없음 (nether·end·overworld).

## E2E 검증 (실제 운영 데이터)

수정된 스크립트로 factory 네더 렌더 → 마운트 소스가 `factory`(활성)로 바뀌고 **실제 렌더 진행(53%→88%) + hires 300개** 생성. (수정 전: instant "up-to-date" / 0 hires)

> 참고: 본 변경은 bash 스크립트라 Playwright/Vitest e2e 대상이 아니며, 셸 단위 테스트로 커버. 동일한 위성-우선 로직이 `WorldRepository`(backup/world-info)에도 있는지는 별도 후속 점검 권장.

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)