### PR TITLE
fix(shared): resolveRegionDirs 스테일 위성 우선 선택 버그 수정 (#544)

### DIFF
--- a/platform/services/shared/src/infrastructure/adapters/dimensionRegions.ts
+++ b/platform/services/shared/src/infrastructure/adapters/dimensionRegions.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { Dimension } from '../../domain/index.js';
 
@@ -17,13 +17,52 @@ export function hasRegionData(dir: string): boolean {
   }
 }
 
+/** Newest `.mca` modification time (epoch ms) in a dir, or 0 if none/missing. */
+function newestRegionMtime(dir: string): number {
+  try {
+    let newest = 0;
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith('.mca')) continue;
+      const m = statSync(join(dir, f)).mtimeMs;
+      if (m > newest) newest = m;
+    }
+    return newest;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Choose the active region directory among layout candidates. When more than
+ * one candidate holds region data — e.g. a world migrated from Paper (split
+ * folders) to a single-folder server type leaves a stale satellite behind —
+ * pick whichever was written most recently, i.e. the layout the server is
+ * actually using. Ties keep the earlier candidate (the split satellite),
+ * matching render-map.sh's behavior. Returns undefined when none have data.
+ */
+function pickRegionDir(candidates: string[]): string | undefined {
+  const withData = candidates.filter(hasRegionData);
+  if (withData.length <= 1) return withData[0];
+  let best = withData[0]!;
+  let bestMtime = newestRegionMtime(best);
+  for (const dir of withData.slice(1)) {
+    const m = newestRegionMtime(dir);
+    if (m > bestMtime) {
+      best = dir;
+      bestMtime = m;
+    }
+  }
+  return best;
+}
+
 /**
  * Resolve each present dimension's region directory for a world, handling both
  * vanilla (DIM-1/DIM1) and Paper/Spigot split-folder (`<name>_nether` /
  * `<name>_the_end`) layouts. A candidate only wins if it actually contains
- * region data, so an empty split folder never shadows populated vanilla data
- * (mirrors render-map.sh's has_region_data). Single source of truth shared by
- * the structure reader (#530) and block scanner (#531).
+ * region data; when both layouts hold data the more recently written one is
+ * chosen, so a stale split satellite never shadows the active single-folder
+ * data (mirrors render-map.sh). Single source of truth shared by the structure
+ * reader (#530) and block scanner (#531).
  */
 export function resolveRegionDirs(worldPath: string): DimensionRegionDir[] {
   const candidates: Record<Dimension, string[]> = {
@@ -40,7 +79,7 @@ export function resolveRegionDirs(worldPath: string): DimensionRegionDir[] {
 
   const out: DimensionRegionDir[] = [];
   for (const dimension of [Dimension.Overworld, Dimension.Nether, Dimension.End]) {
-    const dir = candidates[dimension].find(hasRegionData);
+    const dir = pickRegionDir(candidates[dimension]);
     if (dir) out.push({ dimension, dir });
   }
   return out;

--- a/platform/services/shared/tests/dimensionRegions.test.ts
+++ b/platform/services/shared/tests/dimensionRegions.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveRegionDirs } from '../src/infrastructure/adapters/dimensionRegions.js';
+import { Dimension } from '../src/domain/index.js';
+
+describe('resolveRegionDirs', () => {
+  let work: string;
+
+  beforeEach(() => {
+    work = mkdtempSync(join(tmpdir(), 'dimregions-'));
+  });
+
+  afterEach(() => {
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  // Create a region dir with one .mca file stamped at the given epoch ms.
+  const mkRegion = (dir: string, mtimeMs: number): void => {
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, 'r.0.0.mca');
+    writeFileSync(file, '');
+    const secs = mtimeMs / 1000;
+    utimesSync(file, secs, secs);
+  };
+
+  const dirFor = (worldPath: string, dim: Dimension): string | undefined =>
+    resolveRegionDirs(worldPath).find((r) => r.dimension === dim)?.dir;
+
+  const OLD = Date.parse('2026-02-02T12:00:00Z');
+  const NEW = Date.parse('2026-06-28T12:00:00Z');
+
+  it('nether: stale satellite + newer single-folder -> single-folder (issue #544)', () => {
+    const w = join(work, 'w1');
+    mkRegion(join(w, 'DIM-1', 'region'), NEW); // active single-folder
+    mkRegion(join(`${w}_nether`, 'DIM-1', 'region'), OLD); // stale satellite
+    expect(dirFor(w, Dimension.Nether)).toBe(join(w, 'DIM-1', 'region'));
+  });
+
+  it('nether: only split satellite (genuine Paper) -> satellite (no regression)', () => {
+    const w = join(work, 'w2');
+    mkRegion(join(`${w}_nether`, 'DIM-1', 'region'), NEW);
+    expect(dirFor(w, Dimension.Nether)).toBe(join(`${w}_nether`, 'DIM-1', 'region'));
+  });
+
+  it('nether: only single-folder -> single-folder', () => {
+    const w = join(work, 'w3');
+    mkRegion(join(w, 'DIM-1', 'region'), NEW);
+    expect(dirFor(w, Dimension.Nether)).toBe(join(w, 'DIM-1', 'region'));
+  });
+
+  it('nether: newer split satellite -> satellite', () => {
+    const w = join(work, 'w4');
+    mkRegion(join(w, 'DIM-1', 'region'), OLD);
+    mkRegion(join(`${w}_nether`, 'DIM-1', 'region'), NEW);
+    expect(dirFor(w, Dimension.Nether)).toBe(join(`${w}_nether`, 'DIM-1', 'region'));
+  });
+
+  it('nether: no region data -> dimension absent', () => {
+    const w = join(work, 'w5');
+    mkdirSync(w, { recursive: true });
+    expect(dirFor(w, Dimension.Nether)).toBeUndefined();
+  });
+
+  it('end: stale satellite + newer single-folder -> single-folder', () => {
+    const w = join(work, 'e1');
+    mkRegion(join(w, 'DIM1', 'region'), NEW);
+    mkRegion(join(`${w}_the_end`, 'DIM1', 'region'), OLD);
+    expect(dirFor(w, Dimension.End)).toBe(join(w, 'DIM1', 'region'));
+  });
+
+  it('overworld: region present -> world region dir', () => {
+    const w = join(work, 'o1');
+    mkRegion(join(w, 'region'), NEW);
+    expect(dirFor(w, Dimension.Overworld)).toBe(join(w, 'region'));
+  });
+});


### PR DESCRIPTION
## Summary

`resolveRegionDirs()`가 차원별 region 디렉토리 후보 중 **첫 번째로 `.mca`가 있는 것**을 골라, 분리레이아웃 위성(`<world>_nether`/`<world>_the_end`)이 후보 맨 앞에 있어 **스테일 위성이 활성 단일폴더 데이터를 가리던** 버그를 수정합니다. #542/PR #543(render-map.sh)와 동일한 버그 클래스의 TS 버전입니다.

영향: `AnvilBlockScanner`(블록/광물 통계 #531), `PrismarineWorldDataReader.readStructures`(구조물 마커 #530) — Paper→단일폴더(NeoForge 등) 전환 월드에서 오래된 네더/엔드 데이터로 계산.

## Changes

- `newestRegionMtime()` 추가 — 디렉토리 내 최신 `.mca` mtime(ms)
- `pickRegionDir()` 추가 — 데이터 있는 후보가 여럿이면 **최신 mtime** 선택(동률 시 위성 유지, render-map.sh와 일치)
- `resolveRegionDirs()`의 `candidates.find(hasRegionData)` → `pickRegionDir(candidates)` 교체
- 단일 후보/단일 레이아웃 동작 불변

## Test (TDD: Red → Green)

`platform/services/shared/tests/dimensionRegions.test.ts` 신규 — 스테일 위성+최신 단일폴더 / 위성만(정상 Paper) / 단일폴더만 / 위성이 최신 / 데이터 없음 / overworld (nether·end·overworld). 

검증: `tsc --noEmit` OK, shared 전체 **591 테스트 통과**, eslint OK.

## Notes

- 관련: #542 / PR #543 (render-map.sh 동일 수정). 두 PR은 독립 파일.
- `PrismarineWorldDataReader.detectDimensions()`는 디렉토리 존재만 보는 presence 플래그(영향 경미)로 본 PR 범위에서 제외.

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)