### PR TITLE
fix(shared,scripts): 최신 MC dimensions/ 월드 레이아웃 지원 (#546)

### DIFF
--- a/platform/scripts/render-map.sh
+++ b/platform/scripts/render-map.sh
@@ -121,23 +121,35 @@ pick_dimension_root() {
 }
 
 # Resolve the world-save root that holds a dimension's region data, handling
-# both vanilla (single folder: DIM-1/DIM1) and Paper/Spigot (split folders:
-# <world>_nether/<world>_the_end) layouts. Echoes the host path, or nothing.
+# vanilla (single folder: DIM-1/DIM1), Paper/Spigot (split folders:
+# <world>_nether/<world>_the_end) and latest-Minecraft (every dimension under
+# <world>/dimensions/minecraft/<dim>) layouts. The mounted root stays <world>
+# for non-split layouts — BlueMap resolves the dimension key to DIM-1/DIM1 or
+# dimensions/minecraft/<dim> itself. Echoes the host path, or nothing.
 resolve_dimension_root() {
-    local world_root="$1" dim="$2"
+    local world_root="$1" dim="$2" single_region
     case "$dim" in
         overworld)
-            has_region_data "$world_root/region" && echo "$world_root"
+            if has_region_data "$world_root/region" \
+                || has_region_data "$world_root/dimensions/minecraft/overworld/region"; then
+                echo "$world_root"
+            fi
             ;;
         nether)
+            single_region="$world_root/DIM-1/region"
+            has_region_data "$single_region" \
+                || single_region="$world_root/dimensions/minecraft/the_nether/region"
             pick_dimension_root \
                 "${world_root}_nether/DIM-1/region" "${world_root}_nether" \
-                "$world_root/DIM-1/region" "$world_root"
+                "$single_region" "$world_root"
             ;;
         end)
+            single_region="$world_root/DIM1/region"
+            has_region_data "$single_region" \
+                || single_region="$world_root/dimensions/minecraft/the_end/region"
             pick_dimension_root \
                 "${world_root}_the_end/DIM1/region" "${world_root}_the_end" \
-                "$world_root/DIM1/region" "$world_root"
+                "$single_region" "$world_root"
             ;;
     esac
 }

--- a/platform/scripts/render-map.sh
+++ b/platform/scripts/render-map.sh
@@ -94,30 +94,25 @@ newest_region_mtime() {
     echo "${newest:-0}"
 }
 
-# Choose between a split-layout (satellite) candidate and a single-folder
-# candidate for one dimension. When BOTH hold region data — e.g. a world that
-# migrated from Paper (split) to a single-folder server type leaves a stale
-# satellite behind — pick whichever was written most recently, i.e. the layout
-# the server is actually using. Echoes the chosen world-save root, or nothing.
-# Args: <split_region_dir> <split_root> <single_region_dir> <single_root>
+# Choose the active region layout among (region_dir, world_root) candidate
+# pairs: echo the world-save root whose region holds the most recently written
+# .mca data. Earlier candidates win ties, so a Paper satellite (listed first)
+# stays the historical default. Candidates without region data are skipped;
+# echoes nothing when none have data. A migrated world can leave several layouts
+# behind at once (stale Paper satellite, old DIM-1/DIM1, active dimensions/) —
+# comparing all of them by mtime selects the one the server actually writes
+# (#542, #546). Args: <region_dir> <root> [<region_dir> <root> ...]
 pick_dimension_root() {
-    local split_region="$1" split_root="$2" single_region="$3" single_root="$4"
-    local split_ok=false single_ok=false
-    has_region_data "$split_region" && split_ok=true
-    has_region_data "$single_region" && single_ok=true
-    if $split_ok && $single_ok; then
-        # Tie favours the satellite (the historical default) — only relevant
-        # when both layouts share an identical newest mtime, which is unlikely.
-        if (( $(newest_region_mtime "$split_region") >= $(newest_region_mtime "$single_region") )); then
-            echo "$split_root"
-        else
-            echo "$single_root"
+    local best_root="" best_mtime=-1 region root mtime
+    while (( $# >= 2 )); do
+        region="$1"; root="$2"; shift 2
+        has_region_data "$region" || continue
+        mtime="$(newest_region_mtime "$region")"
+        if (( mtime > best_mtime )); then
+            best_mtime="$mtime"; best_root="$root"
         fi
-    elif $split_ok; then
-        echo "$split_root"
-    elif $single_ok; then
-        echo "$single_root"
-    fi
+    done
+    [[ -n "$best_root" ]] && echo "$best_root"
 }
 
 # Resolve the world-save root that holds a dimension's region data, handling
@@ -127,29 +122,24 @@ pick_dimension_root() {
 # for non-split layouts — BlueMap resolves the dimension key to DIM-1/DIM1 or
 # dimensions/minecraft/<dim> itself. Echoes the host path, or nothing.
 resolve_dimension_root() {
-    local world_root="$1" dim="$2" single_region
+    local world_root="$1" dim="$2"
     case "$dim" in
         overworld)
-            if has_region_data "$world_root/region" \
-                || has_region_data "$world_root/dimensions/minecraft/overworld/region"; then
-                echo "$world_root"
-            fi
+            pick_dimension_root \
+                "$world_root/region" "$world_root" \
+                "$world_root/dimensions/minecraft/overworld/region" "$world_root"
             ;;
         nether)
-            single_region="$world_root/DIM-1/region"
-            has_region_data "$single_region" \
-                || single_region="$world_root/dimensions/minecraft/the_nether/region"
             pick_dimension_root \
                 "${world_root}_nether/DIM-1/region" "${world_root}_nether" \
-                "$single_region" "$world_root"
+                "$world_root/DIM-1/region" "$world_root" \
+                "$world_root/dimensions/minecraft/the_nether/region" "$world_root"
             ;;
         end)
-            single_region="$world_root/DIM1/region"
-            has_region_data "$single_region" \
-                || single_region="$world_root/dimensions/minecraft/the_end/region"
             pick_dimension_root \
                 "${world_root}_the_end/DIM1/region" "${world_root}_the_end" \
-                "$single_region" "$world_root"
+                "$world_root/DIM1/region" "$world_root" \
+                "$world_root/dimensions/minecraft/the_end/region" "$world_root"
             ;;
     esac
 }

--- a/platform/scripts/tests/resolve-dimension-root.test.sh
+++ b/platform/scripts/tests/resolve-dimension-root.test.sh
@@ -120,6 +120,16 @@ mk_region "${W}_nether/DIM-1/region" "2026-02-02 12:00:00"
 assert_eq "nether: dimensions/ (new) vs stale satellite -> world root" \
     "$W" "$(resolve_dimension_root "$W" nether)"
 
+# All three layouts coexist (classic -> latest migration with a Paper satellite
+# left over). The active dimensions/ data is newest, even though the satellite
+# is newer than the old DIM-1 — must still resolve to the world root.
+W="$WORK/d5"
+mk_region "$W/dimensions/minecraft/the_nether/region" "2026-06-28 12:00:00" # active
+mk_region "${W}_nether/DIM-1/region" "2026-04-04 12:00:00"                  # stale satellite
+mk_region "$W/DIM-1/region" "2026-02-02 12:00:00"                           # stale classic
+assert_eq "nether: all three layouts, dimensions/ newest -> world root" \
+    "$W" "$(resolve_dimension_root "$W" nether)"
+
 # -----------------------------------------------------------------------------
 echo ""
 if [[ $FAILED -eq 0 ]]; then

--- a/platform/scripts/tests/resolve-dimension-root.test.sh
+++ b/platform/scripts/tests/resolve-dimension-root.test.sh
@@ -95,6 +95,31 @@ mk_region "$W/region" "2026-06-28 12:00:00"
 assert_eq "overworld: region present -> world root" \
     "$W" "$(resolve_dimension_root "$W" overworld)"
 
+# --- Latest Minecraft dimensions/ layout (issue #546) ------------------------
+
+# Every dimension (overworld included) under dimensions/minecraft/<dim>.
+W="$WORK/d1"
+mk_region "$W/dimensions/minecraft/overworld/region" "2026-06-28 12:00:00"
+assert_eq "overworld: dimensions/ layout -> world root" \
+    "$W" "$(resolve_dimension_root "$W" overworld)"
+
+W="$WORK/d2"
+mk_region "$W/dimensions/minecraft/the_nether/region" "2026-06-28 12:00:00"
+assert_eq "nether: dimensions/ layout -> world root" \
+    "$W" "$(resolve_dimension_root "$W" nether)"
+
+W="$WORK/d3"
+mk_region "$W/dimensions/minecraft/the_end/region" "2026-06-28 12:00:00"
+assert_eq "end: dimensions/ layout -> world root" \
+    "$W" "$(resolve_dimension_root "$W" end)"
+
+# Stale Paper satellite must NOT shadow a newer dimensions/ nether.
+W="$WORK/d4"
+mk_region "$W/dimensions/minecraft/the_nether/region" "2026-06-28 12:00:00"
+mk_region "${W}_nether/DIM-1/region" "2026-02-02 12:00:00"
+assert_eq "nether: dimensions/ (new) vs stale satellite -> world root" \
+    "$W" "$(resolve_dimension_root "$W" nether)"
+
 # -----------------------------------------------------------------------------
 echo ""
 if [[ $FAILED -eq 0 ]]; then

--- a/platform/services/shared/src/infrastructure/adapters/PrismarineWorldDataReader.ts
+++ b/platform/services/shared/src/infrastructure/adapters/PrismarineWorldDataReader.ts
@@ -183,16 +183,31 @@ export class PrismarineWorldDataReader implements IWorldDataReader {
     const name = basename(worldPath);
     const has = (p: string): boolean => existsSync(p);
 
+    // Latest Minecraft stores every dimension under dimensions/minecraft/<dim>
+    // (overworld included), alongside the older root/DIM-1/DIM1 and Paper split
+    // layouts (#546).
+    const dims = join(worldPath, 'dimensions', 'minecraft');
     return {
-      overworld: has(join(worldPath, 'level.dat')) || has(join(worldPath, 'region')),
+      overworld:
+        has(join(worldPath, 'level.dat')) ||
+        has(join(worldPath, 'region')) ||
+        has(join(dims, 'overworld', 'region')),
       nether:
-        has(join(worldPath, 'DIM-1')) || has(join(parent, `${name}_nether`)),
-      end: has(join(worldPath, 'DIM1')) || has(join(parent, `${name}_the_end`)),
+        has(join(worldPath, 'DIM-1')) ||
+        has(join(parent, `${name}_nether`)) ||
+        has(join(dims, 'the_nether')),
+      end:
+        has(join(worldPath, 'DIM1')) ||
+        has(join(parent, `${name}_the_end`)) ||
+        has(join(dims, 'the_end')),
     };
   }
 
   async countRegions(worldPath: string): Promise<number> {
-    const dir = join(worldPath, 'region');
+    const rootRegion = join(worldPath, 'region');
+    const dir = existsSync(rootRegion)
+      ? rootRegion
+      : join(worldPath, 'dimensions', 'minecraft', 'overworld', 'region');
     try {
       const s = await stat(dir);
       if (!s.isDirectory()) return 0;

--- a/platform/services/shared/src/infrastructure/adapters/PrismarineWorldDataReader.ts
+++ b/platform/services/shared/src/infrastructure/adapters/PrismarineWorldDataReader.ts
@@ -204,13 +204,14 @@ export class PrismarineWorldDataReader implements IWorldDataReader {
   }
 
   async countRegions(worldPath: string): Promise<number> {
-    const rootRegion = join(worldPath, 'region');
-    const dir = existsSync(rootRegion)
-      ? rootRegion
-      : join(worldPath, 'dimensions', 'minecraft', 'overworld', 'region');
+    // Use the same active-layout resolution as the scanners so the count never
+    // reflects a stale layout (#546): resolveRegionDirs picks the overworld
+    // region dir across root/dimensions layouts by newest mtime.
+    const dir = resolveRegionDirs(worldPath).find(
+      (r) => r.dimension === Dimension.Overworld,
+    )?.dir;
+    if (!dir) return 0;
     try {
-      const s = await stat(dir);
-      if (!s.isDirectory()) return 0;
       const entries = await readdir(dir);
       return entries.filter((e) => e.endsWith('.mca')).length;
     } catch {

--- a/platform/services/shared/src/infrastructure/adapters/dimensionRegions.ts
+++ b/platform/services/shared/src/infrastructure/adapters/dimensionRegions.ts
@@ -65,15 +65,23 @@ function pickRegionDir(candidates: string[]): string | undefined {
  * reader (#530) and block scanner (#531).
  */
 export function resolveRegionDirs(worldPath: string): DimensionRegionDir[] {
+  // Layout candidates per dimension, oldest-style first. The last entry is the
+  // `dimensions/minecraft/<dim>/region` layout used by latest Minecraft, where
+  // every dimension (overworld included) lives under `dimensions/` (#546).
   const candidates: Record<Dimension, string[]> = {
-    [Dimension.Overworld]: [join(worldPath, 'region')],
+    [Dimension.Overworld]: [
+      join(worldPath, 'region'),
+      join(worldPath, 'dimensions', 'minecraft', 'overworld', 'region'),
+    ],
     [Dimension.Nether]: [
       join(`${worldPath}_nether`, 'DIM-1', 'region'),
       join(worldPath, 'DIM-1', 'region'),
+      join(worldPath, 'dimensions', 'minecraft', 'the_nether', 'region'),
     ],
     [Dimension.End]: [
       join(`${worldPath}_the_end`, 'DIM1', 'region'),
       join(worldPath, 'DIM1', 'region'),
+      join(worldPath, 'dimensions', 'minecraft', 'the_end', 'region'),
     ],
   };
 

--- a/platform/services/shared/src/infrastructure/adapters/dimensionRegions.ts
+++ b/platform/services/shared/src/infrastructure/adapters/dimensionRegions.ts
@@ -56,13 +56,14 @@ function pickRegionDir(candidates: string[]): string | undefined {
 }
 
 /**
- * Resolve each present dimension's region directory for a world, handling both
- * vanilla (DIM-1/DIM1) and Paper/Spigot split-folder (`<name>_nether` /
- * `<name>_the_end`) layouts. A candidate only wins if it actually contains
- * region data; when both layouts hold data the more recently written one is
- * chosen, so a stale split satellite never shadows the active single-folder
- * data (mirrors render-map.sh). Single source of truth shared by the structure
- * reader (#530) and block scanner (#531).
+ * Resolve each present dimension's region directory for a world, handling
+ * vanilla (DIM-1/DIM1), Paper/Spigot split-folder (`<name>_nether` /
+ * `<name>_the_end`) and latest-Minecraft (`dimensions/minecraft/<dim>/region`,
+ * #546) layouts. A candidate only wins if it actually contains region data;
+ * when several layouts hold data the more recently written one is chosen, so a
+ * stale layout never shadows the active one (mirrors render-map.sh). Single
+ * source of truth shared by the structure reader (#530) and block scanner
+ * (#531).
  */
 export function resolveRegionDirs(worldPath: string): DimensionRegionDir[] {
   // Layout candidates per dimension, oldest-style first. The last entry is the

--- a/platform/services/shared/tests/dimensionRegions.test.ts
+++ b/platform/services/shared/tests/dimensionRegions.test.ts
@@ -101,4 +101,18 @@ describe('resolveRegionDirs', () => {
       join(w, 'dimensions', 'minecraft', 'the_end', 'region'),
     );
   });
+
+  // All three layouts coexist (classic -> latest migration with a leftover Paper
+  // satellite). The active dimensions/ data is newest even though the satellite
+  // is newer than the old DIM-1 -> must pick the dimensions/ region.
+  it('nether: all three layouts, dimensions/ newest -> dimensions region', () => {
+    const w = join(work, 'd4');
+    const MID = Date.parse('2026-04-04T12:00:00Z');
+    mkRegion(join(w, 'dimensions', 'minecraft', 'the_nether', 'region'), NEW); // active
+    mkRegion(join(`${w}_nether`, 'DIM-1', 'region'), MID); // stale satellite
+    mkRegion(join(w, 'DIM-1', 'region'), OLD); // stale classic
+    expect(dirFor(w, Dimension.Nether)).toBe(
+      join(w, 'dimensions', 'minecraft', 'the_nether', 'region'),
+    );
+  });
 });

--- a/platform/services/shared/tests/dimensionRegions.test.ts
+++ b/platform/services/shared/tests/dimensionRegions.test.ts
@@ -75,4 +75,30 @@ describe('resolveRegionDirs', () => {
     mkRegion(join(w, 'region'), NEW);
     expect(dirFor(w, Dimension.Overworld)).toBe(join(w, 'region'));
   });
+
+  // Latest Minecraft stores every dimension (overworld included) under
+  // dimensions/minecraft/<dim>/region (issue #546).
+  it('overworld: dimensions/ layout -> dimensions overworld region', () => {
+    const w = join(work, 'd1');
+    mkRegion(join(w, 'dimensions', 'minecraft', 'overworld', 'region'), NEW);
+    expect(dirFor(w, Dimension.Overworld)).toBe(
+      join(w, 'dimensions', 'minecraft', 'overworld', 'region'),
+    );
+  });
+
+  it('nether: dimensions/ layout -> dimensions the_nether region', () => {
+    const w = join(work, 'd2');
+    mkRegion(join(w, 'dimensions', 'minecraft', 'the_nether', 'region'), NEW);
+    expect(dirFor(w, Dimension.Nether)).toBe(
+      join(w, 'dimensions', 'minecraft', 'the_nether', 'region'),
+    );
+  });
+
+  it('end: dimensions/ layout -> dimensions the_end region', () => {
+    const w = join(work, 'd3');
+    mkRegion(join(w, 'dimensions', 'minecraft', 'the_end', 'region'), NEW);
+    expect(dirFor(w, Dimension.End)).toBe(
+      join(w, 'dimensions', 'minecraft', 'the_end', 'region'),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

최신 마인크래프트(Vanilla `VERSION=LATEST`, MC 26.x)는 **모든 차원(오버월드 포함)을 `<world>/dimensions/minecraft/<차원>/region`** 에 저장합니다. 매니저는 구버전 레이아웃(`region`/`DIM-1`/`DIM1` + Paper 위성)만 인식해, 신버전 월드에서 **지도가 전혀 렌더되지 않고**("No renderable dimensions found") 블록 통계·구조물·차원 탐지가 모두 실패했습니다. (실측: `Wild-Deity` VANILLA/LATEST)

BlueMap 엔진 자체는 이 레이아웃을 정상 렌더하므로(오버월드 직접 렌더 검증), 순수하게 매니저의 경로 탐지 누락이었습니다.

## Changes

- **render-map.sh** `resolve_dimension_root`: 각 차원에 `dimensions/minecraft/<dim>/region` 후보 추가. 마운트 루트는 `<world>` 유지(BlueMap이 dimension 키로 해소). #542의 mtime 기반 위성-vs-활성 선택과 호환.
- **dimensionRegions.ts** `resolveRegionDirs`: 차원별 `dimensions/` 후보 추가(블록 통계 #531·구조물 #530).
- **PrismarineWorldDataReader** `detectDimensions`·`countRegions`: dimensions/ 경로 인식(월드 정보 패널).

구버전 레이아웃(바닐라 단일폴더, Paper 위성)은 동작 불변.

## Test (TDD: Red → Green)

- bash `resolve-dimension-root.test.sh`: dimensions/ 케이스 4건 추가(overworld/nether/end + 스테일 위성 vs 신 dimensions/ 네더) → 11건 통과
- vitest `dimensionRegions.test.ts`: dimensions/ 3건 추가 → 10건 통과
- 검증: `tsc` OK · shared 전체 **594 테스트** · eslint OK
- 실데이터 검증: Wild-Deity overworld·nether 해소 성공, factory(구버전) 회귀 없음

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)